### PR TITLE
feat(ui): add extensible themes with runtime hot reload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,14 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         "$<TARGET_FILE_DIR:${PROJECT_NAME}>/shaders"
 )
 
+if(EXISTS "${CMAKE_SOURCE_DIR}/themes")
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_SOURCE_DIR}/themes"
+            "$<TARGET_FILE_DIR:${PROJECT_NAME}>/themes"
+    )
+endif()
+
 target_link_libraries(${PROJECT_NAME} PRIVATE
     glfw
     OpenGL::GL

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ GLDraw is now a canvas-oriented OpenGL drawing editor. The project has been rest
 - App Bar with menu and quick actions (New/Open/Save/Undo/Redo/Zoom)
 - Left Tool Rail for Select/Hand/Line/Rect/Ellipse
 - Responsive inspector behavior (auto-hide under constrained width) with lightweight show/hide transition
+- Theme framework with built-in `GLDraw Light`, `GLDraw Dark+`, and `GLDraw High Contrast`
+- External theme files loaded from `themes/*.json` (startup scan)
+- Runtime hot reload for `themes/` directory (auto-detect file changes)
+- Theme selection from the top menu, persisted in `gldraw.settings.json` via `workbench.colorTheme`
 - Grid and origin axes rendering
 - Modular C11 codebase with GLFW, GLAD, and Nuklear
 
@@ -63,6 +67,16 @@ cmake --build build --config Release
 - `Delete` / `Backspace`: Delete current selection
 - `Mouse Wheel`: Zoom at cursor
 - `Esc`: Clear tool state, or close window when already in select mode
+
+## Theme Configuration
+
+- Select themes from the `Theme` top menu.
+- Use `Theme -> Reload Themes` to force refresh theme files immediately.
+- Current choice is persisted in `gldraw.settings.json` using key `workbench.colorTheme`.
+- You can add custom themes by dropping JSON files into `themes/`.
+- Theme file edits are hot-reloaded while the app is running.
+- Status bar messages distinguish `auto` reloads and `manually` triggered reloads.
+- Theme file schema and examples are documented in [themes/README.md](./themes/README.md).
 
 ## Project Structure
 

--- a/include/ui/ui_theme.h
+++ b/include/ui/ui_theme.h
@@ -1,6 +1,8 @@
 #ifndef GLDRAW_UI_UI_THEME_H
 #define GLDRAW_UI_UI_THEME_H
 
+#include <stddef.h>
+
 #ifndef NK_NUKLEAR_H_
 typedef unsigned char nk_byte;
 typedef int nk_bool;
@@ -54,7 +56,21 @@ typedef struct UiThemeTokens {
     float transition_duration;
 } UiThemeTokens;
 
+typedef struct UiThemeDescriptor {
+    const char* id;
+    const char* label;
+} UiThemeDescriptor;
+
 UiThemeTokens ui_theme_default_tokens(void);
+UiThemeTokens ui_theme_tokens_for_id(const char* theme_id);
+int ui_theme_count(void);
+const UiThemeDescriptor* ui_theme_descriptor_at(int index);
+int ui_theme_index_of_id(const char* theme_id);
+const char* ui_theme_default_id(void);
+int ui_theme_reload_external(const char* directory_path);
+unsigned long long ui_theme_external_signature(const char* directory_path);
+int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_theme_id_size);
+int ui_theme_save_selected_id(const char* path, const char* theme_id);
 void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens);
 
 #endif /* GLDRAW_UI_UI_THEME_H */

--- a/src/ui/ui_menubar.c
+++ b/src/ui/ui_menubar.c
@@ -17,11 +17,13 @@
 
 #include "nuklear/nuklear.h"
 #include "nuklear/nuklear_glfw_gl3.h"
+#include <ui/ui_theme.h>
 
 #include <stdio.h>
 #include <stdlib.h>
 
 #define MENU_BAR_HEIGHT 30.0f
+#define MENU_PARENT_THEME 900
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
 typedef struct UiTopMenuDef {
@@ -35,6 +37,7 @@ static const UiTopMenuDef g_top_menus[] = {
     { "File", MENU_ID_FILE, {210.0f, 300.0f}, 58.0f },
     { "Edit", MENU_ID_EDIT, {210.0f, 300.0f}, 58.0f },
     { "View", MENU_ID_VIEW, {220.0f, 300.0f}, 62.0f },
+    { "Theme", MENU_PARENT_THEME, {260.0f, 280.0f}, 76.0f },
     { "Help", MENU_ID_HELP, {220.0f, 220.0f}, 62.0f },
 };
 
@@ -79,6 +82,9 @@ UiMenuBar* ui_menubar_create(void* ctx)
     menubar->ctx = (struct nk_context*)ctx;
     menubar->show_inspector = true;
     menubar->menu_height = MENU_BAR_HEIGHT;
+    menubar->active_theme_index = 0;
+    menubar->requested_theme_index = -1;
+    menubar->requested_theme_reload = 0;
 
     return menubar;
 }
@@ -105,6 +111,72 @@ void ui_menubar_set_height(UiMenuBar* menubar, float height)
     }
 
     menubar->menu_height = (height > 10.0f) ? height : MENU_BAR_HEIGHT;
