### PR TITLE
 build: suppress -Wpedantic warning in glad.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,10 @@ set(SOURCES
 # =============================================================================
 # 创建可执行文件
 # =============================================================================
+# glad.c uses ISO C-forbidden void*→function* casts (required for OpenGL loaders)
+set_source_files_properties(${CMAKE_SOURCE_DIR}/src/glad.c
+    PROPERTIES COMPILE_FLAGS "-Wno-pedantic"
+)
 add_executable(${PROJECT_NAME} ${SOURCES} ${GLAD_EXTRA_SOURCE})
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- suppress the `-Wpedantic` warning in `glad.c` for the generated loader-specific function-pointer casts
- keep the warning suppression scoped to `glad.c` so the rest of the codebase remains unaffected

## Testing
- Build passes with the targeted warning suppression applied only to `glad.c`
