### PR TITLE
feat(canvas): layout-driven architecture with unified bounds and GL scissor

### DIFF
--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -9,11 +9,22 @@
 struct Workspace;
 typedef int (*WorkspaceCommandFn)(struct Workspace* workspace, void* user_data);
 
+typedef struct WorkspaceLayout {
+    RectF window_bounds;
+    RectF canvas_content_bounds;
+    RectF appbar_bounds;
+    RectF rail_bounds;
+    RectF panel_bounds;
+    RectF status_bounds;
+    unsigned int layout_revision;
+} WorkspaceLayout;
+
 typedef struct Workspace {
     Document document;
     DocumentHistory history;
     CanvasView canvas;
     ToolController tools;
+    WorkspaceLayout layout;
     char current_document_path[260];
     char status_message[256];
     unsigned int saved_revision;

--- a/include/canvas/canvas_view.h
+++ b/include/canvas/canvas_view.h
@@ -4,8 +4,15 @@
 #include <base/types.h>
 #include <document/document.h>
 
+typedef struct CanvasViewportState {
+    RectF viewport;
+    Vec2 center;
+    float zoom;
+} CanvasViewportState;
+
 typedef struct CanvasView {
     Document* document;
+    CanvasViewportState viewport_state;
     RectF viewport;
     Vec2 center;
     float zoom;
@@ -16,6 +23,12 @@ typedef struct CanvasView {
 void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport);
 void canvas_view_set_document(CanvasView* canvas, Document* document);
 void canvas_view_set_viewport(CanvasView* canvas, RectF viewport);
+void canvas_view_set_center(CanvasView* canvas, Vec2 center);
+void canvas_view_set_zoom(CanvasView* canvas, float zoom);
+void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom);
+RectF canvas_view_viewport(const CanvasView* canvas);
+Vec2 canvas_view_center(const CanvasView* canvas);
+float canvas_view_zoom(const CanvasView* canvas);
 Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world);
 Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen);
 void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen);

--- a/include/ui/ui_system.h
+++ b/include/ui/ui_system.h
@@ -13,6 +13,9 @@ void ui_system_destroy(UiSystem* ui);
 void ui_system_begin_frame(UiSystem* ui);
 void ui_system_build(UiSystem* ui, struct Workspace* workspace);
 void ui_system_render(UiSystem* ui);
+int ui_system_has_active_interaction(const UiSystem* ui);
 int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos);
+RectF ui_system_content_bounds(const UiSystem* ui);
+Color ui_system_canvas_background(const UiSystem* ui);
 
 #endif /* GLDRAW_UI_UI_SYSTEM_H */

--- a/include/ui/ui_theme.h
+++ b/include/ui/ui_theme.h
@@ -18,6 +18,7 @@ typedef struct UiThemeTokens {
     struct nk_color background;
     struct nk_color panel;
     struct nk_color panel_hover;
+    struct nk_color canvas_background;
 
     /* Text */
     struct nk_color text;

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -23,15 +23,8 @@ typedef struct {
     RenderSystem* renderer;
     UiSystem* ui;
     Vec2 cursor_screen;
+    int cursor_inside_canvas;
 } Application;
-
-/* Global application instance for menu actions */
-static Application* g_app = NULL;
-
-void* app_get_instance(void)
-{
-    return g_app;
-}
 
 static int app_workspace_save(Workspace* workspace, void* user_data);
 static int app_workspace_load(Workspace* workspace, void* user_data);
@@ -191,14 +184,169 @@ static ToolContext app_tool_context(Application* app)
     return context;
 }
 