+}
+
+void ui_menubar_set_themes(UiMenuBar* menubar, const UiThemeDescriptor* themes, int theme_count)
+{
+    if (!menubar) {
+        return;
+    }
+
+    menubar->themes = themes;
+    menubar->theme_count = (theme_count > 0) ? theme_count : 0;
+
+    if (menubar->theme_count == 0) {
+        menubar->active_theme_index = -1;
+    } else if (menubar->active_theme_index < 0 ||
+               menubar->active_theme_index >= menubar->theme_count) {
+        menubar->active_theme_index = 0;
+    }
+}
+
+void ui_menubar_set_active_theme_index(UiMenuBar* menubar, int theme_index)
+{
+    if (!menubar) {
+        return;
+    }
+
+    if (menubar->theme_count <= 0) {
+        menubar->active_theme_index = -1;
+        return;
+    }
+
+    if (theme_index < 0) {
+        menubar->active_theme_index = 0;
+        return;
+    }
+    if (theme_index >= menubar->theme_count) {
+        menubar->active_theme_index = menubar->theme_count - 1;
+        return;
+    }
+
+    menubar->active_theme_index = theme_index;
+}
+
+int ui_menubar_take_theme_request(UiMenuBar* menubar)
+{
+    int requested_theme_index = -1;
+
+    if (!menubar) {
+        return -1;
+    }
+
+    requested_theme_index = menubar->requested_theme_index;
+    menubar->requested_theme_index = -1;
+    return requested_theme_index;
+}
+
+int ui_menubar_take_theme_reload_request(UiMenuBar* menubar)
+{
+    int requested = 0;
+
+    if (!menubar) {
+        return 0;
+    }
+
+    requested = menubar->requested_theme_reload;
+    menubar->requested_theme_reload = 0;
+    return requested;
 }
 
 /**
@@ -159,17 +231,67 @@ static int ui_render_dropdown(struct nk_context* ctx, int parent_id)
     return clicked_id;
 }
 
-static int ui_render_top_menu(struct nk_context* ctx, const UiTopMenuDef* menu)
+static int ui_render_theme_dropdown(UiMenuBar* menubar)
 {
+    struct nk_context* ctx = NULL;
+
+    if (!menubar) {
+        return -1;
+    }
+
+    ctx = menubar->ctx;
+    if (!ctx) {
+        return -1;
+    }
+
+    if (!menubar->themes || menubar->theme_count <= 0) {
+        nk_label(ctx, "No themes available", NK_TEXT_LEFT);
+        return -1;
+    }
+
+    if (nk_menu_item_label(ctx, "Reload Themes", NK_TEXT_LEFT)) {
+        menubar->requested_theme_reload = 1;
+    }
+    nk_labelf(ctx, NK_TEXT_CENTERED, "----------------");
+
+    for (int i = 0; i < menubar->theme_count; ++i) {
+        const UiThemeDescriptor* theme = &menubar->themes[i];
+        char item_label[128];
+        const char* label = (theme->label && theme->label[0] != '\0') ? theme->label : "Unnamed Theme";
+        const char* marker = (i == menubar->active_theme_index) ? "[x]" : "[ ]";
+
+        snprintf(item_label, sizeof(item_label), "%s %s", marker, label);
+        if (nk_menu_item_label(ctx, item_label, NK_TEXT_LEFT)) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+static int ui_render_top_menu(UiMenuBar* menubar, const UiTopMenuDef* menu)
+{
+    struct nk_context* ctx = NULL;
     int clicked_id = -1;
 
-    if (!ctx || !menu || !menu->label) {
+    if (!menubar || !menu || !menu->label) {
+        return -1;
+    }
+    ctx = menubar->ctx;
+    if (!ctx) {
         return -1;
     }
 
     if (nk_menu_begin_label(ctx, menu->label, NK_TEXT_LEFT, menu->popup_size)) {
         nk_layout_row_dynamic(ctx, 25.0f, 1);
-        clicked_id = ui_render_dropdown(ctx, menu->parent_id);
+        if (menu->parent_id == MENU_PARENT_THEME) {
+            int theme_index = ui_render_theme_dropdown(menubar);
+            if (theme_index >= 0) {
+                menubar->requested_theme_index = theme_index;
+            }
+        } else {
+            clicked_id = ui_render_dropdown(ctx, menu->parent_id);
+        }
         nk_menu_end(ctx);
     }
 
@@ -243,7 +365,7 @@ void ui_menubar_build(UiMenuBar* menubar, Workspace* workspace, int window_width
         for (size_t i = 0; i < menu_count; i++) {
             int id;
             nk_layout_row_push(ctx, g_top_menus[i].item_width);
-            id = ui_render_top_menu(ctx, &g_top_menus[i]);
+            id = ui_render_top_menu(menubar, &g_top_menus[i]);
             if (id != -1) {
                 clicked_id = id;
             }

--- a/src/ui/ui_menubar.h
+++ b/src/ui/ui_menubar.h
@@ -6,6 +6,8 @@
 
 struct nk_context;
 struct Workspace;
+struct UiThemeDescriptor;
+typedef struct UiThemeDescriptor UiThemeDescriptor;
 
 /**
  * @file ui_menubar.h
@@ -22,6 +24,11 @@ typedef struct UiMenuBar {
     struct nk_context* ctx;
     bool show_inspector;        /**< Inspector panel visibility */
     float menu_height;          /**< Height of the menu bar */
+    const UiThemeDescriptor* themes;
+    int theme_count;
+    int active_theme_index;
+    int requested_theme_index;
+    int requested_theme_reload;
 } UiMenuBar;
 
 /**
@@ -65,5 +72,9 @@ float ui_menubar_height(const UiMenuBar* menubar);
  * @param height Height in pixels
  */
 void ui_menubar_set_height(UiMenuBar* menubar, float height);
+void ui_menubar_set_themes(UiMenuBar* menubar, const UiThemeDescriptor* themes, int theme_count);
+void ui_menubar_set_active_theme_index(UiMenuBar* menubar, int theme_index);
+int ui_menubar_take_theme_request(UiMenuBar* menubar);
+int ui_menubar_take_theme_reload_request(UiMenuBar* menubar);
 
 #endif /* GLDRAW_UI_UI_MENUBAR_H */

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -27,16 +27,27 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define UI_MAX_VERTEX_BUFFER (512 * 1024)
 #define UI_MAX_ELEMENT_BUFFER (128 * 1024)
 #define UI_MIN_CANVAS_WIDTH 320.0f
