### PR TITLE
docs: add bilingual C contributor guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Important boundaries:
 | GLAD | OpenGL loader | Committed in repo |
 | Nuklear | Immediate-mode UI | Header-only local include |
 
+## Documentation
+
+- Wiki Home: [doc/wiki/Home.md](./doc/wiki/Home.md)
+- C Contributor Guide (EN): [doc/c-language-must-know-for-gldraw.en.md](./doc/c-language-must-know-for-gldraw.en.md)
+- C 贡献者指南 (ZH): [doc/c-language-must-know-for-gldraw.md](./doc/c-language-must-know-for-gldraw.md)
+
 ## Status
 
 This is the current baseline of the refactor. The new architecture is in place, the old direct-coupled runtime has been removed from the build, and the editor now supports document history plus JSON persistence. Future work can extend this foundation with:

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -112,6 +112,12 @@ GLDraw/
 | GLAD | OpenGL 加载器 | 已提交到仓库 |
 | Nuklear | 即时模式 UI | 本地 header-only |
 
+## 文档入口
+
+- Wiki 首页：[wiki/Home.md](./wiki/Home.md)
+- C 贡献者指南（中文）：[c-language-must-know-for-gldraw.md](./c-language-must-know-for-gldraw.md)
+- C Contributor Guide (English)：[c-language-must-know-for-gldraw.en.md](./c-language-must-know-for-gldraw.en.md)
+
 ## 当前阶段
 
 这是当前重构基线版本。新架构已经落地，旧的耦合式运行时已经从构建中移除，并已经具备基础历史记录与 JSON 持久化能力。后续可以继续扩展：