+static RectF app_window_bounds(const Application* app)
+{
+    RectF bounds = {0.0f, 0.0f, 1.0f, 1.0f};
+
+    if (!app) {
+        return bounds;
+    }
+
+    bounds.w = (float)app->window.width;
+    bounds.h = (float)app->window.height;
+    if (bounds.w < 1.0f) {
+        bounds.w = 1.0f;
+    }
+    if (bounds.h < 1.0f) {
+        bounds.h = 1.0f;
+    }
+    return bounds;
+}
+
+static RectF app_clamp_rect_to_bounds(RectF rect, RectF bounds)
+{
+    float max_x = bounds.x + bounds.w;
+    float max_y = bounds.y + bounds.h;
+
+    if (rect.w < 0.0f) {
+        rect.w = 0.0f;
+    }
+    if (rect.h < 0.0f) {
+        rect.h = 0.0f;
+    }
+    if (rect.x < bounds.x) {
+        rect.w -= (bounds.x - rect.x);
+        rect.x = bounds.x;
+    }
+    if (rect.y < bounds.y) {
+        rect.h -= (bounds.y - rect.y);
+        rect.y = bounds.y;
+    }
+    if (rect.x > max_x) {
+        rect.x = max_x;
+    }
+    if (rect.y > max_y) {
+        rect.y = max_y;
+    }
+    if (rect.x + rect.w > max_x) {
+        rect.w = max_x - rect.x;
+    }
+    if (rect.y + rect.h > max_y) {
+        rect.h = max_y - rect.y;
+    }
+    if (rect.w < 0.0f) {
+        rect.w = 0.0f;
+    }
+    if (rect.h < 0.0f) {
+        rect.h = 0.0f;
+    }
+
+    return rect;
+}
+
+static int app_pointer_hits_canvas(const Application* app, Vec2 screen_pos)
+{
+    RectF canvas_bounds;
+
+    if (!app) {
+        return 1;
+    }
+
+    canvas_bounds = app->workspace.layout.canvas_content_bounds;
+    if (canvas_bounds.w <= 1.0f || canvas_bounds.h <= 1.0f) {
+        canvas_bounds = app_window_bounds(app);
+    }
+
+    return rectf_contains_point(&canvas_bounds, screen_pos);
+}
+
+static int app_pointer_hits_ui_region(const Application* app, Vec2 screen_pos)
+{
+    const WorkspaceLayout* layout;
+    RectF window_bounds;
+    RectF appbar_bounds;
+    RectF rail_bounds;
+    RectF panel_bounds;
+    RectF status_bounds;
+
+    if (!app) {
+        return 0;
+    }
+
+    layout = &app->workspace.layout;
+    window_bounds = app_window_bounds(app);
+    appbar_bounds = app_clamp_rect_to_bounds(layout->appbar_bounds, window_bounds);
+    rail_bounds = app_clamp_rect_to_bounds(layout->rail_bounds, window_bounds);
+    panel_bounds = app_clamp_rect_to_bounds(layout->panel_bounds, window_bounds);
+    status_bounds = app_clamp_rect_to_bounds(layout->status_bounds, window_bounds);
+
+    return rectf_contains_point(&appbar_bounds, screen_pos) ||
+           rectf_contains_point(&rail_bounds, screen_pos) ||
+           rectf_contains_point(&panel_bounds, screen_pos) ||
+           rectf_contains_point(&status_bounds, screen_pos);
+}
+
+static int app_pointer_blocks_canvas(const Application* app, Vec2 screen_pos)
+{
+    if (!app) {
+        return 0;
+    }
+
+    if (app->ui && ui_system_has_active_interaction(app->ui)) {
+        return 1;
+    }
+
+    return app_pointer_hits_ui_region(app, screen_pos) ||
+           !app_pointer_hits_canvas(app, screen_pos);
+}
+
+static void app_sync_tool_pointer_anchor(Application* app)
+{
+    if (!app) {
+        return;
+    }
+
+    app->workspace.tools.last_screen = app->cursor_screen;
+    app->workspace.tools.last_world =
+        canvas_view_screen_to_world(&app->workspace.canvas, app->cursor_screen);
+}
+
+static void app_sync_canvas_boundary(Application* app)
+{
+    int inside_canvas = 0;
+
+    if (!app || app->workspace.tools.pointer_captured) {
+        return;
+    }
+
+    inside_canvas = app_pointer_hits_canvas(app, app->cursor_screen);
+    if (inside_canvas != app->cursor_inside_canvas) {
+        app->cursor_inside_canvas = inside_canvas;
+        app_sync_tool_pointer_anchor(app);
+    }
+}
+
 static void update_canvas_viewport(Application* app)
 {
+    RectF window_bounds;
     RectF viewport;
-    viewport.x = 0.0f;
-    viewport.y = 0.0f;
-    viewport.w = (float)app->window.width;
-    viewport.h = (float)app->window.height;
+
+    if (!app) {
+        return;
+    }
+
+    window_bounds = app_window_bounds(app);
+    viewport = app_clamp_rect_to_bounds(app->workspace.layout.canvas_content_bounds, window_bounds);
+    if (viewport.w <= 1.0f || viewport.h <= 1.0f) {
+        viewport = window_bounds;
+    }
+
+    if (app->ui) {
+        app->workspace.canvas.background = ui_system_canvas_background(app->ui);
+    }
+
     canvas_view_set_viewport(&app->workspace.canvas, viewport);
+    app_sync_canvas_boundary(app);
 }
 
 static ToolEvent make_tool_event(Application* app, int button, int mods, float wheel_y)
@@ -237,13 +385,15 @@ static void cursor_pos_callback(GLFWwindow* handle, double xpos, double ypos)
     }
 
     app->cursor_screen = vec2_make((float)xpos, (float)ypos);
-    context = app_tool_context(app);
-    event = make_tool_event(app, -1, 0, 0.0f);
+    app_sync_canvas_boundary(app);
 
     if (!app->workspace.tools.pointer_captured &&
-        ui_system_blocks_pointer(app->ui, app->cursor_screen)) {
+        app_pointer_blocks_canvas(app, app->cursor_screen)) {
         return;
     }
+
+    context = app_tool_context(app);
+    event = make_tool_event(app, -1, 0, 0.0f);
 
     tool_controller_pointer_move(&app->workspace.tools, &context, &event);
 }
@@ -258,16 +408,23 @@ static void mouse_button_callback(GLFWwindow* handle, int button, int action, in
         return;
     }
 
-    context = app_tool_context(app);
-    event = make_tool_event(app, button, mods, 0.0f);
-
     if (action == GLFW_PRESS) {
         if (!app->workspace.tools.pointer_captured &&
-            ui_system_blocks_pointer(app->ui, app->cursor_screen)) {
+            app_pointer_blocks_canvas(app, app->cursor_screen)) {
             return;
         }
+        context = app_tool_context(app);
+        event = make_tool_event(app, button, mods, 0.0f);
         tool_controller_pointer_down(&app->workspace.tools, &context, &event);
     } else if (action == GLFW_RELEASE) {
+        if (!app->workspace.tools.pointer_captured) {
+            if (app_pointer_blocks_canvas(app, app->cursor_screen)) {
+                return;
+            }
+            return;
+        }
+        context = app_tool_context(app);
+        event = make_tool_event(app, button, mods, 0.0f);
         tool_controller_pointer_up(&app->workspace.tools, &context, &event);
     }
 }
@@ -344,7 +501,8 @@ static void scroll_callback(GLFWwindow* handle, double xoffset, double yoffset)
         return;
     }
 