+#define UI_THEME_ID_CAPACITY 64
+#define UI_THEME_SETTINGS_PATH "gldraw.settings.json"
+#define UI_THEME_DIRECTORY_PATH "themes"
+#define UI_THEME_DESCRIPTOR_CACHE_MAX 64
+#define UI_THEME_WATCH_INTERVAL_SECONDS 0.35
 
 struct UiSystem {
     struct nk_glfw glfw;
     struct nk_context* ctx;
     UiMenuBar* menu_bar;
     UiThemeTokens theme;
+    char active_theme_id[UI_THEME_ID_CAPACITY];
+    char theme_settings_path[260];
+    UiThemeDescriptor theme_descriptors_cache[UI_THEME_DESCRIPTOR_CACHE_MAX];
+    unsigned long long theme_directory_signature;
+    double theme_watch_last_check_seconds;
     RectF appbar_bounds;
     RectF rail_bounds;
     RectF panel_bounds;
@@ -49,6 +60,12 @@ struct UiSystem {
     double last_frame_seconds;
 };
 
+typedef enum UiThemeReloadReason {
+    UI_THEME_RELOAD_REASON_STARTUP = 0,
+    UI_THEME_RELOAD_REASON_AUTO,
+    UI_THEME_RELOAD_REASON_MANUAL
+} UiThemeReloadReason;
+
 static float ui_clampf(float value, float min_value, float max_value)
 {
     if (value < min_value) {
@@ -58,6 +75,171 @@ static float ui_clampf(float value, float min_value, float max_value)
         return max_value;
     }
     return value;
+}
+
+static const char* ui_theme_reload_reason_label(UiThemeReloadReason reason)
+{
+    switch (reason) {
+    case UI_THEME_RELOAD_REASON_MANUAL:
+        return "manually";
+    case UI_THEME_RELOAD_REASON_AUTO:
+        return "auto";
+    case UI_THEME_RELOAD_REASON_STARTUP:
+    default:
+        return "startup";
+    }
+}
+
+static void ui_system_sync_menubar_themes(UiSystem* ui)
+{
+    int theme_count = 0;
+    int active_theme_index = 0;
+
+    if (!ui || !ui->menu_bar) {
+        return;
+    }
+
+    theme_count = ui_theme_count();
+    if (theme_count < 0) {
+        theme_count = 0;
+    }
+    if (theme_count > UI_THEME_DESCRIPTOR_CACHE_MAX) {
+        theme_count = UI_THEME_DESCRIPTOR_CACHE_MAX;
+    }
+
+    for (int i = 0; i < theme_count; ++i) {
+        const UiThemeDescriptor* descriptor = ui_theme_descriptor_at(i);
+        ui->theme_descriptors_cache[i].id = descriptor ? descriptor->id : "";
+        ui->theme_descriptors_cache[i].label = descriptor ? descriptor->label : "";
+    }
+
+    ui_menubar_set_themes(ui->menu_bar, ui->theme_descriptors_cache, theme_count);
+
+    active_theme_index = ui_theme_index_of_id(ui->active_theme_id);
+    if (active_theme_index < 0 || active_theme_index >= theme_count) {
+        active_theme_index = ui_theme_index_of_id(ui_theme_default_id());
+    }
+    if (active_theme_index < 0) {
+        active_theme_index = 0;
+    }
+    ui_menubar_set_active_theme_index(ui->menu_bar, active_theme_index);
+}
+
+static int ui_system_set_theme(UiSystem* ui, const char* theme_id, int persist_selection)
+{
+    int theme_index = -1;
+    const UiThemeDescriptor* descriptor = NULL;
+
+    if (!ui || !ui->ctx) {
+        return 0;
+    }
+
+    theme_index = ui_theme_index_of_id(theme_id);
+    if (theme_index < 0) {
+        theme_index = ui_theme_index_of_id(ui_theme_default_id());
+    }
+    descriptor = ui_theme_descriptor_at(theme_index);
+    if (!descriptor || !descriptor->id) {
+        return 0;
+    }
+
+    snprintf(ui->active_theme_id,
+             sizeof(ui->active_theme_id),
+             "%s",
+             descriptor->id);
+
+    ui->theme = ui_theme_tokens_for_id(ui->active_theme_id);
+    ui_theme_apply(ui->ctx, &ui->theme);
+
+    if (ui->menu_bar) {
+        ui_menubar_set_height(ui->menu_bar, ui->theme.menu_height);
+        ui_system_sync_menubar_themes(ui);
+    }
+
+    if (persist_selection) {
+        ui_theme_save_selected_id(ui->theme_settings_path, ui->active_theme_id);
+    }
+
+    return 1;
+}
+
+static void ui_system_reload_themes(UiSystem* ui,
+                                    Workspace* workspace,
+                                    int notify_status,
+                                    UiThemeReloadReason reason)
+{
+    char previous_theme_id[UI_THEME_ID_CAPACITY];
+    int custom_theme_count = 0;
+    int fallback_to_default = 0;
+
+    if (!ui) {
+        return;
+    }
+
+    snprintf(previous_theme_id, sizeof(previous_theme_id), "%s", ui->active_theme_id);
+    custom_theme_count = ui_theme_reload_external(UI_THEME_DIRECTORY_PATH);
+    ui->theme_directory_signature = ui_theme_external_signature(UI_THEME_DIRECTORY_PATH);
+
+    /* Keep current theme id if still present; otherwise fall back through ui_system_set_theme. */
+    ui_system_set_theme(ui, previous_theme_id, 0);
+    fallback_to_default = (strcmp(previous_theme_id, ui->active_theme_id) != 0);
+
+    if (notify_status && workspace) {
+        const char* reason_label = ui_theme_reload_reason_label(reason);
+        if (fallback_to_default) {
+            snprintf(workspace->status_message,
+                     sizeof(workspace->status_message),
+                     "Themes %s reloaded (%d custom), active theme missing -> fallback",
+                     reason_label,
+                     custom_theme_count);
+        } else {
+            snprintf(workspace->status_message,
+                     sizeof(workspace->status_message),
+                     "Themes %s reloaded (%d custom)",
+                     reason_label,
+                     custom_theme_count);
+        }
+    }
+}
+
+static void ui_system_load_theme_from_settings(UiSystem* ui)
+{
+    char loaded_theme_id[UI_THEME_ID_CAPACITY];
+
+    if (!ui) {
+        return;
+    }
+
+    if (ui_theme_load_selected_id(ui->theme_settings_path,
+                                  loaded_theme_id,
+                                  sizeof(loaded_theme_id))) {
+        if (ui_system_set_theme(ui, loaded_theme_id, 0)) {
+            return;
+        }
+    }
+
+    ui_system_set_theme(ui, ui_theme_default_id(), 0);
+}
+
+static void ui_system_poll_theme_hot_reload(UiSystem* ui, Workspace* workspace, double now_seconds)
+{
+    unsigned long long signature = 0ull;
+
+    if (!ui) {
+        return;
+    }
+
+    if ((now_seconds - ui->theme_watch_last_check_seconds) < UI_THEME_WATCH_INTERVAL_SECONDS) {
+        return;
+    }
+    ui->theme_watch_last_check_seconds = now_seconds;
+
+    signature = ui_theme_external_signature(UI_THEME_DIRECTORY_PATH);
+    if (signature == ui->theme_directory_signature) {
+        return;
+    }
+
+    ui_system_reload_themes(ui, workspace, 1, UI_THEME_RELOAD_REASON_AUTO);
 }
 
 static float ui_smoothstep(float t)
@@ -464,13 +646,19 @@ UiSystem* ui_system_create(PlatformWindow* window)
     nk_glfw3_font_stash_begin(&ui->glfw, &atlas);
     nk_glfw3_font_stash_end(&ui->glfw);
 
-    ui->theme = ui_theme_default_tokens();
-    ui_theme_apply(ui->ctx, &ui->theme);
+    snprintf(ui->theme_settings_path,
+             sizeof(ui->theme_settings_path),
+             "%s",
+             UI_THEME_SETTINGS_PATH);
+
+    ui_system_reload_themes(ui, NULL, 0, UI_THEME_RELOAD_REASON_STARTUP);
+    ui->theme_watch_last_check_seconds = glfwGetTime();
 
     ui->menu_bar = ui_menubar_create(ui->ctx);
     if (ui->menu_bar) {
-        ui_menubar_set_height(ui->menu_bar, ui->theme.menu_height);
+        ui_system_sync_menubar_themes(ui);
     }
+    ui_system_load_theme_from_settings(ui);
 
     ui->inspector_anim_t = 1.0f;
     ui->inspector_target_visible = 1;
@@ -532,10 +720,31 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
     dt_seconds = (float)(now_seconds - ui->last_frame_seconds);
     ui->last_frame_seconds = now_seconds;
     dt_seconds = ui_clampf(dt_seconds, 0.0f, 0.10f);
+    ui_system_poll_theme_hot_reload(ui, workspace, now_seconds);
 
     if (ui->menu_bar) {
+        int requested_theme_index = -1;
+        int requested_theme_reload = 0;
+        const UiThemeDescriptor* requested_theme = NULL;
+
         ui_menubar_set_height(ui->menu_bar, ui->theme.menu_height);
         ui_menubar_build(ui->menu_bar, workspace, width);
+
+        requested_theme_reload = ui_menubar_take_theme_reload_request(ui->menu_bar);
+        if (requested_theme_reload) {
+            ui_system_reload_themes(ui, workspace, 1, UI_THEME_RELOAD_REASON_MANUAL);
+        }
+
+        requested_theme_index = ui_menubar_take_theme_request(ui->menu_bar);
+        if (requested_theme_index >= 0) {
+            requested_theme = ui_theme_descriptor_at(requested_theme_index);
+            if (requested_theme && ui_system_set_theme(ui, requested_theme->id, 1)) {
+                snprintf(workspace->status_message,
+                         sizeof(workspace->status_message),
+                         "Theme: %s",
+                         requested_theme->label ? requested_theme->label : requested_theme->id);
+            }
+        }
     }
 
     ui->appbar_bounds.x = 0.0f;

--- a/src/ui/ui_theme.c
+++ b/src/ui/ui_theme.c
@@ -1,6 +1,55 @@
 #include <nuklear/nuklear.h>
 #include <ui/ui_theme.h>
 
+#include <ctype.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dirent.h>
+#include <sys/stat.h>
+#endif
+
+#define UI_THEME_CONFIG_KEY "workbench.colorTheme"
+#define UI_THEME_COMPAT_KEY "theme"
+#define UI_THEME_MAX_CUSTOM 32
+#define UI_THEME_MAX_ID_LEN 64
+#define UI_THEME_MAX_LABEL_LEN 96
+#define UI_THEME_MAX_PATH_LEN 512
+#define UI_THEME_HASH_OFFSET_BASIS 1469598103934665603ull
+#define UI_THEME_HASH_PRIME 1099511628211ull
+
+enum {
+    UI_THEME_LIGHT_INDEX = 0,
+    UI_THEME_DARK_PLUS_INDEX = 1,
+    UI_THEME_HIGH_CONTRAST_INDEX = 2
+};
+
+typedef struct UiCustomThemeEntry {
+    UiThemeDescriptor descriptor;
+    UiThemeTokens tokens;
+    char id[UI_THEME_MAX_ID_LEN];
+    char label[UI_THEME_MAX_LABEL_LEN];
+} UiCustomThemeEntry;
+
+static const UiThemeDescriptor g_builtin_theme_descriptors[] = {
+    {"gldraw-light", "GLDraw Light"},
+    {"gldraw-dark-plus", "GLDraw Dark+"},
+    {"gldraw-high-contrast", "GLDraw High Contrast"},
+};
+
+static UiCustomThemeEntry g_custom_theme_entries[UI_THEME_MAX_CUSTOM];
+static int g_custom_theme_count = 0;
+
+static UiThemeTokens ui_theme_light_tokens(void);
+static UiThemeTokens ui_theme_dark_plus_tokens(void);
+static UiThemeTokens ui_theme_high_contrast_tokens(void);
+static int ui_theme_builtin_count(void);
+
 static struct nk_color ui_theme_mix_channel(struct nk_color a, struct nk_color b, float t)
 {
     struct nk_color out;
@@ -19,7 +68,7 @@ static struct nk_color ui_theme_mix_channel(struct nk_color a, struct nk_color b
     return out;
 }
 
-UiThemeTokens ui_theme_default_tokens(void)
+static UiThemeTokens ui_theme_light_tokens(void)
 {
     UiThemeTokens tokens;
 
@@ -58,6 +107,1053 @@ UiThemeTokens ui_theme_default_tokens(void)
     tokens.enable_transitions = nk_true;
     tokens.transition_duration = 0.12f;
     return tokens;
+}
+
+static UiThemeTokens ui_theme_dark_plus_tokens(void)
+{
+    UiThemeTokens tokens;
+
+    tokens.primary = nk_rgba(86, 156, 214, 255);
+    tokens.primary_hover = nk_rgba(104, 173, 228, 255);
+    tokens.primary_active = nk_rgba(63, 138, 203, 255);
+
+    tokens.background = nk_rgba(25, 28, 34, 255);
+    tokens.panel = nk_rgba(37, 41, 49, 255);
+    tokens.panel_hover = nk_rgba(48, 54, 64, 255);
+    tokens.canvas_background = nk_rgba(20, 23, 30, 255);
+
+    tokens.text = nk_rgba(228, 233, 241, 255);
+    tokens.text_secondary = nk_rgba(164, 172, 186, 255);
+    tokens.text_disabled = nk_rgba(113, 121, 138, 255);
+
+    tokens.border = nk_rgba(72, 79, 92, 255);
+    tokens.border_hover = nk_rgba(103, 113, 130, 255);
+
+    tokens.success = nk_rgba(99, 186, 120, 255);
+    tokens.warning = nk_rgba(214, 167, 87, 255);
+    tokens.error = nk_rgba(218, 102, 102, 255);
+
+    tokens.row_height = 30.0f;
+    tokens.panel_width = 292.0f;
+    tokens.menu_height = 34.0f;
+    tokens.status_height = 32.0f;
+    tokens.tool_rail_width = 96.0f;
+
+    tokens.padding = 5.0f;
+    tokens.margin = 0.0f;
+    tokens.gap = 0.0f;
+
+    tokens.border_radius = 2.0f;
+
+    tokens.enable_transitions = nk_true;
+    tokens.transition_duration = 0.12f;
+    return tokens;
+}
+
+static UiThemeTokens ui_theme_high_contrast_tokens(void)
+{
+    UiThemeTokens tokens;
+
+    tokens.primary = nk_rgba(0, 157, 255, 255);
+    tokens.primary_hover = nk_rgba(79, 193, 255, 255);
+    tokens.primary_active = nk_rgba(0, 121, 204, 255);
+
+    tokens.background = nk_rgba(12, 12, 12, 255);
+    tokens.panel = nk_rgba(0, 0, 0, 255);
+    tokens.panel_hover = nk_rgba(24, 24, 24, 255);
+    tokens.canvas_background = nk_rgba(8, 8, 8, 255);
+
+    tokens.text = nk_rgba(255, 255, 255, 255);
+    tokens.text_secondary = nk_rgba(222, 222, 222, 255);
+    tokens.text_disabled = nk_rgba(148, 148, 148, 255);
+
+    tokens.border = nk_rgba(255, 255, 255, 210);
+    tokens.border_hover = nk_rgba(255, 255, 255, 255);
+
+    tokens.success = nk_rgba(0, 255, 136, 255);
+    tokens.warning = nk_rgba(255, 204, 0, 255);
+    tokens.error = nk_rgba(255, 95, 95, 255);
+
+    tokens.row_height = 30.0f;
+    tokens.panel_width = 292.0f;
+    tokens.menu_height = 34.0f;
+    tokens.status_height = 32.0f;
+    tokens.tool_rail_width = 96.0f;
+
+    tokens.padding = 5.0f;
+    tokens.margin = 0.0f;
+    tokens.gap = 0.0f;
+
+    tokens.border_radius = 0.0f;
+
+    tokens.enable_transitions = nk_true;
+    tokens.transition_duration = 0.12f;
+    return tokens;
+}
+
+UiThemeTokens ui_theme_default_tokens(void)
+{
+    return ui_theme_light_tokens();
+}
+
+static int ui_theme_builtin_count(void)
+{
+    return (int)(sizeof(g_builtin_theme_descriptors) / sizeof(g_builtin_theme_descriptors[0]));
+}
+
+static const UiThemeDescriptor* ui_theme_builtin_descriptor_at(int index)
+{
+    if (index < 0 || index >= ui_theme_builtin_count()) {
+        return NULL;
+    }
+    return &g_builtin_theme_descriptors[index];
+}
+
+static UiThemeTokens ui_theme_builtin_tokens_at(int index)
+{
+    switch (index) {
+    case UI_THEME_DARK_PLUS_INDEX:
+        return ui_theme_dark_plus_tokens();
+    case UI_THEME_HIGH_CONTRAST_INDEX:
+        return ui_theme_high_contrast_tokens();
+    case UI_THEME_LIGHT_INDEX:
+    default:
+        return ui_theme_light_tokens();
+    }
+}
+
+static int ui_theme_custom_index_of_id(const char* theme_id)
+{
+    if (!theme_id || theme_id[0] == '\0') {
+        return -1;
+    }
+
+    for (int i = 0; i < g_custom_theme_count; ++i) {
+        if (strcmp(theme_id, g_custom_theme_entries[i].descriptor.id) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int ui_theme_count(void)
+{
+    return ui_theme_builtin_count() + g_custom_theme_count;
+}
+
+const UiThemeDescriptor* ui_theme_descriptor_at(int index)
+{
+    int builtin_count = ui_theme_builtin_count();
+    int custom_index = index - builtin_count;
+
+    if (index < 0 || index >= ui_theme_count()) {
+        return NULL;
+    }
+    if (index < builtin_count) {
+        return ui_theme_builtin_descriptor_at(index);
+    }
+    return &g_custom_theme_entries[custom_index].descriptor;
+}
+
+int ui_theme_index_of_id(const char* theme_id)
+{
+    int builtin_count = ui_theme_builtin_count();
+    int custom_index = -1;
+
+    if (!theme_id || theme_id[0] == '\0') {
+        return UI_THEME_LIGHT_INDEX;
+    }
+
+    for (int i = 0; i < builtin_count; ++i) {
+        if (strcmp(theme_id, g_builtin_theme_descriptors[i].id) == 0) {
+            return i;
+        }
+    }
+
+    custom_index = ui_theme_custom_index_of_id(theme_id);
+    if (custom_index >= 0) {
+        return builtin_count + custom_index;
+    }
+
+    return -1;
+}
+
+const char* ui_theme_default_id(void)
+{
+    return g_builtin_theme_descriptors[UI_THEME_LIGHT_INDEX].id;
+}
+
+UiThemeTokens ui_theme_tokens_for_id(const char* theme_id)
+{
+    int theme_index = ui_theme_index_of_id(theme_id);
+    int builtin_count = ui_theme_builtin_count();
+
+    if (theme_index < 0) {
+        return ui_theme_default_tokens();
+    }
+    if (theme_index < builtin_count) {
+        return ui_theme_builtin_tokens_at(theme_index);
+    }
+    return g_custom_theme_entries[theme_index - builtin_count].tokens;
+}
+
+static char* ui_read_text_file(const char* path)
+{
+    FILE* file = NULL;
+    char* buffer = NULL;
+    long size = 0;
+    size_t read_size = 0;
+
+    if (!path || path[0] == '\0') {
+        return NULL;
+    }
+
+    file = fopen(path, "rb");
+    if (!file) {
+        return NULL;
+    }
+
+    if (fseek(file, 0, SEEK_END) != 0) {
+        fclose(file);
+        return NULL;
+    }
+    size = ftell(file);
+    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        return NULL;
+    }
+
+    buffer = (char*)malloc((size_t)size + 1u);
+    if (!buffer) {
+        fclose(file);
+        return NULL;
+    }
+
+    read_size = fread(buffer, 1u, (size_t)size, file);
+    if (read_size != (size_t)size && ferror(file)) {
+        free(buffer);
+        fclose(file);
+        return NULL;
+    }
+    buffer[read_size] = '\0';
+    fclose(file);
+    return buffer;
+}
+
+static int ui_extract_json_string_value(const char* text,
+                                        const char* key,
+                                        char* out_value,
+                                        size_t out_value_size)
+{
+    char key_pattern[96];
+    const char* cursor = NULL;
+    int key_pattern_length = 0;
+    size_t out_length = 0u;
+
+    if (!text || !key || !out_value || out_value_size == 0u) {
+        return 0;
+    }
+
+    key_pattern_length = snprintf(key_pattern, sizeof(key_pattern), "\"%s\"", key);
+    if (key_pattern_length <= 0 || (size_t)key_pattern_length >= sizeof(key_pattern)) {
+        return 0;
+    }
+
+    cursor = strstr(text, key_pattern);
+    if (!cursor) {
+        return 0;
+    }
+
+    cursor += (size_t)key_pattern_length;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+    if (*cursor != ':') {
+        return 0;
+    }
+
+    cursor++;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+    if (*cursor != '"') {
+        return 0;
+    }
+
+    cursor++;
+    while (*cursor != '\0') {
+        if (*cursor == '"') {
+            out_value[out_length] = '\0';
+            return 1;
+        }
+
+        if (*cursor == '\\') {
+            cursor++;
+            if (*cursor == '\0') {
+                return 0;
+            }
+        }
+
+        if (out_length + 1u >= out_value_size) {
+            return 0;
+        }
+
+        out_value[out_length++] = *cursor;
+        cursor++;
+    }
+
+    return 0;
+}
+
+static int ui_extract_json_number_value(const char* text, const char* key, float* out_value)
+{
+    char key_pattern[96];
+    const char* cursor = NULL;
+    char* number_end = NULL;
+    int key_pattern_length = 0;
+    double number_value = 0.0;
+
+    if (!text || !key || !out_value) {
+        return 0;
+    }
+
+    key_pattern_length = snprintf(key_pattern, sizeof(key_pattern), "\"%s\"", key);
+    if (key_pattern_length <= 0 || (size_t)key_pattern_length >= sizeof(key_pattern)) {
+        return 0;
+    }
+
+    cursor = strstr(text, key_pattern);
+    if (!cursor) {
+        return 0;
+    }
+
+    cursor += (size_t)key_pattern_length;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+    if (*cursor != ':') {
+        return 0;
+    }
+
+    cursor++;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+
+    number_value = strtod(cursor, &number_end);
+    if (number_end == cursor) {
+        return 0;
+    }
+
+    *out_value = (float)number_value;
+    return 1;
+}
+
+static int ui_extract_json_bool_value(const char* text, const char* key, int* out_value)
+{
+    char key_pattern[96];
+    const char* cursor = NULL;
+    int key_pattern_length = 0;
+
+    if (!text || !key || !out_value) {
+        return 0;
+    }
+
+    key_pattern_length = snprintf(key_pattern, sizeof(key_pattern), "\"%s\"", key);
+    if (key_pattern_length <= 0 || (size_t)key_pattern_length >= sizeof(key_pattern)) {
+        return 0;
+    }
+
+    cursor = strstr(text, key_pattern);
+    if (!cursor) {
+        return 0;
+    }
+
+    cursor += (size_t)key_pattern_length;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+    if (*cursor != ':') {
+        return 0;
+    }
+
+    cursor++;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+
+    if (strncmp(cursor, "true", 4) == 0) {
+        *out_value = 1;
+        return 1;
+    }
+    if (strncmp(cursor, "false", 5) == 0) {
+        *out_value = 0;
+        return 1;
+    }
+    return 0;
+}
+
+static int ui_hex_digit_value(char c)
+{
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+    if (c >= 'a' && c <= 'f') {
+        return 10 + (c - 'a');
+    }
+    if (c >= 'A' && c <= 'F') {
+        return 10 + (c - 'A');
+    }
+    return -1;
+}
+
+static int ui_parse_hex_byte(const char* text, unsigned char* out_value)
+{
+    int hi = 0;
+    int lo = 0;
+
+    if (!text || !out_value) {
+        return 0;
+    }
+
+    hi = ui_hex_digit_value(text[0]);
+    lo = ui_hex_digit_value(text[1]);
+    if (hi < 0 || lo < 0) {
+        return 0;
+    }
+
+    *out_value = (unsigned char)((hi << 4) | lo);
+    return 1;
+}
+
+static int ui_parse_hex_color(const char* hex_text, struct nk_color* out_color)
+{
+    size_t length = 0u;
+    unsigned char r = 0u;
+    unsigned char g = 0u;
+    unsigned char b = 0u;
+    unsigned char a = 255u;
+
+    if (!hex_text || !out_color || hex_text[0] != '#') {
+        return 0;
+    }
+
+    length = strlen(hex_text);
+    if (length != 7u && length != 9u) {
+        return 0;
+    }
+
+    if (!ui_parse_hex_byte(hex_text + 1, &r) ||
+        !ui_parse_hex_byte(hex_text + 3, &g) ||
+        !ui_parse_hex_byte(hex_text + 5, &b)) {
+        return 0;
+    }
+    if (length == 9u && !ui_parse_hex_byte(hex_text + 7, &a)) {
+        return 0;
+    }
+
+    out_color->r = (nk_byte)r;
+    out_color->g = (nk_byte)g;
+    out_color->b = (nk_byte)b;
+    out_color->a = (nk_byte)a;
+    return 1;
+}
+
+static int ui_theme_path_has_json_extension(const char* path)
+{
+    size_t length = 0u;
+    const char* ext = NULL;
+
+    if (!path) {
+        return 0;
+    }
+
+    length = strlen(path);
+    if (length < 5u) {
+        return 0;
+    }
+
+    ext = path + length - 5u;
+    return (tolower((unsigned char)ext[0]) == '.') &&
+           (tolower((unsigned char)ext[1]) == 'j') &&
+           (tolower((unsigned char)ext[2]) == 's') &&
+           (tolower((unsigned char)ext[3]) == 'o') &&
+           (tolower((unsigned char)ext[4]) == 'n');
+}
+
+static unsigned long long ui_theme_hash_bytes(unsigned long long seed, const void* data, size_t size)
+{
+    const unsigned char* bytes = (const unsigned char*)data;
+    unsigned long long hash = seed;
+
+    if (!bytes) {
+        return hash;
+    }
+
+    for (size_t i = 0u; i < size; ++i) {
+        hash ^= (unsigned long long)bytes[i];
+        hash *= UI_THEME_HASH_PRIME;
+    }
+    return hash;
+}
+
+static unsigned long long ui_theme_hash_cstring(unsigned long long seed, const char* text)
+{
+    if (!text) {
+        return seed;
+    }
+    return ui_theme_hash_bytes(seed, text, strlen(text));
+}
+
+static unsigned long long ui_theme_hash_u64(unsigned long long seed, unsigned long long value)
+{
+    return ui_theme_hash_bytes(seed, &value, sizeof(value));
+}
+
+static int ui_theme_id_is_safe_for_json(const char* theme_id)
+{
+    const unsigned char* cursor = (const unsigned char*)theme_id;
+
+    if (!theme_id || theme_id[0] == '\0') {
+        return 0;
+    }
+
+    while (*cursor != '\0') {
+        if (!(isalnum(*cursor) || *cursor == '-' || *cursor == '_' || *cursor == '.')) {
+            return 0;
+        }
+        cursor++;
+    }
+
+    return 1;
+}
+
+static const char* ui_theme_filename_from_path(const char* path)
+{
+    const char* last_slash = NULL;
+    const char* last_backslash = NULL;
+
+    if (!path) {
+        return NULL;
+    }
+
+    last_slash = strrchr(path, '/');
+    last_backslash = strrchr(path, '\\');
+    if (!last_slash && !last_backslash) {
+        return path;
+    }
+    if (!last_slash) {
+        return last_backslash + 1;
+    }
+    if (!last_backslash) {
+        return last_slash + 1;
+    }
+    return (last_slash > last_backslash) ? (last_slash + 1) : (last_backslash + 1);
+}
+
+static int ui_theme_id_from_path(const char* path, char* out_id, size_t out_id_size)
+{
+    const char* filename = NULL;
+    size_t length = 0u;
+    size_t write_length = 0u;
+
+    if (!path || !out_id || out_id_size == 0u) {
+        return 0;
+    }
+
+    filename = ui_theme_filename_from_path(path);
+    if (!filename || filename[0] == '\0') {
+        return 0;
+    }
+
+    length = strlen(filename);
+    if (length > 5u && ui_theme_path_has_json_extension(filename)) {
+        length -= 5u;
+    }
+    if (length == 0u) {
+        return 0;
+    }
+
+    write_length = (length < (out_id_size - 1u)) ? length : (out_id_size - 1u);
+    memcpy(out_id, filename, write_length);
+    out_id[write_length] = '\0';
+    return write_length > 0u;
+}
+
+static void ui_theme_apply_color_overrides(const char* text, UiThemeTokens* tokens)
+{
+    typedef struct UiThemeColorField {
+        const char* key;
+        size_t offset;
+    } UiThemeColorField;
+
+    static const UiThemeColorField fields[] = {
+        {"primary", offsetof(UiThemeTokens, primary)},
+        {"primary_hover", offsetof(UiThemeTokens, primary_hover)},
+        {"primary_active", offsetof(UiThemeTokens, primary_active)},
+        {"background", offsetof(UiThemeTokens, background)},
+        {"panel", offsetof(UiThemeTokens, panel)},
+        {"panel_hover", offsetof(UiThemeTokens, panel_hover)},
+        {"canvas_background", offsetof(UiThemeTokens, canvas_background)},
+        {"text", offsetof(UiThemeTokens, text)},
+        {"text_secondary", offsetof(UiThemeTokens, text_secondary)},
+        {"text_disabled", offsetof(UiThemeTokens, text_disabled)},
+        {"border", offsetof(UiThemeTokens, border)},
+        {"border_hover", offsetof(UiThemeTokens, border_hover)},
+        {"success", offsetof(UiThemeTokens, success)},
+        {"warning", offsetof(UiThemeTokens, warning)},
+        {"error", offsetof(UiThemeTokens, error)},
+    };
+
+    if (!text || !tokens) {
+        return;
+    }
+
+    for (size_t i = 0; i < (sizeof(fields) / sizeof(fields[0])); ++i) {
+        char color_text[16];
+        struct nk_color parsed;
+
+        if (!ui_extract_json_string_value(text, fields[i].key, color_text, sizeof(color_text))) {
+            continue;
+        }
+        if (!ui_parse_hex_color(color_text, &parsed)) {
+            continue;
+        }
+
+        *(struct nk_color*)((char*)tokens + fields[i].offset) = parsed;
+    }
+}
+
+static void ui_theme_apply_float_overrides(const char* text, UiThemeTokens* tokens)
+{
+    typedef struct UiThemeFloatField {
+        const char* key;
+        size_t offset;
+    } UiThemeFloatField;
+
+    static const UiThemeFloatField fields[] = {
+        {"row_height", offsetof(UiThemeTokens, row_height)},
+        {"panel_width", offsetof(UiThemeTokens, panel_width)},
+        {"menu_height", offsetof(UiThemeTokens, menu_height)},
+        {"status_height", offsetof(UiThemeTokens, status_height)},
+        {"tool_rail_width", offsetof(UiThemeTokens, tool_rail_width)},
+        {"padding", offsetof(UiThemeTokens, padding)},
+        {"margin", offsetof(UiThemeTokens, margin)},
+        {"gap", offsetof(UiThemeTokens, gap)},
+        {"border_radius", offsetof(UiThemeTokens, border_radius)},
+        {"transition_duration", offsetof(UiThemeTokens, transition_duration)},
+    };
+
+    if (!text || !tokens) {
+        return;
+    }
+
+    for (size_t i = 0; i < (sizeof(fields) / sizeof(fields[0])); ++i) {
+        float value = 0.0f;
+        if (!ui_extract_json_number_value(text, fields[i].key, &value)) {
+            continue;
+        }
+        *(float*)((char*)tokens + fields[i].offset) = value;
+    }
+}
+
+static void ui_theme_apply_bool_overrides(const char* text, UiThemeTokens* tokens)
+{
+    int bool_value = 0;
+
+    if (!text || !tokens) {
+        return;
+    }
+
+    if (ui_extract_json_bool_value(text, "enable_transitions", &bool_value)) {
+        tokens->enable_transitions = bool_value ? nk_true : nk_false;
+    }
+}
+
+static int ui_theme_store_custom_entry(const char* theme_id,
+                                       const char* label,
+                                       const UiThemeTokens* tokens)
+{
+    int existing_index = -1;
+    int target_index = -1;
+
+    if (!theme_id || !tokens) {
+        return 0;
+    }
+    if (!ui_theme_id_is_safe_for_json(theme_id)) {
+        return 0;
+    }
+    if (ui_theme_index_of_id(theme_id) >= 0 && ui_theme_custom_index_of_id(theme_id) < 0) {
+        /* Built-in IDs are reserved and cannot be overridden by file themes. */
+        return 0;
+    }
+
+    existing_index = ui_theme_custom_index_of_id(theme_id);
+    if (existing_index >= 0) {
+        target_index = existing_index;
+    } else {
+        if (g_custom_theme_count >= UI_THEME_MAX_CUSTOM) {
+            return 0;
+        }
+        target_index = g_custom_theme_count++;
+    }
+
+    snprintf(g_custom_theme_entries[target_index].id,
+             sizeof(g_custom_theme_entries[target_index].id),
+             "%s",
+             theme_id);
+    snprintf(g_custom_theme_entries[target_index].label,
+             sizeof(g_custom_theme_entries[target_index].label),
+             "%s",
+             (label && label[0] != '\0') ? label : theme_id);
+
+    g_custom_theme_entries[target_index].descriptor.id = g_custom_theme_entries[target_index].id;
+    g_custom_theme_entries[target_index].descriptor.label = g_custom_theme_entries[target_index].label;
+    g_custom_theme_entries[target_index].tokens = *tokens;
+    return 1;
+}
+
+static int ui_theme_load_external_file(const char* path)
+{
+    char* text = NULL;
+    char theme_id[UI_THEME_MAX_ID_LEN];
+    char theme_label[UI_THEME_MAX_LABEL_LEN];
+    char base_theme_id[UI_THEME_MAX_ID_LEN];
+    UiThemeTokens tokens;
+    int base_index = -1;
+    int loaded = 0;
+
+    if (!path) {
+        return 0;
+    }
+
+    text = ui_read_text_file(path);
+    if (!text) {
+        return 0;
+    }
+
+    theme_id[0] = '\0';
+    theme_label[0] = '\0';
+    base_theme_id[0] = '\0';
+
+    if (!ui_extract_json_string_value(text, "id", theme_id, sizeof(theme_id))) {
+        ui_theme_id_from_path(path, theme_id, sizeof(theme_id));
+    }
+    if (!ui_theme_id_is_safe_for_json(theme_id)) {
+        free(text);
+        return 0;
+    }
+
+    ui_extract_json_string_value(text, "label", theme_label, sizeof(theme_label));
+    if (!ui_extract_json_string_value(text, "base_theme", base_theme_id, sizeof(base_theme_id))) {
+        if (!ui_extract_json_string_value(text, "base", base_theme_id, sizeof(base_theme_id))) {
+            ui_extract_json_string_value(text, "extends", base_theme_id, sizeof(base_theme_id));
+        }
+    }
+
+    base_index = ui_theme_index_of_id(base_theme_id);
+    if (base_index >= 0) {
+        const UiThemeDescriptor* base_descriptor = ui_theme_descriptor_at(base_index);
+        tokens = ui_theme_tokens_for_id(base_descriptor ? base_descriptor->id : ui_theme_default_id());
+    } else {
+        tokens = ui_theme_default_tokens();
+    }
+
+    ui_theme_apply_color_overrides(text, &tokens);
+    ui_theme_apply_float_overrides(text, &tokens);
+    ui_theme_apply_bool_overrides(text, &tokens);
+    loaded = ui_theme_store_custom_entry(theme_id, theme_label, &tokens);
+
+    free(text);
+    return loaded;
+}
+
+int ui_theme_reload_external(const char* directory_path)
+{
+    int loaded_count = 0;
+
+    g_custom_theme_count = 0;
+    memset(g_custom_theme_entries, 0, sizeof(g_custom_theme_entries));
+
+    if (!directory_path || directory_path[0] == '\0') {
+        return 0;
+    }
+
+#ifdef _WIN32
+    {
+        WIN32_FIND_DATAA find_data;
+        HANDLE find_handle = INVALID_HANDLE_VALUE;
+        char search_pattern[UI_THEME_MAX_PATH_LEN];
+
+        snprintf(search_pattern, sizeof(search_pattern), "%s\\*.json", directory_path);
+        find_handle = FindFirstFileA(search_pattern, &find_data);
+        if (find_handle == INVALID_HANDLE_VALUE) {
+            return 0;
+        }
+
+        do {
+            char file_path[UI_THEME_MAX_PATH_LEN];
+            if ((find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+                continue;
+            }
+
+            snprintf(file_path, sizeof(file_path), "%s\\%s", directory_path, find_data.cFileName);
+            loaded_count += ui_theme_load_external_file(file_path);
+        } while (FindNextFileA(find_handle, &find_data));
+
+        FindClose(find_handle);
+    }
+#else
+    {
+        DIR* directory = NULL;
+        struct dirent* entry = NULL;
+
+        directory = opendir(directory_path);
+        if (!directory) {
+            return 0;
+        }
+
+        while ((entry = readdir(directory)) != NULL) {
+            char file_path[UI_THEME_MAX_PATH_LEN];
+
+            if (entry->d_name[0] == '.') {
+                continue;
+            }
+            if (!ui_theme_path_has_json_extension(entry->d_name)) {
+                continue;
+            }
+
+            snprintf(file_path, sizeof(file_path), "%s/%s", directory_path, entry->d_name);
+            loaded_count += ui_theme_load_external_file(file_path);
+        }
+
+        closedir(directory);
+    }
+#endif
+
+    return loaded_count;
+}
+
+unsigned long long ui_theme_external_signature(const char* directory_path)
+{
+    unsigned long long aggregate_hash = UI_THEME_HASH_OFFSET_BASIS;
+    unsigned long long file_count = 0ull;
+
+    if (!directory_path || directory_path[0] == '\0') {
+        return aggregate_hash;
+    }
+
+#ifdef _WIN32
+    {
+        WIN32_FIND_DATAA find_data;
+        HANDLE find_handle = INVALID_HANDLE_VALUE;
+        char search_pattern[UI_THEME_MAX_PATH_LEN];
+
+        snprintf(search_pattern, sizeof(search_pattern), "%s\\*.json", directory_path);
+        find_handle = FindFirstFileA(search_pattern, &find_data);
+        if (find_handle == INVALID_HANDLE_VALUE) {
+            return aggregate_hash;
+        }
+
+        do {
+            unsigned long long file_hash = UI_THEME_HASH_OFFSET_BASIS;
+            unsigned long long file_size = 0ull;
+            unsigned long long file_time = 0ull;
+
+            if ((find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+                continue;
+            }
+
+            file_size = ((unsigned long long)find_data.nFileSizeHigh << 32) |
+                        (unsigned long long)find_data.nFileSizeLow;
+            file_time = ((unsigned long long)find_data.ftLastWriteTime.dwHighDateTime << 32) |
+                        (unsigned long long)find_data.ftLastWriteTime.dwLowDateTime;
+
+            file_hash = ui_theme_hash_cstring(file_hash, find_data.cFileName);
+            file_hash = ui_theme_hash_u64(file_hash, file_size);
+            file_hash = ui_theme_hash_u64(file_hash, file_time);
+
+            aggregate_hash ^= file_hash;
+            file_count++;
+        } while (FindNextFileA(find_handle, &find_data));
+
+        FindClose(find_handle);
+    }
+#else
+    {
+        DIR* directory = NULL;
+        struct dirent* entry = NULL;
+
+        directory = opendir(directory_path);
+        if (!directory) {
+            return aggregate_hash;
+        }
+
+        while ((entry = readdir(directory)) != NULL) {
+            char file_path[UI_THEME_MAX_PATH_LEN];
+            struct stat info;
+            unsigned long long file_hash = UI_THEME_HASH_OFFSET_BASIS;
+            unsigned long long file_size = 0ull;
+            unsigned long long file_time = 0ull;
+
+            if (entry->d_name[0] == '.') {
+                continue;
+            }
+            if (!ui_theme_path_has_json_extension(entry->d_name)) {
+                continue;
+            }
+
+            snprintf(file_path, sizeof(file_path), "%s/%s", directory_path, entry->d_name);
+            if (stat(file_path, &info) != 0) {
+                continue;
+            }
+
+            file_size = (unsigned long long)info.st_size;
+            file_time = (unsigned long long)info.st_mtime;
+
+            file_hash = ui_theme_hash_cstring(file_hash, entry->d_name);
+            file_hash = ui_theme_hash_u64(file_hash, file_size);
+            file_hash = ui_theme_hash_u64(file_hash, file_time);
+
+            aggregate_hash ^= file_hash;
+            file_count++;
+        }
+
+        closedir(directory);
+    }
+#endif
+
+    aggregate_hash = ui_theme_hash_u64(aggregate_hash, file_count);
+    return aggregate_hash;
+}
+
+int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_theme_id_size)
+{
+    char* text = NULL;
+    int loaded = 0;
+
+    if (!path || !out_theme_id || out_theme_id_size == 0u) {
+        return 0;
+    }
+
+    out_theme_id[0] = '\0';
+    text = ui_read_text_file(path);
+    if (!text) {
+        return 0;
+    }
+
+    loaded = ui_extract_json_string_value(text,
+                                          UI_THEME_CONFIG_KEY,
+                                          out_theme_id,
+                                          out_theme_id_size);
+    if (!loaded) {
+        loaded = ui_extract_json_string_value(text,
+                                              UI_THEME_COMPAT_KEY,
+                                              out_theme_id,
+                                              out_theme_id_size);
+    }
+
+    free(text);
+    return loaded && out_theme_id[0] != '\0';
+}
+
+static char* ui_duplicate_path_with_suffix(const char* path, const char* suffix)
+{
+    size_t path_length = 0u;
+    size_t suffix_length = 0u;
+    char* result = NULL;
+
+    if (!path || !suffix) {
+        return NULL;
+    }
+
+    path_length = strlen(path);
+    suffix_length = strlen(suffix);
+    result = (char*)malloc(path_length + suffix_length + 1u);
+    if (!result) {
+        return NULL;
+    }
+
+    memcpy(result, path, path_length);
+    memcpy(result + path_length, suffix, suffix_length);
+    result[path_length + suffix_length] = '\0';
+    return result;
+}
+
+static int ui_replace_file_with_temp(const char* temp_path, const char* target_path)
+{
+    if (!temp_path || !target_path) {
+        return 0;
+    }
+
+#ifdef _WIN32
+    if (MoveFileExA(temp_path,
+                    target_path,
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        return 1;
+    }
+    remove(temp_path);
+    return 0;
+#else
+    if (rename(temp_path, target_path) == 0) {
+        return 1;
+    }
+    remove(temp_path);
+    return 0;
+#endif
+}
+
+int ui_theme_save_selected_id(const char* path, const char* theme_id)
+{
+    FILE* file = NULL;
+    char* temp_path = NULL;
+    int close_result = 0;
+
+    if (!path || !theme_id) {
+        return 0;
+    }
+    if (ui_theme_index_of_id(theme_id) < 0) {
+        return 0;
+    }
+    if (!ui_theme_id_is_safe_for_json(theme_id)) {
+        return 0;
+    }
+
+    temp_path = ui_duplicate_path_with_suffix(path, ".tmp");
+    if (!temp_path) {
+        return 0;
+    }
+
+    file = fopen(temp_path, "wb");
+    if (!file) {
+        free(temp_path);
+        return 0;
+    }
+
+    fprintf(file, "{\n");
+    fprintf(file, "  \"%s\": \"%s\"\n", UI_THEME_CONFIG_KEY, theme_id);
+    fprintf(file, "}\n");
+    if (ferror(file)) {
+        fclose(file);
+        remove(temp_path);
+        free(temp_path);
+        return 0;
+    }
+
+    close_result = fclose(file);
+    if (close_result != 0) {
+        remove(temp_path);
+        free(temp_path);
+        return 0;
+    }
+
+    if (!ui_replace_file_with_temp(temp_path, path)) {
+        free(temp_path);
+        return 0;
+    }
+
+    free(temp_path);
+    return 1;
 }
 
 void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens)

--- a/themes/README.md
+++ b/themes/README.md
@@ -1,0 +1,51 @@
+Theme Files (`themes/*.json`)
+======================================
+
+GLDraw loads custom themes from the `themes/` directory at startup.
+Each file with `.json` extension is parsed as one theme entry.
+Theme files are also hot-reloaded while GLDraw is running.
+You can force a refresh from `Theme -> Reload Themes`.
+
+Required fields:
+
+- `id` (string): unique identifier, allowed chars `[A-Za-z0-9._-]`
+
+Optional fields:
+
+- `label` (string): display name in the `Theme` menu
+- `base_theme` (string): parent theme id (for example `gldraw-dark-plus`)
+- `base` or `extends` can be used as aliases for `base_theme`
+- `base_theme` should point to a built-in theme for predictable load order
+
+Color fields (`#RRGGBB` or `#RRGGBBAA`):
+
+- `primary`, `primary_hover`, `primary_active`
+- `background`, `panel`, `panel_hover`, `canvas_background`
+- `text`, `text_secondary`, `text_disabled`
+- `border`, `border_hover`
+- `success`, `warning`, `error`
+
+Float fields:
+
+- `row_height`, `panel_width`, `menu_height`, `status_height`, `tool_rail_width`
+- `padding`, `margin`, `gap`
+- `border_radius`
+- `transition_duration`
+
+Boolean fields:
+
+- `enable_transitions`
+
+Example:
+
+```json
+{
+  "id": "my-team-theme",
+  "label": "My Team Theme",
+  "base_theme": "gldraw-dark-plus",
+  "primary": "#57A7FF",
+  "panel": "#18212B",
+  "canvas_background": "#0E141B",
+  "enable_transitions": true
+}
+```

--- a/themes/oceanic.json
+++ b/themes/oceanic.json
@@ -1,0 +1,30 @@
+{
+  "id": "oceanic-night",
+  "label": "Oceanic Night",
+  "base_theme": "gldraw-dark-plus",
+
+  "primary": "#4FC3F7",
+  "primary_hover": "#81D4FA",
+  "primary_active": "#29B6F6",
+
+  "background": "#101820",
+  "panel": "#16222D",
+  "panel_hover": "#1D2C39",
+  "canvas_background": "#0C131A",
+
+  "text": "#E5EEF7",
+  "text_secondary": "#AFC4D8",
+  "text_disabled": "#6E859A",
+
+  "border": "#294258",
+  "border_hover": "#41627C",
+
+  "row_height": 30,
+  "menu_height": 34,
+  "status_height": 32,
+  "tool_rail_width": 100,
+  "border_radius": 2,
+
+  "enable_transitions": true,
+  "transition_duration": 0.14
+}

--- a/themes/paper_ink.json
+++ b/themes/paper_ink.json
@@ -1,0 +1,29 @@
+{
+  "id": "paper-ink",
+  "label": "Paper Ink",
+  "base_theme": "gldraw-light",
+
+  "primary": "#0E5A8A",
+  "primary_hover": "#1A6DA5",
+  "primary_active": "#094566",
+
+  "background": "#F4F0E6",
+  "panel": "#FCFAF2",
+  "panel_hover": "#F3EEE0",
+  "canvas_background": "#EFE8D8",
+
+  "text": "#2D2A24",
+  "text_secondary": "#61594D",
+  "text_disabled": "#9A9184",
+
+  "border": "#C7BCA8",
+  "border_hover": "#AFA28C",
+
+  "padding": 6,
+  "panel_width": 300,
+  "tool_rail_width": 104,
+  "border_radius": 0,
+
+  "enable_transitions": true,
+  "transition_duration": 0.1
+}


### PR DESCRIPTION
## Summary
- add an extensible theme framework with built-in + external JSON themes
- add runtime hot reload for the themes directory with signature-based change detection
- add Theme menu actions for selecting themes and manually reloading
- persist selected theme via gldraw.settings.json and document theme file schema

## Testing
- cmake --build build-vs2022 --config Release