--- a/doc/c-language-must-know-for-gldraw.en.md
+++ b/doc/c-language-must-know-for-gldraw.en.md
@@ -1,0 +1,146 @@
+# GLDraw C Contributor Guide (Developers / Open Source Contributors)
+
+This guide is for developers who want to read, modify, and extend GLDraw.  
+It does not try to teach all of C. It focuses on the syntax and practices that matter in this repository.
+
+Language:
+- English (this file)
+- 中文: [c-language-must-know-for-gldraw.md](./c-language-must-know-for-gldraw.md)
+
+## Who this is for
+
+- New contributors preparing to submit PRs to GLDraw
+- Developers with basic C knowledge but limited project-level experience
+- Contributors who need a quick map of module boundaries and change points
+
+## Read this first before contributing
+
+1. `doc/wiki/architecture.md`
+2. `doc/wiki/data-flow.md`
+3. `src/app/application.c`
+4. `src/tools/tool_controller.c`
+5. `src/document/object.c`
+
+First build a clear mental model of the main path:  
+`GLFW callbacks -> ToolController -> Document/CanvasView -> RenderSystem`.
+
+## Must-know C syntax (prioritized for this project)
+
+Every item below maps directly to real code in this repository.
+
+| Syntax / Concept | Why it matters | Typical files |
+|---|---|---|
+| `struct` + `typedef` | Organizing app state and module boundaries | `include/app/workspace.h` |
+| Pointers `*`, address-of `&`, member access `.` / `->` | Used across nearly all call paths | `src/app/application.c` |
+| Pass-by-value vs pass-by-pointer | Avoiding copies and mutating shared state | `src/document/document.c` |
+| `enum` + `switch` | Tool/object state dispatch | `include/tools/tool.h`, `src/tools/tool_controller.c` |
+| Fixed arrays + bounds checks | Object pool and selection safety | `include/document/document.h` |
+| Function pointers + vtable | Object/tool polymorphism | `include/document/object.h`, `src/document/object.c` |
+| Callbacks + `void*` user pointer | Recover `Application*` from window callbacks | `src/app/application.c` |
+| Dynamic memory management | Prevent leaks and dangling pointers | `src/document/history.c` |
+| `const` / `static` / scope | Visibility and mutability control | Most `.h/.c` files |
+| Preprocessor platform branches | Windows and non-Windows behavior | `src/document/persistence.c` |
+| Bitmask operations | Modifier key handling | `src/tools/tool_controller.c` |
+| String formatting safety | Status text, paths, logging | `src/app/application.c` |
+
+## Key syntax patterns used in GLDraw
+
+### 1) Callback bridge (must understand)
+
+```c
+glfwSetWindowUserPointer(app->window.handle, app);
+Application* app = (Application*)glfwGetWindowUserPointer(handle);
+```
+
+Why: GLFW callbacks only provide `GLFWwindow*`.  
+The user pointer is how callbacks recover the application state for that window.
+
+### 2) Vtable-style polymorphism
+
+```c
+struct GraphicObjectVTable {
+    void (*translate)(GraphicObject* object, Vec2 delta);
+    int (*hit_test)(const GraphicObject* object, Vec2 point, float tolerance);
+};
+```
+
+Why: New object types can be added by implementing a function set and wiring a vtable, not by scattering `if/else`.
+
+### 3) Consistent null-check guard
+
+```c
+if (!app) {
+    return;
+}
+```
+
+Why: Reduces crash risk and matches the repository coding style.
+
+## Contributor change entry points (by task type)
+
+### Add a new shape/object type
+
+1. Add `GraphicObjectType` in `include/document/object.h`
+2. Implement constructor + vtable callbacks in `src/document/object.c`
+3. Ensure hit test, path points, scalar get/set are complete
+4. If needed, add tool creation flow and inspector bindings
+
+### Add a new tool
+
+1. Add `ToolKind` in `include/tools/tool.h`
+2. Add state struct + callbacks in `src/tools/tool_controller.c`
+3. Register tool in `tool_controller_init()`
+4. Add toolbar button and shortcut mapping
+
+### Change inspector/property editing behavior
+
+1. Edit `src/ui/ui_system.c`
+2. Ensure object edits correctly push to `document_history_push()`
+3. Verify dirty state sync via `workspace_sync_document_dirty()`
+
+## Pre-PR checklist
+
+1. The app builds and runs locally
+2. Manual flow check for create/select/move/undo/redo
+3. No obvious leaks (allocation/free ownership is paired)
+4. No array bound breakage or missing null checks
+5. Docs/comments are updated when behavior changes
+
+## Common issues for new contributors
+
+### Issue 1: Mixing `.` and `->`
+
+- Struct variable: `.`
+- Pointer: `->`
+
+### Issue 2: Object changes not recorded in history
+
+Symptom: `Ctrl+Z` does not undo your edit.  
+Check: Did your code call `document_history_push()` at the right place?
+
+### Issue 3: Rendering changed, model unchanged
+
+Symptom: UI looks right, but save/load loses data.  
+Check: Did you update `Document` and persistence logic, not just renderer output?
+
+### Issue 4: Missing platform branch handling
+
+Symptom: Works on Windows but fails on Linux/macOS (or vice versa).  
+Check: Is your `#ifdef _WIN32` split complete?
+
+## Suggested learning and contribution path
+
+1. Read-only walkthrough: main loop, event routing, render path
+2. Small edits: shortcut, status text, tool switching behavior
+3. Medium edits: add/modify object properties, tweak tool behavior
+4. Structural edits: new shape type, history extension, persistence format changes
+
+## Minimum bar for independent contribution
+
+You are ready for small-to-medium PRs when you can:
+
+1. Trace `Application*` through callback routing
+2. Modify `Document` data safely with bounds/guard checks
+3. Implement or extend tool/object callbacks (vtable style)
+4. Find and fix one memory ownership issue
+5. Complete a full local change-build-run verification loop