-    if (ui_system_blocks_pointer(app->ui, app->cursor_screen)) {
+    if (!app->workspace.tools.pointer_captured &&
+        app_pointer_blocks_canvas(app, app->cursor_screen)) {
         return;
     }
 
@@ -355,8 +513,6 @@ static void scroll_callback(GLFWwindow* handle, double xoffset, double yoffset)
 static int app_init(Application* app)
 {
     RectF viewport = {0.0f, 0.0f, 1440.0f, 900.0f};
-
-    g_app = app;
 
     if (platform_window_init(&app->window, 1440, 900, "GLDraw Canvas") != 0) {
         LOG_ERROR("%s", "Failed to create window");
@@ -376,6 +532,8 @@ static int app_init(Application* app)
     app->workspace.command_user_data = app;
     workspace_mark_saved(&app->workspace);
     app_set_status(app, "Initializing editor");
+    app->cursor_screen = vec2_make(app->window.width * 0.5f, app->window.height * 0.5f);
+    app->cursor_inside_canvas = 1;
 
     app->renderer = render_system_create(&app->window);
     if (!app->renderer) {
@@ -399,7 +557,8 @@ static int app_init(Application* app)
 
     render_system_resize(app->renderer, app->window.width, app->window.height);
     update_canvas_viewport(app);
-    app->cursor_screen = vec2_make(app->window.width * 0.5f, app->window.height * 0.5f);
+    app->cursor_inside_canvas = app_pointer_hits_canvas(app, app->cursor_screen);
+    app_sync_tool_pointer_anchor(app);
     app_open_startup_document(app);
     return 0;
 }
@@ -409,8 +568,6 @@ static void app_shutdown(Application* app)
     if (!app) {
         return;
     }
-
-    g_app = NULL;
 
     ui_system_destroy(app->ui);
     render_system_destroy(app->renderer);
@@ -439,6 +596,7 @@ int app_run(void)
         platform_window_poll_events();
         ui_system_begin_frame(app->ui);
         ui_system_build(app->ui, &app->workspace);
+        update_canvas_viewport(app);
         render_system_draw(app->renderer,
                            &app->workspace.document,
                            &app->workspace.canvas,

--- a/src/canvas/canvas_view.c
+++ b/src/canvas/canvas_view.c
@@ -4,6 +4,103 @@
 
 #include <stddef.h>
 
+static CanvasViewportState canvas_viewport_state_from_compat(const CanvasView* canvas)
+{
+    CanvasViewportState state;
+    state.viewport.x = 0.0f;
+    state.viewport.y = 0.0f;
+    state.viewport.w = 0.0f;
+    state.viewport.h = 0.0f;
+    state.center = vec2_make(0.0f, 0.0f);
+    state.zoom = 1.0f;
+
+    if (!canvas) {
+        return state;
+    }
+
+    state.viewport = canvas->viewport;
+    state.center = canvas->center;
+    state.zoom = (canvas->zoom > 0.0f) ? canvas->zoom : 1.0f;
+    return state;
+}
+
+static void canvas_view_sync_compat(CanvasView* canvas)
+{
+    if (!canvas) {
+        return;
+    }
+
+    canvas->viewport = canvas->viewport_state.viewport;
+    canvas->center = canvas->viewport_state.center;
+    canvas->zoom = canvas->viewport_state.zoom;
+}
+
+static Vec2 canvas_viewport_world_to_screen(const CanvasViewportState* state, Vec2 world)
+{
+    Vec2 screen = {0.0f, 0.0f};
+
+    if (!state) {
+        return screen;
+    }
+
+    screen.x = state->viewport.x + (state->viewport.w * 0.5f) + (world.x - state->center.x) * state->zoom;
+    screen.y = state->viewport.y + (state->viewport.h * 0.5f) - (world.y - state->center.y) * state->zoom;
+    return screen;
+}
+
+static Vec2 canvas_viewport_screen_to_world(const CanvasViewportState* state, Vec2 screen)
+{
+    Vec2 world = {0.0f, 0.0f};
+
+    if (!state || state->zoom <= 0.0f) {
+        return world;
+    }
+
+    world.x = state->center.x + (screen.x - (state->viewport.x + state->viewport.w * 0.5f)) / state->zoom;
+    world.y = state->center.y - (screen.y - (state->viewport.y + state->viewport.h * 0.5f)) / state->zoom;
+    return world;
+}
+
+static void canvas_viewport_pan_screen_delta(CanvasViewportState* state, Vec2 delta_screen)
+{
+    if (!state || state->zoom <= 0.0f) {
+        return;
+    }
+
+    state->center.x -= delta_screen.x / state->zoom;
+    state->center.y += delta_screen.y / state->zoom;
+}
+
+static void canvas_viewport_zoom_at_screen_point(CanvasViewportState* state, float factor, Vec2 screen_anchor)
+{
+    Vec2 before = {0.0f, 0.0f};
+    Vec2 after = {0.0f, 0.0f};
+
+    if (!state || factor <= 0.0f) {
+        return;
+    }
+
+    before = canvas_viewport_screen_to_world(state, screen_anchor);
+    state->zoom = clampf(state->zoom * factor, 0.1f, 12.0f);
+    after = canvas_viewport_screen_to_world(state, screen_anchor);
+    state->center = vec2_add(state->center, vec2_sub(before, after));
+}
+
+static RectF canvas_viewport_visible_world_rect(const CanvasViewportState* state)
+{
+    RectF rect = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    if (!state || state->zoom <= 0.0f) {
+        return rect;
+    }
+
+    rect.w = state->viewport.w / state->zoom;
+    rect.h = state->viewport.h / state->zoom;
+    rect.x = state->center.x - rect.w * 0.5f;
+    rect.y = state->center.y - rect.h * 0.5f;
+    return rect;
+}
+
 void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport)
 {
     if (!canvas) {
@@ -11,13 +108,14 @@ void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport)
     }
 
     canvas->document = document;
-    canvas->viewport = viewport;
-    canvas->center = vec2_make(0.0f, 0.0f);
-    canvas->zoom = 1.0f;
+    canvas->viewport_state.viewport = viewport;
+    canvas->viewport_state.center = vec2_make(0.0f, 0.0f);
+    canvas->viewport_state.zoom = 1.0f;
+    canvas_view_sync_compat(canvas);
     canvas->show_grid = 1;
-    canvas->background.r = 0.11f;
-    canvas->background.g = 0.12f;
-    canvas->background.b = 0.14f;
+    canvas->background.r = 218.0f / 255.0f;
+    canvas->background.g = 226.0f / 255.0f;
+    canvas->background.b = 236.0f / 255.0f;
     canvas->background.a = 1.0f;
 }
 
@@ -30,80 +128,131 @@ void canvas_view_set_document(CanvasView* canvas, Document* document)
 
 void canvas_view_set_viewport(CanvasView* canvas, RectF viewport)
 {
-    if (canvas) {
-        canvas->viewport = viewport;
+    CanvasViewportState state;
+
+    if (!canvas) {
+        return;
     }
+
+    state = canvas_viewport_state_from_compat(canvas);
+    state.viewport = viewport;
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
+}
+
+void canvas_view_set_center(CanvasView* canvas, Vec2 center)
+{
+    CanvasViewportState state;
+
+    if (!canvas) {
+        return;
+    }
+
+    state = canvas_viewport_state_from_compat(canvas);
+    state.center = center;
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
+}
+
+void canvas_view_set_zoom(CanvasView* canvas, float zoom)
+{
+    CanvasViewportState state;
+
+    if (!canvas) {
+        return;
+    }
+
+    state = canvas_viewport_state_from_compat(canvas);
+    state.zoom = clampf(zoom, 0.1f, 12.0f);
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
+}
+
+void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom)
+{
+    CanvasViewportState state;
+
+    if (!canvas) {
+        return;
+    }
+
+    state = canvas_viewport_state_from_compat(canvas);
+    state.center = center;
+    state.zoom = clampf(zoom, 0.1f, 12.0f);
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
+}
+
+RectF canvas_view_viewport(const CanvasView* canvas)
+{
+    return canvas_viewport_state_from_compat(canvas).viewport;
+}
+
+Vec2 canvas_view_center(const CanvasView* canvas)
+{
+    return canvas_viewport_state_from_compat(canvas).center;
+}
+
+float canvas_view_zoom(const CanvasView* canvas)
+{
+    return canvas_viewport_state_from_compat(canvas).zoom;
 }
 
 Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world)
 {
-    Vec2 screen = {0.0f, 0.0f};
-    if (!canvas) {
-        return screen;
-    }
-
-    screen.x = canvas->viewport.x + (canvas->viewport.w * 0.5f) + (world.x - canvas->center.x) * canvas->zoom;
-    screen.y = canvas->viewport.y + (canvas->viewport.h * 0.5f) - (world.y - canvas->center.y) * canvas->zoom;
-    return screen;
+    CanvasViewportState state = canvas_viewport_state_from_compat(canvas);
+    return canvas_viewport_world_to_screen(&state, world);
 }
 
 Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen)
 {
-    Vec2 world = {0.0f, 0.0f};
-    if (!canvas || canvas->zoom <= 0.0f) {
-        return world;
-    }
-
-    world.x = canvas->center.x + (screen.x - (canvas->viewport.x + canvas->viewport.w * 0.5f)) / canvas->zoom;
-    world.y = canvas->center.y - (screen.y - (canvas->viewport.y + canvas->viewport.h * 0.5f)) / canvas->zoom;
-    return world;
+    CanvasViewportState state = canvas_viewport_state_from_compat(canvas);
+    return canvas_viewport_screen_to_world(&state, screen);
 }
 
 void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen)
 {
-    if (!canvas || canvas->zoom <= 0.0f) {
+    CanvasViewportState state;
+
+    if (!canvas) {
         return;
     }
 
-    canvas->center.x -= delta_screen.x / canvas->zoom;
-    canvas->center.y += delta_screen.y / canvas->zoom;
+    state = canvas_viewport_state_from_compat(canvas);
+    canvas_viewport_pan_screen_delta(&state, delta_screen);
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
 }
 
 void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 screen_anchor)
 {
-    Vec2 before = {0.0f, 0.0f};
-    Vec2 after = {0.0f, 0.0f};
+    CanvasViewportState state;
 
-    if (!canvas || factor <= 0.0f) {
+    if (!canvas) {
         return;
     }
 
-    before = canvas_view_screen_to_world(canvas, screen_anchor);
-    canvas->zoom = clampf(canvas->zoom * factor, 0.1f, 12.0f);
-    after = canvas_view_screen_to_world(canvas, screen_anchor);
-    canvas->center = vec2_add(canvas->center, vec2_sub(before, after));
+    state = canvas_viewport_state_from_compat(canvas);
+    canvas_viewport_zoom_at_screen_point(&state, factor, screen_anchor);
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
 }
 
 float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pixels)
 {
-    if (!canvas || canvas->zoom <= 0.0f) {
+    float zoom = canvas_view_zoom(canvas);
+
+    if (zoom <= 0.0f) {
         return pixels;
     }
-    return pixels / canvas->zoom;
+
+    return pixels / zoom;
 }
 
 RectF canvas_view_visible_world_rect(const CanvasView* canvas)
 {
-    RectF rect = {0.0f, 0.0f, 0.0f, 0.0f};
-    if (!canvas || canvas->zoom <= 0.0f) {
-        return rect;
-    }
-
-    rect.w = canvas->viewport.w / canvas->zoom;
-    rect.h = canvas->viewport.h / canvas->zoom;
-    rect.x = canvas->center.x - rect.w * 0.5f;
-    rect.y = canvas->center.y - rect.h * 0.5f;
-    return rect;
+    CanvasViewportState state = canvas_viewport_state_from_compat(canvas);
+    return canvas_viewport_visible_world_rect(&state);
 }
 
 GraphicObject* canvas_view_pick_object(const CanvasView* canvas, Vec2 screen_point, float tolerance_pixels)

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -222,6 +222,53 @@ static void draw_object(RenderSystem* renderer,
     draw_polyline(renderer, canvas, renderer->path_buffer, point_count, object->style.stroke_color, object->style.stroke_width);
 }
 
+static int render_canvas_scissor_box(const RectF* viewport, int framebuffer_width, int framebuffer_height, GLint out_scissor[4])
+{
+    int x = 0;
+    int y_top = 0;
+    int w = 0;
+    int h = 0;
+    int y = 0;
+
+    if (!viewport || !out_scissor || framebuffer_width <= 0 || framebuffer_height <= 0) {
+        return 0;
+    }
+
+    if (viewport->w <= 0.0f || viewport->h <= 0.0f) {
+        return 0;
+    }
+
+    x = (int)floorf(viewport->x);
+    y_top = (int)floorf(viewport->y);
+    w = (int)ceilf(viewport->w);
+    h = (int)ceilf(viewport->h);
+    y = framebuffer_height - y_top - h;
+
+    if (x < 0) {
+        w += x;
+        x = 0;
+    }
+    if (y < 0) {
+        h += y;
+        y = 0;
+    }
+    if (x + w > framebuffer_width) {
+        w = framebuffer_width - x;
+    }
+    if (y + h > framebuffer_height) {
+        h = framebuffer_height - y;
+    }
+    if (w <= 0 || h <= 0) {
+        return 0;
+    }
+
+    out_scissor[0] = (GLint)x;
+    out_scissor[1] = (GLint)y;
+    out_scissor[2] = (GLint)w;
+    out_scissor[3] = (GLint)h;
+    return 1;
+}
+
 RenderSystem* render_system_create(PlatformWindow* window)
 {
     RenderSystem* renderer = (RenderSystem*)calloc(1, sizeof(*renderer));
@@ -304,12 +351,35 @@ void render_system_draw(RenderSystem* renderer,
                         const GraphicObject* overlay_object)
 {
     int i = 0;
+    GLboolean scissor_was_enabled = GL_FALSE;
+    GLint previous_scissor_box[4] = {0, 0, 0, 0};
+    GLint canvas_scissor_box[4] = {0, 0, 0, 0};
+    RectF viewport;
+    int has_canvas_area = 0;
 
     if (!renderer || !document || !canvas) {
         return;
     }
 
+    viewport = canvas_view_viewport(canvas);
+    has_canvas_area = render_canvas_scissor_box(&viewport,
+                                                renderer->width,
+                                                renderer->height,
+                                                canvas_scissor_box);
+
     glViewport(0, 0, renderer->width, renderer->height);
+    scissor_was_enabled = glIsEnabled(GL_SCISSOR_TEST);
+    glGetIntegerv(GL_SCISSOR_BOX, previous_scissor_box);
+
+    if (!has_canvas_area) {
+        if (!scissor_was_enabled) {
+            glDisable(GL_SCISSOR_TEST);
+        }
+        return;
+    }
+
+    glEnable(GL_SCISSOR_TEST);
+    glScissor(canvas_scissor_box[0], canvas_scissor_box[1], canvas_scissor_box[2], canvas_scissor_box[3]);
     glClearColor(canvas->background.r, canvas->background.g, canvas->background.b, canvas->background.a);
     glClear(GL_COLOR_BUFFER_BIT);
 
@@ -333,4 +403,13 @@ void render_system_draw(RenderSystem* renderer,
     glLineWidth(1.0f);
     glBindVertexArray(0);
     glUseProgram(0);
+
+    if (scissor_was_enabled) {
+        glScissor(previous_scissor_box[0],
+                  previous_scissor_box[1],
+                  previous_scissor_box[2],
+                  previous_scissor_box[3]);
+    } else {
+        glDisable(GL_SCISSOR_TEST);
+    }
 }

--- a/src/ui/ui_menu_actions.c
+++ b/src/ui/ui_menu_actions.c
@@ -2,6 +2,7 @@
 
 #include <app/workspace.h>
 #include <base/log.h>
+#include <base/math2d.h>
 #include <canvas/canvas_view.h>
 #include <document/document.h>
 #include <document/history.h>
@@ -31,9 +32,7 @@ static void app_workspace_new(Workspace* workspace)
     }
 
     /* Reset canvas zoom and center */
-    workspace->canvas.zoom = 1.0f;
-    workspace->canvas.center.x = 0.0f;
-    workspace->canvas.center.y = 0.0f;
+    canvas_view_set_center_zoom(&workspace->canvas, vec2_make(0.0f, 0.0f), 1.0f);
 
     /* Clear document path */
     workspace->current_document_path[0] = '\0';
@@ -56,9 +55,7 @@ static void app_zoom_to_fit(Workspace* workspace)
 
     if (doc->count == 0) {
         /* No objects, reset to default view */
-        canvas->zoom = 1.0f;
-        canvas->center.x = 0.0f;
-        canvas->center.y = 0.0f;
+        canvas_view_set_center_zoom(canvas, vec2_make(0.0f, 0.0f), 1.0f);
         return;
     }
 
@@ -102,17 +99,18 @@ static void app_zoom_to_fit(Workspace* workspace)
     float content_h = max_y - min_y;
 
     /* Calculate zoom to fit */
-    float zoom_x = canvas->viewport.w / content_w;
-    float zoom_y = canvas->viewport.h / content_h;
+    RectF canvas_viewport = canvas_view_viewport(canvas);
+    float zoom_x = canvas_viewport.w / content_w;
+    float zoom_y = canvas_viewport.h / content_h;
     float new_zoom = (zoom_x < zoom_y) ? zoom_x : zoom_y;
 
     /* Clamp zoom to valid range */
     new_zoom = (new_zoom < 0.1f) ? 0.1f : (new_zoom > 12.0f) ? 12.0f : new_zoom;
 
     /* Set new zoom and center */
-    canvas->zoom = new_zoom;
-    canvas->center.x = (min_x + max_x) * 0.5f;
-    canvas->center.y = (min_y + max_y) * 0.5f;
+    canvas_view_set_center_zoom(canvas,
+                                vec2_make((min_x + max_x) * 0.5f, (min_y + max_y) * 0.5f),
+                                new_zoom);
 }
 
 static void app_toggle_grid(Workspace* workspace)
@@ -246,14 +244,20 @@ void ui_menu_execute(Workspace* workspace, MenuId id)
 
     /* View menu */
     case MENU_ID_VIEW_ZOOM_IN:
+    {
+        Vec2 center = canvas_view_center(&workspace->canvas);
         canvas_view_zoom_at_screen_point(&workspace->canvas, 1.25f,
-                                        canvas_view_world_to_screen(&workspace->canvas, workspace->canvas.center));
+                                         canvas_view_world_to_screen(&workspace->canvas, center));
         break;
+    }
 
     case MENU_ID_VIEW_ZOOM_OUT:
+    {
+        Vec2 center = canvas_view_center(&workspace->canvas);
         canvas_view_zoom_at_screen_point(&workspace->canvas, 0.8f,
-                                        canvas_view_world_to_screen(&workspace->canvas, workspace->canvas.center));
+                                         canvas_view_world_to_screen(&workspace->canvas, center));
         break;
+    }
 
     case MENU_ID_VIEW_ZOOM_FIT:
         app_zoom_to_fit(workspace);

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -41,6 +41,8 @@ struct UiSystem {
     RectF rail_bounds;
     RectF panel_bounds;
     RectF status_bounds;
+    RectF content_bounds;
+    WorkspaceLayout layout_snapshot;
     float inspector_anim_t;
     int inspector_target_visible;
     int inspector_anim_initialized;
@@ -62,6 +64,94 @@ static float ui_smoothstep(float t)
 {
     float clamped = ui_clampf(t, 0.0f, 1.0f);
     return clamped * clamped * (3.0f - 2.0f * clamped);
+}
+
+static int ui_rectf_equals(RectF a, RectF b)
+{
+    const float eps = 1e-3f;
+    return fabsf(a.x - b.x) <= eps &&
+           fabsf(a.y - b.y) <= eps &&
+           fabsf(a.w - b.w) <= eps &&
+           fabsf(a.h - b.h) <= eps;
+}
+
+static RectF ui_clamp_rect_to_window(RectF rect, RectF window_bounds)
+{
+    float max_x = window_bounds.x + window_bounds.w;
+    float max_y = window_bounds.y + window_bounds.h;
+
+    if (rect.w < 0.0f) {
+        rect.w = 0.0f;
+    }
+    if (rect.h < 0.0f) {
+        rect.h = 0.0f;
+    }
+    if (rect.x < window_bounds.x) {
+        rect.w -= (window_bounds.x - rect.x);
+        rect.x = window_bounds.x;
+    }
+    if (rect.y < window_bounds.y) {
+        rect.h -= (window_bounds.y - rect.y);
+        rect.y = window_bounds.y;
+    }
+    if (rect.x > max_x) {
+        rect.x = max_x;
+    }
+    if (rect.y > max_y) {
+        rect.y = max_y;
+    }
+    if (rect.x + rect.w > max_x) {
+        rect.w = max_x - rect.x;
+    }
+    if (rect.y + rect.h > max_y) {
+        rect.h = max_y - rect.y;
+    }
+    if (rect.w < 0.0f) {
+        rect.w = 0.0f;
+    }
+    if (rect.h < 0.0f) {
+        rect.h = 0.0f;
+    }
+
+    return rect;
+}
+
+static void ui_publish_layout(UiSystem* ui, Workspace* workspace, int width, int height)
+{
+    WorkspaceLayout next_layout;
+    RectF window_bounds;
+    int changed = 0;
+
+    if (!ui || !workspace) {
+        return;
+    }
+
+    window_bounds.x = 0.0f;
+    window_bounds.y = 0.0f;
+    window_bounds.w = (float)width;
+    window_bounds.h = (float)height;
+
+    next_layout = workspace->layout;
+    next_layout.window_bounds = window_bounds;
+    next_layout.appbar_bounds = ui_clamp_rect_to_window(ui->appbar_bounds, window_bounds);
+    next_layout.rail_bounds = ui_clamp_rect_to_window(ui->rail_bounds, window_bounds);
+    next_layout.panel_bounds = ui_clamp_rect_to_window(ui->panel_bounds, window_bounds);
+    next_layout.status_bounds = ui_clamp_rect_to_window(ui->status_bounds, window_bounds);
+    next_layout.canvas_content_bounds = ui_clamp_rect_to_window(ui->content_bounds, window_bounds);
+
+    changed = !ui_rectf_equals(workspace->layout.window_bounds, next_layout.window_bounds) ||
+              !ui_rectf_equals(workspace->layout.appbar_bounds, next_layout.appbar_bounds) ||
+              !ui_rectf_equals(workspace->layout.rail_bounds, next_layout.rail_bounds) ||
+              !ui_rectf_equals(workspace->layout.panel_bounds, next_layout.panel_bounds) ||
+              !ui_rectf_equals(workspace->layout.status_bounds, next_layout.status_bounds) ||
+              !ui_rectf_equals(workspace->layout.canvas_content_bounds, next_layout.canvas_content_bounds);
+
+    if (changed) {
+        next_layout.layout_revision = workspace->layout.layout_revision + 1u;
+        workspace->layout = next_layout;
+    }
+
+    ui->layout_snapshot = workspace->layout;
 }
 
 static ToolContext ui_tool_context(Workspace* workspace)
@@ -319,22 +409,21 @@ static void ui_selection_panel(UiSystem* ui, Workspace* workspace, RectF bounds)
 static void ui_status_bar(UiSystem* ui, Workspace* workspace, int window_width, int window_height)
 {
     struct nk_context* ctx = ui->ctx;
-    const float margin = ui->theme.margin;
     const float status_h = ui->theme.status_height;
     const char* status_text = workspace->status_message[0] ? workspace->status_message : "Ready";
     float status_row_h = ui->theme.row_height * 0.65f;
     char zoom_text[24];
 
-    ui->status_bounds.x = margin;
-    ui->status_bounds.w = (float)window_width - (margin * 2.0f);
+    ui->status_bounds.x = 0.0f;
+    ui->status_bounds.w = (float)window_width;
     ui->status_bounds.h = status_h;
-    ui->status_bounds.y = (float)window_height - margin - status_h;
+    ui->status_bounds.y = (float)window_height - status_h;
 
     if (ui->status_bounds.w <= 32.0f || ui->status_bounds.h <= 14.0f) {
         return;
     }
 
-    snprintf(zoom_text, sizeof(zoom_text), "Zoom: %.0f%%", workspace->canvas.zoom * 100.0f);
+    snprintf(zoom_text, sizeof(zoom_text), "Zoom: %.0f%%", canvas_view_zoom(&workspace->canvas) * 100.0f);
 
     if (nk_begin(ctx, "Status",
                  nk_rect(ui->status_bounds.x, ui->status_bounds.y, ui->status_bounds.w, ui->status_bounds.h),
@@ -454,26 +543,23 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
     ui->appbar_bounds.w = (float)width;
     ui->appbar_bounds.h = ui_menubar_height(ui->menu_bar);
 
-    content_top = ui->appbar_bounds.h + ui->theme.margin;
-    content_bottom = (float)height - ui->theme.margin - ui->theme.status_height;
+    content_top = ui->appbar_bounds.h;
+    content_bottom = (float)height - ui->theme.status_height;
     content_height = content_bottom - content_top;
-    if (content_height < 80.0f) {
-        content_height = 80.0f;
+    if (content_height < 1.0f) {
+        content_height = 1.0f;
     }
 
-    rail_bounds.x = ui->theme.margin;
+    rail_bounds.x = 0.0f;
     rail_bounds.y = content_top;
     rail_bounds.w = ui->theme.tool_rail_width;
     rail_bounds.h = content_height;
     ui_tool_rail(ui, workspace, rail_bounds);
 
     inspector_requested = ui_menubar_inspector_visible(ui->menu_bar);
-    needed_width = ui->theme.margin * 2.0f +
-                   ui->theme.tool_rail_width +
-                   ui->theme.gap +
-                   UI_MIN_CANVAS_WIDTH;
+    needed_width = ui->theme.tool_rail_width + UI_MIN_CANVAS_WIDTH;
     if (inspector_requested) {
-        needed_width += ui->theme.gap + ui->theme.panel_width;
+        needed_width += ui->theme.panel_width;
     }
     inspector_target_visible = inspector_requested && ((float)width >= needed_width);
     ui->inspector_target_visible = inspector_target_visible;
@@ -497,8 +583,8 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
         inspector_eased_t = ui_smoothstep(ui->inspector_anim_t);
         inspector_bounds.w = ui->theme.panel_width;
         inspector_bounds.h = content_height;
-        inspector_hidden_x = (float)width + ui->theme.gap;
-        inspector_shown_x = (float)width - ui->theme.margin - inspector_bounds.w;
+        inspector_hidden_x = (float)width;
+        inspector_shown_x = (float)width - inspector_bounds.w;
         inspector_bounds.x = inspector_hidden_x + (inspector_shown_x - inspector_hidden_x) * inspector_eased_t;
         inspector_bounds.y = content_top;
         ui_selection_panel(ui, workspace, inspector_bounds);
@@ -510,6 +596,24 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
     }
 
     ui_status_bar(ui, workspace, width, height);
+
+    ui->content_bounds.x = ui->rail_bounds.x + ui->rail_bounds.w;
+    ui->content_bounds.y = ui->appbar_bounds.y + ui->appbar_bounds.h;
+    if (ui->panel_bounds.w > 1e-3f) {
+        ui->content_bounds.w = ui->panel_bounds.x - ui->content_bounds.x;
+    } else {
+        ui->content_bounds.w = (float)width - ui->content_bounds.x;
+    }
+    ui->content_bounds.h = ui->status_bounds.y - ui->content_bounds.y;
+
+    if (ui->content_bounds.w < 1.0f) {
+        ui->content_bounds.w = 1.0f;
+    }
+    if (ui->content_bounds.h < 1.0f) {
+        ui->content_bounds.h = 1.0f;
+    }
+
+    ui_publish_layout(ui, workspace, width, height);
 }
 
 void ui_system_render(UiSystem* ui)
@@ -520,18 +624,53 @@ void ui_system_render(UiSystem* ui)
     nk_glfw3_render(&ui->glfw, NK_ANTI_ALIASING_ON, UI_MAX_VERTEX_BUFFER, UI_MAX_ELEMENT_BUFFER);
 }
 
+int ui_system_has_active_interaction(const UiSystem* ui)
+{
+    if (!ui || !ui->ctx) {
+        return 0;
+    }
+
+    return nk_item_is_any_active(ui->ctx);
+}
+
 int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos)
 {
     if (!ui || !ui->ctx) {
         return 0;
     }
 
-    if (nk_item_is_any_active(ui->ctx)) {
+    if (ui_system_has_active_interaction(ui)) {
         return 1;
     }
 
-    return rectf_contains_point(&ui->appbar_bounds, screen_pos) ||
-           rectf_contains_point(&ui->rail_bounds, screen_pos) ||
-           rectf_contains_point(&ui->panel_bounds, screen_pos) ||
-           rectf_contains_point(&ui->status_bounds, screen_pos);
+    return rectf_contains_point(&ui->layout_snapshot.appbar_bounds, screen_pos) ||
+           rectf_contains_point(&ui->layout_snapshot.rail_bounds, screen_pos) ||
+           rectf_contains_point(&ui->layout_snapshot.panel_bounds, screen_pos) ||
+           rectf_contains_point(&ui->layout_snapshot.status_bounds, screen_pos);
+}
+
+RectF ui_system_content_bounds(const UiSystem* ui)
+{
+    RectF bounds = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    if (!ui) {
+        return bounds;
+    }
+
+    return ui->layout_snapshot.canvas_content_bounds;
+}
+
+Color ui_system_canvas_background(const UiSystem* ui)
+{
+    Color background = {0.11f, 0.12f, 0.14f, 1.0f};
+
+    if (!ui) {
+        return background;
+    }
+
+    background.r = (float)ui->theme.canvas_background.r / 255.0f;
+    background.g = (float)ui->theme.canvas_background.g / 255.0f;
+    background.b = (float)ui->theme.canvas_background.b / 255.0f;
+    background.a = (float)ui->theme.canvas_background.a / 255.0f;
+    return background;
 }

--- a/src/ui/ui_theme.c
+++ b/src/ui/ui_theme.c
@@ -23,39 +23,40 @@ UiThemeTokens ui_theme_default_tokens(void)
 {
     UiThemeTokens tokens;
 
-    tokens.primary = nk_rgba(46, 117, 224, 255);
-    tokens.primary_hover = nk_rgba(61, 130, 233, 255);
-    tokens.primary_active = nk_rgba(35, 101, 195, 255);
+    tokens.primary = nk_rgba(47, 109, 188, 255);
+    tokens.primary_hover = nk_rgba(62, 123, 205, 255);
+    tokens.primary_active = nk_rgba(37, 89, 160, 255);
 
-    tokens.background = nk_rgba(236, 240, 246, 255);
-    tokens.panel = nk_rgba(250, 252, 255, 255);
-    tokens.panel_hover = nk_rgba(243, 247, 253, 255);
+    tokens.background = nk_rgba(226, 233, 241, 255);
+    tokens.panel = nk_rgba(244, 248, 253, 255);
+    tokens.panel_hover = nk_rgba(233, 240, 248, 255);
+    tokens.canvas_background = nk_rgba(218, 226, 236, 255);
 
-    tokens.text = nk_rgba(34, 40, 49, 255);
-    tokens.text_secondary = nk_rgba(95, 104, 117, 255);
-    tokens.text_disabled = nk_rgba(150, 159, 171, 255);
+    tokens.text = nk_rgba(24, 35, 49, 255);
+    tokens.text_secondary = nk_rgba(84, 96, 111, 255);
+    tokens.text_disabled = nk_rgba(140, 151, 166, 255);
 
-    tokens.border = nk_rgba(188, 198, 212, 255);
-    tokens.border_hover = nk_rgba(164, 176, 194, 255);
+    tokens.border = nk_rgba(181, 194, 212, 255);
+    tokens.border_hover = nk_rgba(149, 166, 189, 255);
 
-    tokens.success = nk_rgba(43, 154, 103, 255);
-    tokens.warning = nk_rgba(204, 136, 36, 255);
-    tokens.error = nk_rgba(196, 70, 70, 255);
+    tokens.success = nk_rgba(45, 143, 105, 255);
+    tokens.warning = nk_rgba(194, 129, 42, 255);
+    tokens.error = nk_rgba(182, 74, 74, 255);
 
-    tokens.row_height = 28.0f;
-    tokens.panel_width = 280.0f;
-    tokens.menu_height = 30.0f;
-    tokens.status_height = 36.0f;
-    tokens.tool_rail_width = 80.0f;
+    tokens.row_height = 30.0f;
+    tokens.panel_width = 292.0f;
+    tokens.menu_height = 34.0f;
+    tokens.status_height = 32.0f;
+    tokens.tool_rail_width = 96.0f;
 
-    tokens.padding = 4.0f;
-    tokens.margin = 12.0f;
-    tokens.gap = 8.0f;
+    tokens.padding = 5.0f;
+    tokens.margin = 0.0f;
+    tokens.gap = 0.0f;
 
-    tokens.border_radius = 4.0f;
+    tokens.border_radius = 0.0f;
 
     tokens.enable_transitions = nk_true;
-    tokens.transition_duration = 0.10f;
+    tokens.transition_duration = 0.12f;
     return tokens;
 }
 
@@ -75,8 +76,8 @@ void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens)
     hover_panel = ui_theme_mix_channel(local_tokens.panel_hover, local_tokens.background, 0.35f);
 
     table[NK_COLOR_TEXT] = local_tokens.text;
-    table[NK_COLOR_WINDOW] = local_tokens.background;
-    table[NK_COLOR_HEADER] = local_tokens.panel;
+    table[NK_COLOR_WINDOW] = local_tokens.panel;
+    table[NK_COLOR_HEADER] = ui_theme_mix_channel(local_tokens.panel, local_tokens.background, 0.60f);
     table[NK_COLOR_BORDER] = local_tokens.border;
     table[NK_COLOR_BUTTON] = subtle_panel;
     table[NK_COLOR_BUTTON_HOVER] = local_tokens.panel_hover;
@@ -110,16 +111,16 @@ void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens)
     nk_style_default(ctx);
     nk_style_from_table(ctx, table);
 