--- a/doc/c-language-must-know-for-gldraw.md
+++ b/doc/c-language-must-know-for-gldraw.md
@@ -1,0 +1,144 @@
+# GLDraw C 语言贡献者指南（开发者 / 开源协作者）
+
+本指南面向准备阅读、修改、扩展 GLDraw 的开发者与开源贡献者。  
+目标不是覆盖全部 C 语法，而是帮助你快速掌握“这个仓库真正会用到的语法和实践”。
+
+语言版本：
+- 中文（当前文件）
+- English: [c-language-must-know-for-gldraw.en.md](./c-language-must-know-for-gldraw.en.md)
+
+## 适用读者
+
+- 想给 GLDraw 提交 PR 的新贡献者
+- 能读基础 C 代码，但对工程化写法不熟
+- 需要快速理解本项目的模块边界与改动入口
+
+## 贡献前建议先读
+
+1. `doc/wiki/architecture.md`
+2. `doc/wiki/data-flow.md`
+3. `src/app/application.c`
+4. `src/tools/tool_controller.c`
+5. `src/document/object.c`
+
+先建立主链路认知：`GLFW 回调 -> ToolController -> Document/CanvasView -> RenderSystem`。
+
+## 必会 C 语法（按项目优先级）
+
+下表中每一项都能在仓库中直接找到对应代码。
+
+| 语法/概念 | 为什么必须会 | 典型文件 |
+|---|---|---|
+| `struct` + `typedef` | 组织应用状态和模块边界 | `include/app/workspace.h` |
+| 指针 `*`、取址 `&`、成员访问 `.`/`->` | 贯穿所有模块调用 | `src/app/application.c` |
+| 传值 vs 传指针 | 避免状态拷贝，支持原地修改 | `src/document/document.c` |
+| `enum` + `switch` | 工具/对象状态分发 | `include/tools/tool.h`, `src/tools/tool_controller.c` |
+| 定长数组与边界检查 | 对象池和选择集安全 | `include/document/document.h` |
+| 函数指针与 vtable | 对象系统与工具系统多态 | `include/document/object.h`, `src/document/object.c` |
+| 回调与 `void*` 用户指针 | 从 GLFW 窗口取回 `Application*` | `src/app/application.c` |
+| 动态内存管理 | 避免泄漏与悬空引用 | `src/document/history.c` |
+| `const` / `static` / 作用域 | 控制可见性与只读约束 | 各模块 `.h/.c` |
+| 预处理与平台分支 | Windows 与非 Windows 路径 | `src/document/persistence.c` |
+| 位运算掩码 | 键盘修饰键处理 | `src/tools/tool_controller.c` |
+| 字符串与安全格式化 | 路径、状态栏文本、日志 | `src/app/application.c` |
+
+## 项目中的关键语法样式
+
+### 1) 回调桥接（必须理解）
+
+```c
+glfwSetWindowUserPointer(app->window.handle, app);
+Application* app = (Application*)glfwGetWindowUserPointer(handle);
+```
+
+意义：GLFW 回调只提供 `GLFWwindow*`，通过 user pointer 才能获取当前窗口对应的应用状态。
+
+### 2) vtable 多态调用
+
+```c
+struct GraphicObjectVTable {
+    void (*translate)(GraphicObject* object, Vec2 delta);
+    int (*hit_test)(const GraphicObject* object, Vec2 point, float tolerance);
+};
+```
+
+意义：新增对象类型时，不改大量 `if/else`，只需实现一组函数并挂到 vtable。
+
+### 3) 统一空指针保护
+
+```c
+if (!app) {
+    return;
+}
+```
+
+意义：减少崩溃风险，是项目代码风格的一部分。
+
+## 贡献者改动入口（按任务类型）
+
+### 新增图元类型
+
+1. 在 `include/document/object.h` 添加 `GraphicObjectType`
+2. 在 `src/document/object.c` 实现构造和 vtable 回调
+3. 确保 hit test、path points、scalar get/set 都完整
+4. 如需要，补充工具创建入口与 UI 编辑项
+
+### 新增工具
+
+1. 在 `include/tools/tool.h` 增加 `ToolKind`
+2. 在 `src/tools/tool_controller.c` 增加状态结构与回调实现
+3. 在 `tool_controller_init()` 注册工具
+4. 补充工具栏按钮和快捷键映射
+
+### 修改属性面板行为
+
+1. 改 `src/ui/ui_system.c`
+2. 修改对象属性时保证 `document_history_push()` 被正确触发
+3. 检查 `workspace_sync_document_dirty()` 是否同步
+
+## 提交 PR 前检查（推荐）
+
+1. 能成功构建并运行应用
+2. 功能路径至少手动测试一次（创建、选择、移动、撤销/重做）
+3. 不引入明显内存泄漏（分配和释放配对）
+4. 不破坏数组边界与空指针防护
+5. 文档或注释与代码改动保持一致
+
+## 新贡献者最常见问题
+
+### 问题 1：把 `.` 和 `->` 混用
+
+- 结构体变量用 `.`
+- 指针用 `->`
+
+### 问题 2：改了对象数据但没进历史栈
+
+症状：修改后无法 `Ctrl+Z`。  
+排查：是否在正确位置调用 `document_history_push()`。
+
+### 问题 3：只改了渲染，没改数据模型
+
+症状：画面能看见，但保存/加载后丢失。  
+排查：是否同步更新了 `Document` 与持久化逻辑。
+
+### 问题 4：忘记处理平台分支
+
+症状：Windows 通过、Linux/macOS 失败（或相反）。  
+排查：`#ifdef _WIN32` 分支是否完整。
+
+## 建议的学习与贡献路径
+
+1. 先做只读导览：主循环、事件路由、渲染调用链
+2. 再做小改动：新增快捷键、状态栏文本、工具切换逻辑
+3. 然后做中等改动：新增简单对象属性或工具行为
+4. 最后再做结构性改造：新图元类型、历史系统增强、持久化格式扩展
+
+## 最低能力门槛（可独立贡献）
+
+满足以下条件即可开始提交中小型 PR：
+
+1. 能看懂 `Application*` 在回调链路中的流转
+2. 能在不破坏边界检查的前提下修改 `Document` 数据
+3. 能为对象或工具补齐 vtable/回调实现
+4. 能定位并修复一个内存管理问题
+5. 能完成一次从代码修改到本地运行验证的闭环

--- a/doc/wiki/Home.md
+++ b/doc/wiki/Home.md
@@ -18,6 +18,14 @@ The project now follows the same split used by common graphics tools:
 3. [Project Structure](project-structure)
 4. [Architecture](architecture)
 
+## Contributor Quick Prep
+
+If you plan to contribute code, read the C contributor guide first.  
+It summarizes repository-specific C patterns (callbacks, pointers, vtable usage, memory ownership) and common PR pitfalls.
+
+- [C Contributor Guide (EN)](../c-language-must-know-for-gldraw.en.md)
+- [C 贡献者指南 (ZH)](../c-language-must-know-for-gldraw.md)
+
 ## Core Systems
 
 - [Overview](core-systems-overview)
@@ -32,5 +40,7 @@ The project now follows the same split used by common graphics tools:
 
 - [Data Flow](data-flow)
 - [Extending the Project](extending)
+- [C Contributor Guide (EN)](../c-language-must-know-for-gldraw.en.md)
+- [C 贡献者指南 (ZH)](../c-language-must-know-for-gldraw.md)
 - [Known Issues](known-issues)
 - [FAQ](faq)

--- a/doc/wiki/_Sidebar.md
+++ b/doc/wiki/_Sidebar.md
@@ -12,6 +12,8 @@
 - [Architecture](architecture)
 - [Data Flow](data-flow)
 - [Extending](extending)
+- [C Contributor Guide (EN)](../c-language-must-know-for-gldraw.en.md)
+- [C 贡献者指南 (ZH)](../c-language-must-know-for-gldraw.md)
 - [Known Issues](known-issues)
 
 ### Core Systems


### PR DESCRIPTION
## Summary
- add a bilingual C contributor guide covering project-specific patterns and expectations
- update the README and wiki to point contributors at the new documentation entry points
- ignore local agent instruction files that should not be committed back to the repository

## Testing
- Verify the new documentation renders correctly
- Check that the wiki links remain valid