-    ctx->style.window.background = local_tokens.background;
-    ctx->style.window.fixed_background = nk_style_item_color(local_tokens.background);
+    ctx->style.window.background = local_tokens.panel;
+    ctx->style.window.fixed_background = nk_style_item_color(local_tokens.panel);
     ctx->style.window.border_color = local_tokens.border;
     ctx->style.window.rounding = local_tokens.border_radius;
     ctx->style.window.border = 1.0f;
-    ctx->style.window.spacing = nk_vec2(local_tokens.gap * 0.5f, local_tokens.gap * 0.5f);
-    ctx->style.window.padding = nk_vec2(local_tokens.padding * 2.0f, local_tokens.padding * 1.5f);
-    ctx->style.window.group_padding = nk_vec2(local_tokens.padding * 2.0f, local_tokens.padding * 1.5f);
-    ctx->style.window.tooltip_padding = nk_vec2(local_tokens.padding * 2.0f, local_tokens.padding * 1.5f);
-    ctx->style.window.menu_padding = nk_vec2(local_tokens.padding * 1.5f, local_tokens.padding * 1.5f);
+    ctx->style.window.spacing = nk_vec2(local_tokens.padding * 0.8f, local_tokens.padding * 0.8f);
+    ctx->style.window.padding = nk_vec2(local_tokens.padding * 1.6f, local_tokens.padding * 1.3f);
+    ctx->style.window.group_padding = nk_vec2(local_tokens.padding * 1.6f, local_tokens.padding * 1.3f);
+    ctx->style.window.tooltip_padding = nk_vec2(local_tokens.padding * 1.8f, local_tokens.padding * 1.4f);
+    ctx->style.window.menu_padding = nk_vec2(local_tokens.padding * 1.3f, local_tokens.padding * 1.1f);
     ctx->style.window.tooltip_border = 1.0f;
     ctx->style.window.tooltip_border_color = local_tokens.border_hover;
 


### PR DESCRIPTION
## Summary
- make `WorkspaceLayout` the single source of truth for region bounds across the editor shell
- fix input routing around pointer release, scroll handling, and pointer-anchor resets at UI boundaries
- constrain canvas rendering to the content region and extract viewport state behind a clearer interface

## Testing
- Verify window resize keeps the canvas content bounds aligned with the UI layout
- Verify drag-release across UI boundaries does not send spurious tool release events
- Verify canvas zoom still works correctly when the tool owns pointer capture and the cursor is over UI
- Verify cursor moves between UI and canvas do not produce delta jumps
- Regression-check Select, Pan, Line, Rectangle, and Ellipse tools
