### PR TITLE
docs: standardize code comments across all source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,14 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         "$<TARGET_FILE_DIR:${PROJECT_NAME}>/shaders"
 )
 
+if(EXISTS "${CMAKE_SOURCE_DIR}/themes")
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_SOURCE_DIR}/themes"
+            "$<TARGET_FILE_DIR:${PROJECT_NAME}>/themes"
+    )
+endif()
+
 target_link_libraries(${PROJECT_NAME} PRIVATE
     glfw
     OpenGL::GL

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ GLDraw is now a canvas-oriented OpenGL drawing editor. The project has been rest
 - App Bar with menu and quick actions (New/Open/Save/Undo/Redo/Zoom)
 - Left Tool Rail for Select/Hand/Line/Rect/Ellipse
 - Responsive inspector behavior (auto-hide under constrained width) with lightweight show/hide transition
+- Theme framework with built-in `GLDraw Light`, `GLDraw Dark+`, and `GLDraw High Contrast`
+- External theme files loaded from `themes/*.json` (startup scan)
+- Runtime hot reload for `themes/` directory (auto-detect file changes)
+- Theme selection from the top menu, persisted in `gldraw.settings.json` via `workbench.colorTheme`
 - Grid and origin axes rendering
 - Modular C11 codebase with GLFW, GLAD, and Nuklear
 
@@ -63,6 +67,16 @@ cmake --build build --config Release
 - `Delete` / `Backspace`: Delete current selection
 - `Mouse Wheel`: Zoom at cursor
 - `Esc`: Clear tool state, or close window when already in select mode
+
+## Theme Configuration
+
+- Select themes from the `Theme` top menu.
+- Use `Theme -> Reload Themes` to force refresh theme files immediately.
+- Current choice is persisted in `gldraw.settings.json` using key `workbench.colorTheme`.
+- You can add custom themes by dropping JSON files into `themes/`.
+- Theme file edits are hot-reloaded while the app is running.
+- Status bar messages distinguish `auto` reloads and `manually` triggered reloads.
+- Theme file schema and examples are documented in [themes/README.md](./themes/README.md).
 
 ## Project Structure
 

--- a/include/app/application.h
+++ b/include/app/application.h
@@ -1,6 +1,31 @@
+/**
+ * @file application.h
+ * @brief Process-level application entry point.
+ *
+ * Role in project:
+ * - Exposes the single runtime entry used by `main`.
+ * - Owns startup, main loop, and shutdown orchestration.
+ *
+ * Module relationships:
+ * - Called by `src/main.c`.
+ * - Coordinates workspace, window, render, tools, and UI systems.
+ */
 #ifndef GLDRAW_APP_APPLICATION_H
 #define GLDRAW_APP_APPLICATION_H
 
+/**
+ * @brief Run the GLDraw application loop.
+ * @param None.
+ * @return `0` on normal exit, `-1` on unrecoverable init/runtime failure.
+ *
+ * Edge cases:
+ * - Returns early if critical resources fail to initialize.
+ * - Performs internal cleanup on failure paths.
+ *
+ * Time complexity:
+ * - Init/teardown are effectively `O(1)`.
+ * - Per-frame work depends on scene size and active UI/tool state.
+ */
 int app_run(void);
 
 #endif /* GLDRAW_APP_APPLICATION_H */

--- a/include/app/application.h
+++ b/include/app/application.h
@@ -15,7 +15,6 @@
 
 /**
  * @brief Run the GLDraw application loop.
- * @param None.
  * @return `0` on normal exit, `-1` on unrecoverable init/runtime failure.
  *
  * Edge cases:

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -39,20 +39,23 @@ typedef struct WorkspaceLayout {
  * Memory ownership notes:
  * - `document`, `history`, `canvas`, and `tools` are embedded values (no extra indirection).
  * - `save_document`/`load_document` are callbacks owned by the application layer.
+ *
+ * Concurrency note:
+ * - This struct is not thread-safe; all access must be serialized by the caller.
  */
 typedef struct Workspace {
-    Document document;
-    DocumentHistory history;
-    CanvasView canvas;
-    ToolController tools;
-    WorkspaceLayout layout;
-    char current_document_path[260];
-    char status_message[256];
-    unsigned int saved_revision;
-    int document_dirty;
-    WorkspaceCommandFn save_document;
-    WorkspaceCommandFn load_document;
-    void* command_user_data;
+    Document document;              /**< In-memory document with objects and selection */
+    DocumentHistory history;        /**< Undo/redo stacks */
+    CanvasView canvas;              /**< Viewport, zoom, pan, and coordinate transforms */
+    ToolController tools;           /**< Active tool and its runtime state */
+    WorkspaceLayout layout;        /**< UI-computed layout rectangles (set by UI system) */
+    char current_document_path[260]; /**< Active file path (empty for new documents) */
+    char status_message[256];       /**< Current status bar message */
+    unsigned int saved_revision;     /**< Document revision last marked as saved */
+    int document_dirty;             /**< Non-zero when current revision differs from saved_revision */
+    WorkspaceCommandFn save_document; /**< Workspace-level save callback */
+    WorkspaceCommandFn load_document; /**< Workspace-level load callback */
+    void* command_user_data;        /**< Caller-supplied context for command callbacks */
 } Workspace;
 
 /**

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -9,11 +9,22 @@
 struct Workspace;
 typedef int (*WorkspaceCommandFn)(struct Workspace* workspace, void* user_data);
 
+typedef struct WorkspaceLayout {
+    RectF window_bounds;
+    RectF canvas_content_bounds;
+    RectF appbar_bounds;
+    RectF rail_bounds;
+    RectF panel_bounds;
+    RectF status_bounds;
+    unsigned int layout_revision;
+} WorkspaceLayout;
+
 typedef struct Workspace {
     Document document;
     DocumentHistory history;
     CanvasView canvas;
     ToolController tools;
+    WorkspaceLayout layout;
     char current_document_path[260];
     char status_message[256];
     unsigned int saved_revision;

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -1,3 +1,15 @@
+/**
+ * @file workspace.h
+ * @brief Shared editor state hub used across runtime systems.
+ *
+ * Role in project:
+ * - Aggregates document, history, canvas, tools, and UI layout state.
+ * - Provides function hooks for save/load commands.
+ *
+ * Module relationships:
+ * - Owned by `application.c`.
+ * - Referenced by tools and UI for coordinated document operations.
+ */
 #ifndef GLDRAW_APP_WORKSPACE_H
 #define GLDRAW_APP_WORKSPACE_H
 
@@ -7,8 +19,10 @@
 #include <tools/tool_controller.h>
 
 struct Workspace;
+/** Callback signature for workspace-level commands (save/load). */
 typedef int (*WorkspaceCommandFn)(struct Workspace* workspace, void* user_data);
 
+/** UI-computed layout snapshot shared with input/canvas subsystems. */
 typedef struct WorkspaceLayout {
     RectF window_bounds;
     RectF canvas_content_bounds;
@@ -19,6 +33,13 @@ typedef struct WorkspaceLayout {
     unsigned int layout_revision;
 } WorkspaceLayout;
 
+/**
+ * @brief Central runtime state passed between systems.
+ *
+ * Memory ownership notes:
+ * - `document`, `history`, `canvas`, and `tools` are embedded values (no extra indirection).
+ * - `save_document`/`load_document` are callbacks owned by the application layer.
+ */
 typedef struct Workspace {
     Document document;
     DocumentHistory history;
@@ -34,6 +55,16 @@ typedef struct Workspace {
     void* command_user_data;
 } Workspace;
 
+/**
+ * @brief Mark the current document revision as persisted.
+ * @param workspace [in,out] Target workspace; ignored when `NULL`.
+ * @return None.
+ *
+ * Edge cases:
+ * - Safe no-op for `NULL`.
+ *
+ * Time complexity: `O(1)`.
+ */
 static inline void workspace_mark_saved(Workspace* workspace)
 {
     if (!workspace) {
@@ -44,6 +75,16 @@ static inline void workspace_mark_saved(Workspace* workspace)
     workspace->document_dirty = 0;
 }
 
+/**
+ * @brief Recompute dirty flag from saved revision and current revision.
+ * @param workspace [in,out] Target workspace; ignored when `NULL`.
+ * @return None.
+ *
+ * Edge cases:
+ * - Safe no-op for `NULL`.
+ *
+ * Time complexity: `O(1)`.
+ */
 static inline void workspace_sync_document_dirty(Workspace* workspace)
 {
     if (!workspace) {

--- a/include/base/log.h
+++ b/include/base/log.h
@@ -7,7 +7,7 @@
  * - Keeps logging dependency-free for low-level modules.
  *
  * Module relationships:
- * - Used by app/document/persistence and other runtime subsystems.
+ * - Used by app, canvas, document, render, tools, and UI subsystems.
  */
 #ifndef GLDRAW_BASE_LOG_H
 #define GLDRAW_BASE_LOG_H
@@ -17,18 +17,15 @@
 
 /**
  * @brief Internal varargs logger writing one line to `stderr`.
- * @param level [in] Log level tag.
- * @param file [in] Source file path.
- * @param line [in] Source line number.
+ * @param level [in] Log level tag string.
+ * @param file [in] Source file path from caller.
+ * @param line [in] Source line number from caller.
  * @param fmt [in] `printf`-style format string.
  * @param ... [in] Format arguments.
- * @return None.
  *
- * Edge cases:
- * - Caller must pass a valid format string and matching varargs.
+ * Note:
  * - Return values of `fprintf`/`vfprintf` are intentionally ignored.
- *
- * Time complexity: `O(L)` where `L` is formatted output length.
+ * - Caller must ensure `fmt` and varargs match.
  */
 static inline void log_write_impl(const char* level,
                                   const char* file,

--- a/include/base/log.h
+++ b/include/base/log.h
@@ -1,9 +1,35 @@
+/**
+ * @file log.h
+ * @brief Lightweight stderr logging helpers.
+ *
+ * Role in project:
+ * - Provides file/line scoped debug/info/warn/error logging macros.
+ * - Keeps logging dependency-free for low-level modules.
+ *
+ * Module relationships:
+ * - Used by app/document/persistence and other runtime subsystems.
+ */
 #ifndef GLDRAW_BASE_LOG_H
 #define GLDRAW_BASE_LOG_H
 
 #include <stdarg.h>
 #include <stdio.h>
 
+/**
+ * @brief Internal varargs logger writing one line to `stderr`.
+ * @param level [in] Log level tag.
+ * @param file [in] Source file path.
+ * @param line [in] Source line number.
+ * @param fmt [in] `printf`-style format string.
+ * @param ... [in] Format arguments.
+ * @return None.
+ *
+ * Edge cases:
+ * - Caller must pass a valid format string and matching varargs.
+ * - Return values of `fprintf`/`vfprintf` are intentionally ignored.
+ *
+ * Time complexity: `O(L)` where `L` is formatted output length.
+ */
 static inline void log_write_impl(const char* level,
                                   const char* file,
                                   int line,

--- a/include/base/math2d.h
+++ b/include/base/math2d.h
@@ -1,9 +1,21 @@
+/**
+ * @file math2d.h
+ * @brief Inline 2D math helpers shared by canvas/tools/render code.
+ *
+ * Role in project:
+ * - Centralizes tiny vector/rectangle operations.
+ * - Avoids repeated ad-hoc math across modules.
+ *
+ * Module relationships:
+ * - Consumed by canvas transforms, tool delta handling, and rendering math.
+ */
 #ifndef GLDRAW_BASE_MATH2D_H
 #define GLDRAW_BASE_MATH2D_H
 
 #include <math.h>
 #include <base/types.h>
 
+/** Build a vector from two scalars. Complexity: `O(1)`. */
 static inline Vec2 vec2_make(float x, float y)
 {
     Vec2 value;
@@ -12,36 +24,47 @@ static inline Vec2 vec2_make(float x, float y)
     return value;
 }
 
+/** Add two vectors component-wise. Complexity: `O(1)`. */
 static inline Vec2 vec2_add(Vec2 a, Vec2 b)
 {
     return vec2_make(a.x + b.x, a.y + b.y);
 }
 
+/** Subtract two vectors component-wise. Complexity: `O(1)`. */
 static inline Vec2 vec2_sub(Vec2 a, Vec2 b)
 {
     return vec2_make(a.x - b.x, a.y - b.y);
 }
 
+/** Multiply a vector by a scalar. Complexity: `O(1)`. */
 static inline Vec2 vec2_scale(Vec2 value, float scalar)
 {
     return vec2_make(value.x * scalar, value.y * scalar);
 }
 
+/** Dot product of two vectors. Complexity: `O(1)`. */
 static inline float vec2_dot(Vec2 a, Vec2 b)
 {
     return a.x * b.x + a.y * b.y;
 }
 
+/** Squared length of a vector (avoids `sqrt`). Complexity: `O(1)`. */
 static inline float vec2_length_sq(Vec2 value)
 {
     return vec2_dot(value, value);
 }
 
+/** Euclidean vector length. Complexity: `O(1)`. */
 static inline float vec2_length(Vec2 value)
 {
     return sqrtf(vec2_length_sq(value));
 }
 
+/**
+ * Clamp a scalar into `[min_value, max_value]`.
+ * Edge case: behavior assumes `min_value <= max_value`.
+ * Complexity: `O(1)`.
+ */
 static inline float clampf(float value, float min_value, float max_value)
 {
     if (value < min_value) {
@@ -53,26 +76,35 @@ static inline float clampf(float value, float min_value, float max_value)
     return value;
 }
 
+/** Rectangle left edge (`x`). Complexity: `O(1)`. */
 static inline float rectf_left(const RectF* rect)
 {
     return rect->x;
 }
 
+/** Rectangle right edge (`x + w`). Complexity: `O(1)`. */
 static inline float rectf_right(const RectF* rect)
 {
     return rect->x + rect->w;
 }
 
+/** Rectangle bottom edge (`y`). Complexity: `O(1)`. */
 static inline float rectf_bottom(const RectF* rect)
 {
     return rect->y;
 }
 
+/** Rectangle top edge (`y + h`). Complexity: `O(1)`. */
 static inline float rectf_top(const RectF* rect)
 {
     return rect->y + rect->h;
 }
 
+/**
+ * Inclusive point-in-rectangle test.
+ * Risk: caller must pass a non-null `rect`.
+ * Complexity: `O(1)`.
+ */
 static inline int rectf_contains_point(const RectF* rect, Vec2 point)
 {
     return point.x >= rect->x &&

--- a/include/base/types.h
+++ b/include/base/types.h
@@ -1,13 +1,27 @@
+/**
+ * @file types.h
+ * @brief Small shared value types used by all core modules.
+ *
+ * Role in project:
+ * - Provides stable primitive structs for geometry and color.
+ * - Reduces cross-module coupling on third-party math/color APIs.
+ *
+ * Module relationships:
+ * - Included by document, canvas, tools, render, and UI headers.
+ */
 #ifndef GLDRAW_BASE_TYPES_H
 #define GLDRAW_BASE_TYPES_H
 
+/** Stable object identity in a document. */
 typedef unsigned int ObjectId;
 
+/** 2D vector in world/screen space. */
 typedef struct {
     float x;
     float y;
 } Vec2;
 
+/** RGBA color in normalized float range `[0, 1]`. */
 typedef struct {
     float r;
     float g;
@@ -15,6 +29,7 @@ typedef struct {
     float a;
 } Color;
 
+/** Floating-point rectangle (`x`, `y`, `width`, `height`). */
 typedef struct {
     float x;
     float y;

--- a/include/canvas/canvas_view.h
+++ b/include/canvas/canvas_view.h
@@ -16,22 +16,28 @@
 #include <base/types.h>
 #include <document/document.h>
 
-/** Canonical camera state used for compatibility migration. */
+/** Canonical camera state used for migration from legacy fields. */
 typedef struct CanvasViewportState {
     RectF viewport;
     Vec2 center;
     float zoom;
 } CanvasViewportState;
 
-/** Runtime canvas view state. */
+/**
+ * @brief Runtime canvas view state.
+ *
+ * Stores viewport, center, zoom, and presentation flags.
+ * Supports both canonical `viewport_state` and legacy compatibility fields
+ * that are kept in sync via `canvas_view_sync_compat()`.
+ */
 typedef struct CanvasView {
-    Document* document;
-    CanvasViewportState viewport_state;
-    RectF viewport;
-    Vec2 center;
-    float zoom;
-    int show_grid;
-    Color background;
+    Document* document;             /**< Document used for picking */
+    CanvasViewportState viewport_state; /**< Canonical camera state */
+    RectF viewport;                 /**< Legacy compatibility field */
+    Vec2 center;                   /**< Legacy compatibility field */
+    float zoom;                    /**< Legacy compatibility field */
+    int show_grid;                 /**< Non-zero to draw grid */
+    Color background;              /**< Canvas background color */
 } CanvasView;
 
 /** Initialize canvas state and bind a document. Complexity: `O(1)`. */
@@ -65,9 +71,16 @@ float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pix
 /** Get currently visible world-space rectangle. Complexity: `O(1)`. */
 RectF canvas_view_visible_world_rect(const CanvasView* canvas);
 /**
- * Pick top-most object at a screen point.
- * Returns `NULL` when canvas/document is invalid or no hit is found.
- * Complexity: `O(n)` where `n` is object count (reverse scan for top-most hit).
+ * @brief Pick top-most object under a screen point.
+ * @param canvas [in] Canvas view instance.
+ * @param screen_point [in] Screen-space pixel coordinate.
+ * @param tolerance_pixels [in] Pick tolerance in screen pixels.
+ * @return Pointer to the top-most hit object, or `NULL` if no hit or invalid input.
+ *
+ * Why reverse loop:
+ * - Newer objects are drawn later and visually on top, so picking scans from end.
+ *
+ * Complexity: `O(n)` where `n` is document object count (reverse linear scan).
  */
 GraphicObject* canvas_view_pick_object(const CanvasView* canvas, Vec2 screen_point, float tolerance_pixels);
 

--- a/include/canvas/canvas_view.h
+++ b/include/canvas/canvas_view.h
@@ -1,15 +1,29 @@
+/**
+ * @file canvas_view.h
+ * @brief Canvas camera and coordinate conversion API.
+ *
+ * Role in project:
+ * - Stores viewport, center, zoom, and presentation flags.
+ * - Converts between world space and screen space for tools/rendering.
+ *
+ * Module relationships:
+ * - Reads `Document` for picking.
+ * - Used by tools, renderer, and application event handling.
+ */
 #ifndef GLDRAW_CANVAS_CANVAS_VIEW_H
 #define GLDRAW_CANVAS_CANVAS_VIEW_H
 
 #include <base/types.h>
 #include <document/document.h>
 
+/** Canonical camera state used for compatibility migration. */
 typedef struct CanvasViewportState {
     RectF viewport;
     Vec2 center;
     float zoom;
 } CanvasViewportState;
 
+/** Runtime canvas view state. */
 typedef struct CanvasView {
     Document* document;
     CanvasViewportState viewport_state;
@@ -20,21 +34,41 @@ typedef struct CanvasView {
     Color background;
 } CanvasView;
 
+/** Initialize canvas state and bind a document. Complexity: `O(1)`. */
 void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport);
+/** Rebind document used for picking. Complexity: `O(1)`. */
 void canvas_view_set_document(CanvasView* canvas, Document* document);
+/** Update screen viewport rectangle. Complexity: `O(1)`. */
 void canvas_view_set_viewport(CanvasView* canvas, RectF viewport);
+/** Set world-space center. Complexity: `O(1)`. */
 void canvas_view_set_center(CanvasView* canvas, Vec2 center);
+/** Set zoom (clamped to valid range). Complexity: `O(1)`. */
 void canvas_view_set_zoom(CanvasView* canvas, float zoom);
+/** Set center and zoom atomically. Complexity: `O(1)`. */
 void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom);
+/** Get current viewport rectangle. Complexity: `O(1)`. */
 RectF canvas_view_viewport(const CanvasView* canvas);
+/** Get current world-space center. Complexity: `O(1)`. */
 Vec2 canvas_view_center(const CanvasView* canvas);
+/** Get current zoom factor. Complexity: `O(1)`. */
 float canvas_view_zoom(const CanvasView* canvas);
+/** Convert world coordinates to screen coordinates. Complexity: `O(1)`. */
 Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world);
+/** Convert screen coordinates to world coordinates. Complexity: `O(1)`. */
 Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen);
+/** Pan camera by a screen-space delta. Complexity: `O(1)`. */
 void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen);
+/** Zoom around a fixed screen anchor to keep cursor focus stable. Complexity: `O(1)`. */
 void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 screen_anchor);
+/** Convert pixel tolerance to world-space tolerance at current zoom. Complexity: `O(1)`. */
 float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pixels);
+/** Get currently visible world-space rectangle. Complexity: `O(1)`. */
 RectF canvas_view_visible_world_rect(const CanvasView* canvas);
+/**
+ * Pick top-most object at a screen point.
+ * Returns `NULL` when canvas/document is invalid or no hit is found.
+ * Complexity: `O(n)` where `n` is object count (reverse scan for top-most hit).
+ */
 GraphicObject* canvas_view_pick_object(const CanvasView* canvas, Vec2 screen_point, float tolerance_pixels);
 
 #endif /* GLDRAW_CANVAS_CANVAS_VIEW_H */

--- a/include/canvas/canvas_view.h
+++ b/include/canvas/canvas_view.h
@@ -4,8 +4,15 @@
 #include <base/types.h>
 #include <document/document.h>
 
+typedef struct CanvasViewportState {
+    RectF viewport;
+    Vec2 center;
+    float zoom;
+} CanvasViewportState;
+
 typedef struct CanvasView {
     Document* document;
+    CanvasViewportState viewport_state;
     RectF viewport;
     Vec2 center;
     float zoom;
@@ -16,6 +23,12 @@ typedef struct CanvasView {
 void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport);
 void canvas_view_set_document(CanvasView* canvas, Document* document);
 void canvas_view_set_viewport(CanvasView* canvas, RectF viewport);
+void canvas_view_set_center(CanvasView* canvas, Vec2 center);
+void canvas_view_set_zoom(CanvasView* canvas, float zoom);
+void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom);
+RectF canvas_view_viewport(const CanvasView* canvas);
+Vec2 canvas_view_center(const CanvasView* canvas);
+float canvas_view_zoom(const CanvasView* canvas);
 Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world);
 Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen);
 void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen);

--- a/include/document/document.h
+++ b/include/document/document.h
@@ -1,3 +1,18 @@
+/**
+ * @file document.h
+ * @brief Core in-memory document model for drawable objects and selection.
+ *
+ * Role in project:
+ * - Owns object storage, stable IDs, selection state, and revision tracking.
+ * - Acts as the authoritative data model for tools, UI, persistence, and render.
+ *
+ * Module relationships:
+ * - Uses object APIs from `document/object.h`.
+ * - Consumed by history, canvas picking, tool operations, and save/load.
+ *
+ * Concurrency note:
+ * - This module is not thread-safe; callers must serialize access externally.
+ */
 #ifndef GLDRAW_DOCUMENT_DOCUMENT_H
 #define GLDRAW_DOCUMENT_DOCUMENT_H
 
@@ -6,6 +21,7 @@
 #define DOCUMENT_MAX_OBJECTS 1024
 #define DOCUMENT_MAX_SELECTION 128
 
+/** Bounded selection list of object IDs. */
 typedef struct {
     ObjectId ids[DOCUMENT_MAX_SELECTION];
     int count;
@@ -19,24 +35,41 @@ typedef struct Document {
     SelectionSet selection;
 } Document;
 
+/** Initialize a document to empty state. Complexity: `O(1)`. */
 void document_init(Document* document);
+/** Destroy all owned objects and clear runtime state. Complexity: `O(n)`. */
 void document_shutdown(Document* document);
+/** Reset to pristine empty document (`revision=1`, `next_id=1`). Complexity: `O(n)`. */
 void document_reset(Document* document);
 
+/** Append object and assign a fresh ID; returns 0 on capacity/null input. Complexity: `O(1)`. */
 int document_add_object(Document* document, GraphicObject* object);
+/** Append object with explicit ID; fails on duplicate/invalid ID. Complexity: `O(n)`. */
 int document_append_object_with_id(Document* document, GraphicObject* object, ObjectId id);
+/** Find object by ID; returns `NULL` when not found. Complexity: `O(n)`. */
 GraphicObject* document_find_object(const Document* document, ObjectId id);
+/** Get object by index; returns `NULL` for invalid index/document. Complexity: `O(1)`. */
 GraphicObject* document_get_object_at(const Document* document, int index);
+/** Remove object by ID and compact array; returns 1 on success. Complexity: `O(n)`. */
 int document_remove_object(Document* document, ObjectId id);
+/** Delete all selected objects. Complexity: up to `O(s*n)` (`s`: selection count). */
 void document_delete_selection(Document* document);
+/** Bump revision for non-structural edits. Complexity: `O(1)`. */
 void document_touch(Document* document);
+/** Compute maximum existing object ID (0 when empty/invalid). Complexity: `O(n)`. */
 ObjectId document_max_id(const Document* document);
 
+/** Clear selection set. Complexity: `O(1)`. */
 void document_clear_selection(Document* document);
+/** Check if ID is selected. Complexity: `O(s)` (`s`: selection count). */
 int document_selection_contains(const Document* document, ObjectId id);
+/** Add ID to selection if not already present. Complexity: `O(s)`. */
 int document_selection_add(Document* document, ObjectId id);
+/** Remove ID from selection if present. Complexity: `O(s)`. */
 void document_selection_remove(Document* document, ObjectId id);
+/** Toggle selection state for an ID. Complexity: `O(s)`. */
 void document_selection_toggle(Document* document, ObjectId id);
+/** Get first selected object; returns `NULL` when none. Complexity: `O(n)` (ID lookup). */
 GraphicObject* document_primary_selection(const Document* document);
 
 #endif /* GLDRAW_DOCUMENT_DOCUMENT_H */

--- a/include/document/document.h
+++ b/include/document/document.h
@@ -27,12 +27,18 @@ typedef struct {
     int count;
 } SelectionSet;
 
+/**
+ * @brief In-memory document storing drawable objects, selection, and metadata.
+ *
+ * Concurrency note:
+ * - This struct is not thread-safe; callers must serialize access externally.
+ */
 typedef struct Document {
-    GraphicObject* objects[DOCUMENT_MAX_OBJECTS];
-    int count;
-    unsigned int revision;
-    ObjectId next_id;
-    SelectionSet selection;
+    GraphicObject* objects[DOCUMENT_MAX_OBJECTS]; /**< Bounded object array */
+    int count;                                     /**< Number of objects currently stored */
+    unsigned int revision;                         /**< Monotonically increasing edit counter */
+    ObjectId next_id;                              /**< Next auto-assign ID for new objects */
+    SelectionSet selection;                        /**< Current selection set */
 } Document;
 
 /** Initialize a document to empty state. Complexity: `O(1)`. */

--- a/include/document/history.h
+++ b/include/document/history.h
@@ -1,3 +1,18 @@
+/**
+ * @file history.h
+ * @brief Snapshot-based undo/redo interfaces.
+ *
+ * Role in project:
+ * - Captures deep copies of `Document` state before/after edits.
+ * - Maintains bounded undo/redo stacks for reversible operations.
+ *
+ * Module relationships:
+ * - Built on top of `document.h` and `object` cloning.
+ * - Called by tools/UI whenever a user-visible edit is committed.
+ *
+ * Concurrency note:
+ * - History stacks are mutable and unsynchronized; use from one thread only.
+ */
 #ifndef GLDRAW_DOCUMENT_HISTORY_H
 #define GLDRAW_DOCUMENT_HISTORY_H
 
@@ -5,6 +20,7 @@
 
 #define DOCUMENT_HISTORY_MAX_ENTRIES 128
 
+/** Deep-copied document state stored in history stacks. */
 typedef struct {
     GraphicObject** objects;
     int capacity;
@@ -14,6 +30,7 @@ typedef struct {
     SelectionSet selection;
 } DocumentSnapshot;
 
+/** One undo/redo transaction pair (`before` -> `after`). */
 typedef struct {
     DocumentSnapshot before;
     DocumentSnapshot after;
@@ -27,16 +44,26 @@ typedef struct DocumentHistory {
     int redo_count;
 } DocumentHistory;
 
+/** Initialize snapshot to empty state. Complexity: `O(1)`. */
 void document_snapshot_init(DocumentSnapshot* snapshot);
+/** Free all objects owned by snapshot. Complexity: `O(n)`. */
 void document_snapshot_free(DocumentSnapshot* snapshot);
+/** Deep-copy document into snapshot. Returns 0 on allocation/clone failure. Complexity: `O(n)`. */
 int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* document);
 
+/** Allocate undo/redo stacks. Returns 0 on allocation failure. Complexity: `O(capacity)`. */
 int document_history_init(DocumentHistory* history);
+/** Release all stack entries and internal arrays. Complexity: `O(total_snapshots)`. */
 void document_history_shutdown(DocumentHistory* history);
+/** Push one transaction and clear redo stack. Complexity: `O(n + capacity)` worst-case. */
 int document_history_push(DocumentHistory* history, DocumentSnapshot* before, const Document* after_document);
+/** Apply latest undo entry. Returns 0 when stack empty/failure. Complexity: `O(n + capacity)` worst-case. */
 int document_history_undo(DocumentHistory* history, Document* document);
+/** Apply latest redo entry. Returns 0 when stack empty/failure. Complexity: `O(n + capacity)` worst-case. */
 int document_history_redo(DocumentHistory* history, Document* document);
+/** Check undo availability. Complexity: `O(1)`. */
 int document_history_can_undo(const DocumentHistory* history);
+/** Check redo availability. Complexity: `O(1)`. */
 int document_history_can_redo(const DocumentHistory* history);
 
 #endif /* GLDRAW_DOCUMENT_HISTORY_H */

--- a/include/document/history.h
+++ b/include/document/history.h
@@ -32,16 +32,22 @@ typedef struct {
 
 /** One undo/redo transaction pair (`before` -> `after`). */
 typedef struct {
-    DocumentSnapshot before;
-    DocumentSnapshot after;
+    DocumentSnapshot before; /**< Document state before the edit */
+    DocumentSnapshot after;  /**< Document state after the edit */
 } DocumentHistoryEntry;
 
+/**
+ * @brief Undo/redo history with bounded stacks.
+ *
+ * Concurrency note:
+ * - Stacks are mutable and unsynchronized; use from one thread only.
+ */
 typedef struct DocumentHistory {
-    DocumentHistoryEntry* undo_stack;
-    DocumentHistoryEntry* redo_stack;
-    int capacity;
-    int undo_count;
-    int redo_count;
+    DocumentHistoryEntry* undo_stack; /**< Uncommitted edits stack */
+    DocumentHistoryEntry* redo_stack; /**< Reverted edits stack */
+    int capacity;                      /**< Max entries per stack */
+    int undo_count;                    /**< Number of entries in undo stack */
+    int redo_count;                    /**< Number of entries in redo stack */
 } DocumentHistory;
 
 /** Initialize snapshot to empty state. Complexity: `O(1)`. */

--- a/include/document/object.h
+++ b/include/document/object.h
@@ -51,7 +51,7 @@ struct GraphicObject {
     unsigned int revision;
 };
 
-/** Return default style tokens for newly created objects. Complexity: `O(1)`. */
+/** Return default style values for newly created objects. Complexity: `O(1)`. */
 GraphicStyle object_default_style(void);
 /** Return human-readable type name. Complexity: `O(1)`. */
 const char* object_type_name(GraphicObjectType type);

--- a/include/document/object.h
+++ b/include/document/object.h
@@ -1,14 +1,27 @@
+/**
+ * @file object.h
+ * @brief Polymorphic drawable object definitions and operations.
+ *
+ * Role in project:
+ * - Defines object type IDs, style data, and vtable contracts.
+ * - Provides creation, mutation, querying, and cloning APIs.
+ *
+ * Module relationships:
+ * - Used by document storage, canvas picking, renderer path extraction, and persistence.
+ */
 #ifndef GLDRAW_DOCUMENT_OBJECT_H
 #define GLDRAW_DOCUMENT_OBJECT_H
 
 #include <base/types.h>
 
+/** Supported built-in object kinds. */
 typedef enum {
     GRAPHIC_OBJECT_LINE = 0,
     GRAPHIC_OBJECT_RECT,
     GRAPHIC_OBJECT_ELLIPSE
 } GraphicObjectType;
 
+/** Shared drawing style carried by each object instance. */
 typedef struct {
     Color stroke_color;
     float stroke_width;
@@ -38,23 +51,39 @@ struct GraphicObject {
     unsigned int revision;
 };
 
+/** Return default style tokens for newly created objects. Complexity: `O(1)`. */
 GraphicStyle object_default_style(void);
+/** Return human-readable type name. Complexity: `O(1)`. */
 const char* object_type_name(GraphicObjectType type);
 
+/** Create a line object; returns `NULL` on allocation failure. Complexity: `O(1)`. */
 GraphicObject* object_create_line(Vec2 p1, Vec2 p2, GraphicStyle style);
+/** Create a rectangle object; returns `NULL` on allocation failure. Complexity: `O(1)`. */
 GraphicObject* object_create_rect(RectF rect, GraphicStyle style);
+/** Create an ellipse object; returns `NULL` on allocation failure. Complexity: `O(1)`. */
 GraphicObject* object_create_ellipse(RectF bounds, GraphicStyle style);
+/** Deep clone object payload/style/metadata; returns `NULL` on failure. Complexity: `O(1)`. */
 GraphicObject* object_clone(const GraphicObject* object);
 
+/** Destroy object via vtable; safe no-op for invalid input. Complexity: `O(1)`. */
 void object_destroy(GraphicObject* object);
+/** Translate geometry in world space and bump object revision. Complexity: `O(1)`. */
 void object_translate(GraphicObject* object, Vec2 delta);
+/** Get object axis-aligned bounds; returns empty rect for invalid input. Complexity: `O(1)`. */
 RectF object_get_bounds(const GraphicObject* object);
+/** Hit-test a world point against object geometry. Complexity: `O(1)`. */
 int object_hit_test(const GraphicObject* object, Vec2 point, float tolerance);
+/** Get polyline sample count for rendering. Complexity: `O(1)`. */
 int object_get_path_point_count(const GraphicObject* object);
+/** Write polyline points into caller-provided buffer. Complexity: `O(k)`. */
 void object_write_path_points(const GraphicObject* object, Vec2* out_points);
+/** Query scalar property by key. Returns 1 when key is supported. Complexity: `O(1)`. */
 int object_get_scalar(const GraphicObject* object, const char* key, float* out_value);
+/** Set scalar property by key and bump revision on success. Complexity: `O(1)`. */
 int object_set_scalar(GraphicObject* object, const char* key, float value);
+/** Update stroke color and bump revision. Complexity: `O(1)`. */
 void object_set_stroke_color(GraphicObject* object, Color color);
+/** Update stroke width and bump revision. Complexity: `O(1)`. */
 void object_set_stroke_width(GraphicObject* object, float stroke_width);
 
 #endif /* GLDRAW_DOCUMENT_OBJECT_H */

--- a/include/document/persistence.h
+++ b/include/document/persistence.h
@@ -1,9 +1,23 @@
+/**
+ * @file persistence.h
+ * @brief Document JSON save/load interface.
+ *
+ * Role in project:
+ * - Serializes in-memory `Document` into stable JSON format.
+ * - Deserializes JSON back to runtime objects with IDs and style data.
+ *
+ * Module relationships:
+ * - Called by application and menu actions.
+ * - Depends on document/object APIs for object construction and lookup.
+ */
 #ifndef GLDRAW_DOCUMENT_PERSISTENCE_H
 #define GLDRAW_DOCUMENT_PERSISTENCE_H
 
 #include <document/document.h>
 
+/** Save document to JSON file path. Returns 1 on success, 0 on I/O/serialization failure. */
 int document_save_json(const Document* document, const char* path);
+/** Load document from JSON file path. Returns 1 on success, 0 on I/O/parse/validation failure. */
 int document_load_json(Document* document, const char* path);
 
 #endif /* GLDRAW_DOCUMENT_PERSISTENCE_H */

--- a/include/platform/window.h
+++ b/include/platform/window.h
@@ -22,9 +22,9 @@ typedef struct {
     const char* title;
 } PlatformWindow;
 
-/** Initialize GLFW and create an OpenGL 3.3 core window. Returns 0 on success. */
+/** Initialize GLFW and create an OpenGL 3.3 Core Profile window. Returns 0 on success, -1 on failure. */
 int platform_window_init(PlatformWindow* window, int width, int height, const char* title);
-/** Destroy window handle if present. */
+/** Destroy window handle if present. Note: does not call `glfwTerminate()`. */
 void platform_window_shutdown(PlatformWindow* window);
 /** Poll pending OS/window events. */
 void platform_window_poll_events(void);

--- a/include/platform/window.h
+++ b/include/platform/window.h
@@ -1,3 +1,14 @@
+/**
+ * @file window.h
+ * @brief Thin GLFW window lifecycle wrapper.
+ *
+ * Role in project:
+ * - Encapsulates window/context creation and basic event/buffer calls.
+ * - Keeps application code independent from raw GLFW setup details.
+ *
+ * Module relationships:
+ * - Used by application startup loop and renderer initialization.
+ */
 #ifndef GLDRAW_PLATFORM_WINDOW_H
 #define GLDRAW_PLATFORM_WINDOW_H
 
@@ -11,10 +22,15 @@ typedef struct {
     const char* title;
 } PlatformWindow;
 
+/** Initialize GLFW and create an OpenGL 3.3 core window. Returns 0 on success. */
 int platform_window_init(PlatformWindow* window, int width, int height, const char* title);
+/** Destroy window handle if present. */
 void platform_window_shutdown(PlatformWindow* window);
+/** Poll pending OS/window events. */
 void platform_window_poll_events(void);
+/** Present current backbuffer if window is valid. */
 void platform_window_swap_buffers(PlatformWindow* window);
+/** Return non-zero when window is invalid or close was requested. */
 int platform_window_should_close(const PlatformWindow* window);
 
 #endif /* GLDRAW_PLATFORM_WINDOW_H */

--- a/include/render/render_system.h
+++ b/include/render/render_system.h
@@ -1,3 +1,15 @@
+/**
+ * @file render_system.h
+ * @brief OpenGL renderer interface for canvas/document drawing.
+ *
+ * Role in project:
+ * - Owns shader program and GPU buffers.
+ * - Draws grid, objects, selection emphasis, and tool overlays.
+ *
+ * Module relationships:
+ * - Consumes `Document` geometry and `CanvasView` transforms.
+ * - Called each frame by the application loop.
+ */
 #ifndef GLDRAW_RENDER_RENDER_SYSTEM_H
 #define GLDRAW_RENDER_RENDER_SYSTEM_H
 
@@ -7,9 +19,13 @@
 
 typedef struct RenderSystem RenderSystem;
 
+/** Create renderer resources for an existing window/context. Returns `NULL` on failure. */
 RenderSystem* render_system_create(PlatformWindow* window);
+/** Release all GL/heap resources owned by renderer. */
 void render_system_destroy(RenderSystem* renderer);
+/** Update framebuffer-dependent renderer state after resize. */
 void render_system_resize(RenderSystem* renderer, int width, int height);
+/** Draw one frame of the canvas scene. Complexity is roughly `O(object_count + grid_lines)`. */
 void render_system_draw(RenderSystem* renderer,
                         const Document* document,
                         const CanvasView* canvas,

--- a/include/tools/tool.h
+++ b/include/tools/tool.h
@@ -1,3 +1,15 @@
+/**
+ * @file tool.h
+ * @brief Generic tool abstraction and event payload types.
+ *
+ * Role in project:
+ * - Defines polymorphic tool vtable used by the tool controller.
+ * - Carries per-event input state in screen/world coordinates.
+ *
+ * Module relationships:
+ * - Implemented by `tool_controller.c` built-in tools.
+ * - Consumes workspace/document/canvas/history through `ToolContext`.
+ */
 #ifndef GLDRAW_TOOLS_TOOL_H
 #define GLDRAW_TOOLS_TOOL_H
 
@@ -9,6 +21,7 @@ struct Document;
 struct CanvasView;
 struct DocumentHistory;
 
+/** Built-in tool identifiers. */
 typedef enum {
     TOOL_KIND_SELECT = 0,
     TOOL_KIND_PAN,
@@ -18,6 +31,7 @@ typedef enum {
     TOOL_KIND_COUNT
 } ToolKind;
 
+/** Normalized pointer/keyboard event payload passed to tools. */
 typedef struct {
     Vec2 screen_pos;
     Vec2 world_pos;
@@ -28,6 +42,7 @@ typedef struct {
     float wheel_y;
 } ToolEvent;
 
+/** Shared handles a tool needs to mutate editor state safely. */
 typedef struct {
     struct Workspace* workspace;
     struct Document* document;

--- a/include/tools/tool.h
+++ b/include/tools/tool.h
@@ -31,43 +31,63 @@ typedef enum {
     TOOL_KIND_COUNT
 } ToolKind;
 
-/** Normalized pointer/keyboard event payload passed to tools. */
+/**
+ * @brief Normalized pointer/keyboard event payload passed to tools.
+ *
+ * Contains screen/world positions, deltas, and input state at the moment
+ * of an input event. All coordinates are in the relevant space already
+ * (screen or world) so tools can use whichever is appropriate.
+ */
 typedef struct {
-    Vec2 screen_pos;
-    Vec2 world_pos;
-    Vec2 delta_screen;
-    Vec2 delta_world;
-    int button;
-    int mods;
-    float wheel_y;
+    Vec2 screen_pos;   /**< Screen-space cursor position at event time */
+    Vec2 world_pos;     /**< World-space cursor position at event time */
+    Vec2 delta_screen;  /**< Screen-space movement since last event */
+    Vec2 delta_world;   /**< World-space movement since last event */
+    int button;         /**< GLFW button index, or -1 for move events */
+    int mods;           /**< Modifier key flags at event time */
+    float wheel_y;      /**< Vertical scroll delta (0 for non-scroll events) */
 } ToolEvent;
 
-/** Shared handles a tool needs to mutate editor state safely. */
+/**
+ * @brief Shared handles a tool uses to safely read/write editor state.
+ *
+ * Passed to tool callbacks so tools can access document, canvas, history,
+ * and workspace without needing a full workspace reference.
+ */
 typedef struct {
-    struct Workspace* workspace;
-    struct Document* document;
-    struct DocumentHistory* history;
-    struct CanvasView* canvas;
+    struct Workspace* workspace;    /**< Editor state and callbacks */
+    struct Document* document;       /**< Active document objects and selection */
+    struct DocumentHistory* history; /**< Undo/redo stack */
+    struct CanvasView* canvas;       /**< Viewport, zoom, and picking */
 } ToolContext;
 
 typedef struct Tool Tool;
 typedef struct ToolVTable ToolVTable;
 
+/**
+ * @brief Virtual dispatch table for polymorphic tool implementations.
+ *
+ * Each tool kind provides function pointers for all input handling callbacks.
+ * A `NULL` vtable entry means that event type is not supported by that tool.
+ */
 struct ToolVTable {
-    const char* (*label)(const Tool* tool);
-    void (*activate)(Tool* tool, ToolContext* context);
-    void (*deactivate)(Tool* tool, ToolContext* context);
-    void (*pointer_down)(Tool* tool, ToolContext* context, const ToolEvent* event);
-    void (*pointer_move)(Tool* tool, ToolContext* context, const ToolEvent* event);
-    void (*pointer_up)(Tool* tool, ToolContext* context, const ToolEvent* event);
-    void (*key_down)(Tool* tool, ToolContext* context, int key, int mods);
+    const char* (*label)(const Tool* tool);         /**< Human-readable tool name */
+    void (*activate)(Tool* tool, ToolContext* context);       /**< Called when tool becomes active */
+    void (*deactivate)(Tool* tool, ToolContext* context);       /**< Called when tool stops being active */
+    void (*pointer_down)(Tool* tool, ToolContext* context, const ToolEvent* event);   /**< Left-press handler */
+    void (*pointer_move)(Tool* tool, ToolContext* context, const ToolEvent* event);   /**< Pointer move handler */
+    void (*pointer_up)(Tool* tool, ToolContext* context, const ToolEvent* event);     /**< Left-release handler */
+    void (*key_down)(Tool* tool, ToolContext* context, int key, int mods);           /**< Keyboard handler */
 };
 
+/**
+ * @brief Runtime instance of a tool with its kind, vtable, and per-tool state.
+ */
 struct Tool {
-    ToolKind kind;
-    const ToolVTable* vtable;
-    void* state;
-    GraphicObject* overlay_object;
+    ToolKind kind;                    /**< Which tool kind this instance represents */
+    const ToolVTable* vtable;        /**< Dispatch table for this tool's callbacks */
+    void* state;                     /**< Per-tool runtime state (e.g., drag state, anchor point) */
+    GraphicObject* overlay_object;    /**< Transient preview object currently being drawn */
 };
 
 #endif /* GLDRAW_TOOLS_TOOL_H */

--- a/include/tools/tool_controller.h
+++ b/include/tools/tool_controller.h
@@ -1,3 +1,15 @@
+/**
+ * @file tool_controller.h
+ * @brief Active tool routing and input dispatch API.
+ *
+ * Role in project:
+ * - Stores all tool instances and tracks the current active tool.
+ * - Forwards pointer/key/scroll events to the active tool implementation.
+ *
+ * Module relationships:
+ * - Built on `tool.h` abstractions.
+ * - Called by application event callbacks and UI tool selectors.
+ */
 #ifndef GLDRAW_TOOLS_TOOL_CONTROLLER_H
 #define GLDRAW_TOOLS_TOOL_CONTROLLER_H
 
@@ -11,18 +23,29 @@ typedef struct {
     Vec2 last_world;
 } ToolController;
 
+/** Initialize all tool slots and internal state. Complexity: `O(tool_count)`. */
 void tool_controller_init(ToolController* controller);
+/** Shutdown tools and free per-tool state. Complexity: `O(tool_count)`. */
 void tool_controller_shutdown(ToolController* controller);
 
+/** Switch active tool and run deactivate/activate hooks as needed. Complexity: `O(1)`. */
 void tool_controller_set_active(ToolController* controller, ToolContext* context, ToolKind kind);
+/** Get mutable pointer to currently active tool, or `NULL` if controller invalid. */
 Tool* tool_controller_get_active(ToolController* controller);
+/** Get active tool display label. */
 const char* tool_controller_active_label(const ToolController* controller);
+/** Get overlay object owned by active tool (preview rendering). */
 GraphicObject* tool_controller_overlay_object(const ToolController* controller);
 
+/** Dispatch pointer press and capture pointer ownership. */
 void tool_controller_pointer_down(ToolController* controller, ToolContext* context, const ToolEvent* event);
+/** Dispatch pointer move to active tool. */
 void tool_controller_pointer_move(ToolController* controller, ToolContext* context, const ToolEvent* event);
+/** Dispatch pointer release and release pointer capture. */
 void tool_controller_pointer_up(ToolController* controller, ToolContext* context, const ToolEvent* event);
+/** Dispatch keyboard input including global shortcuts (undo/redo/tool switching). */
 void tool_controller_key_down(ToolController* controller, ToolContext* context, int key, int mods);
+/** Handle wheel zoom at given screen anchor. */
 void tool_controller_scroll(ToolController* controller, ToolContext* context, Vec2 screen_pos, float yoffset);
 
 #endif /* GLDRAW_TOOLS_TOOL_CONTROLLER_H */

--- a/include/tools/tool_controller.h
+++ b/include/tools/tool_controller.h
@@ -43,9 +43,9 @@ void tool_controller_pointer_down(ToolController* controller, ToolContext* conte
 void tool_controller_pointer_move(ToolController* controller, ToolContext* context, const ToolEvent* event);
 /** Dispatch pointer release and release pointer capture. */
 void tool_controller_pointer_up(ToolController* controller, ToolContext* context, const ToolEvent* event);
-/** Dispatch keyboard input including global shortcuts (undo/redo/tool switching). */
+/** Dispatch keyboard input to global shortcuts or active tool. */
 void tool_controller_key_down(ToolController* controller, ToolContext* context, int key, int mods);
-/** Handle wheel zoom at given screen anchor. */
+/** Handle mouse wheel scroll for zoom around a screen anchor. */
 void tool_controller_scroll(ToolController* controller, ToolContext* context, Vec2 screen_pos, float yoffset);
 
 #endif /* GLDRAW_TOOLS_TOOL_CONTROLLER_H */

--- a/include/ui/ui_system.h
+++ b/include/ui/ui_system.h
@@ -13,6 +13,9 @@ void ui_system_destroy(UiSystem* ui);
 void ui_system_begin_frame(UiSystem* ui);
 void ui_system_build(UiSystem* ui, struct Workspace* workspace);
 void ui_system_render(UiSystem* ui);
+int ui_system_has_active_interaction(const UiSystem* ui);
 int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos);
+RectF ui_system_content_bounds(const UiSystem* ui);
+Color ui_system_canvas_background(const UiSystem* ui);
 
 #endif /* GLDRAW_UI_UI_SYSTEM_H */

--- a/include/ui/ui_system.h
+++ b/include/ui/ui_system.h
@@ -1,3 +1,15 @@
+/**
+ * @file ui_system.h
+ * @brief Nuklear UI system lifecycle and layout query API.
+ *
+ * Role in project:
+ * - Builds toolbar/menu/inspector/status UI each frame.
+ * - Publishes UI layout bounds used by app input filtering and canvas viewport.
+ *
+ * Module relationships:
+ * - Created/destroyed by application runtime.
+ * - Reads/writes workspace state and consumes platform window context.
+ */
 #ifndef GLDRAW_UI_UI_SYSTEM_H
 #define GLDRAW_UI_UI_SYSTEM_H
 
@@ -8,14 +20,23 @@ struct Workspace;
 
 typedef struct UiSystem UiSystem;
 
+/** Create UI system for an initialized window/context. Returns `NULL` on failure. */
 UiSystem* ui_system_create(PlatformWindow* window);
+/** Destroy UI resources and contexts. */
 void ui_system_destroy(UiSystem* ui);
+/** Begin a new UI frame (input capture/reset). */
 void ui_system_begin_frame(UiSystem* ui);
+/** Build all UI panels and apply workspace mutations. */
 void ui_system_build(UiSystem* ui, struct Workspace* workspace);
+/** Render prepared UI draw commands. */
 void ui_system_render(UiSystem* ui);
+/** Return non-zero when any UI widget is actively interacting. */
 int ui_system_has_active_interaction(const UiSystem* ui);
+/** Return non-zero when a screen point is over UI-occupied regions. */
 int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos);
+/** Get computed content area available for canvas. */
 RectF ui_system_content_bounds(const UiSystem* ui);
+/** Get canvas background color derived from active theme. */
 Color ui_system_canvas_background(const UiSystem* ui);
 
 #endif /* GLDRAW_UI_UI_SYSTEM_H */

--- a/include/ui/ui_theme.h
+++ b/include/ui/ui_theme.h
@@ -18,6 +18,7 @@ typedef struct UiThemeTokens {
     struct nk_color background;
     struct nk_color panel;
     struct nk_color panel_hover;
+    struct nk_color canvas_background;
 
     /* Text */
     struct nk_color text;

--- a/include/ui/ui_theme.h
+++ b/include/ui/ui_theme.h
@@ -1,6 +1,8 @@
 #ifndef GLDRAW_UI_UI_THEME_H
 #define GLDRAW_UI_UI_THEME_H
 
+#include <stddef.h>
+
 #ifndef NK_NUKLEAR_H_
 typedef unsigned char nk_byte;
 typedef int nk_bool;
@@ -54,7 +56,21 @@ typedef struct UiThemeTokens {
     float transition_duration;
 } UiThemeTokens;
 
+typedef struct UiThemeDescriptor {
+    const char* id;
+    const char* label;
+} UiThemeDescriptor;
+
 UiThemeTokens ui_theme_default_tokens(void);
+UiThemeTokens ui_theme_tokens_for_id(const char* theme_id);
+int ui_theme_count(void);
+const UiThemeDescriptor* ui_theme_descriptor_at(int index);
+int ui_theme_index_of_id(const char* theme_id);
+const char* ui_theme_default_id(void);
+int ui_theme_reload_external(const char* directory_path);
+unsigned long long ui_theme_external_signature(const char* directory_path);
+int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_theme_id_size);
+int ui_theme_save_selected_id(const char* path, const char* theme_id);
 void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens);
 
 #endif /* GLDRAW_UI_UI_THEME_H */

--- a/include/ui/ui_theme.h
+++ b/include/ui/ui_theme.h
@@ -1,3 +1,15 @@
+/**
+ * @file ui_theme.h
+ * @brief Theme token definitions and load/apply interfaces.
+ *
+ * Role in project:
+ * - Defines color/spacing/radius animation tokens used by UI rendering.
+ * - Supports built-in themes and external theme file hot-reload.
+ *
+ * Module relationships:
+ * - Consumed by `ui_system` and `ui_menubar`.
+ * - Applies style values into Nuklear context.
+ */
 #ifndef GLDRAW_UI_UI_THEME_H
 #define GLDRAW_UI_UI_THEME_H
 
@@ -61,16 +73,27 @@ typedef struct UiThemeDescriptor {
     const char* label;
 } UiThemeDescriptor;
 
+/** Return default built-in theme tokens. */
 UiThemeTokens ui_theme_default_tokens(void);
+/** Resolve theme tokens by ID, falling back to default when missing. */
 UiThemeTokens ui_theme_tokens_for_id(const char* theme_id);
+/** Return total theme count (built-in + loaded custom). */
 int ui_theme_count(void);
+/** Return descriptor at index, or `NULL` when out of range. */
 const UiThemeDescriptor* ui_theme_descriptor_at(int index);
+/** Find index by theme ID, or `-1` when missing. */
 int ui_theme_index_of_id(const char* theme_id);
+/** Return default theme ID string. */
 const char* ui_theme_default_id(void);
+/** Reload external themes from directory; returns custom theme count. */
 int ui_theme_reload_external(const char* directory_path);
+/** Compute signature hash of external theme directory contents. */
 unsigned long long ui_theme_external_signature(const char* directory_path);
+/** Load selected theme ID from settings file. Returns 1 on success. */
 int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_theme_id_size);
+/** Save selected theme ID to settings file. Returns 1 on success. */
 int ui_theme_save_selected_id(const char* path, const char* theme_id);
+/** Apply tokens to Nuklear style tables. */
 void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens);
 
 #endif /* GLDRAW_UI_UI_THEME_H */

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -23,15 +23,8 @@ typedef struct {
     RenderSystem* renderer;
     UiSystem* ui;
     Vec2 cursor_screen;
+    int cursor_inside_canvas;
 } Application;
-
-/* Global application instance for menu actions */
-static Application* g_app = NULL;
-
-void* app_get_instance(void)
-{
-    return g_app;
-}
 
 static int app_workspace_save(Workspace* workspace, void* user_data);
 static int app_workspace_load(Workspace* workspace, void* user_data);
@@ -191,14 +184,169 @@ static ToolContext app_tool_context(Application* app)
     return context;
 }
 
+static RectF app_window_bounds(const Application* app)
+{
+    RectF bounds = {0.0f, 0.0f, 1.0f, 1.0f};
+
+    if (!app) {
+        return bounds;
+    }
+
+    bounds.w = (float)app->window.width;
+    bounds.h = (float)app->window.height;
+    if (bounds.w < 1.0f) {
+        bounds.w = 1.0f;
+    }
+    if (bounds.h < 1.0f) {
+        bounds.h = 1.0f;
+    }
+    return bounds;
+}
+
+static RectF app_clamp_rect_to_bounds(RectF rect, RectF bounds)
+{
+    float max_x = bounds.x + bounds.w;
+    float max_y = bounds.y + bounds.h;
+
+    if (rect.w < 0.0f) {
+        rect.w = 0.0f;
+    }
+    if (rect.h < 0.0f) {
+        rect.h = 0.0f;
+    }
+    if (rect.x < bounds.x) {
+        rect.w -= (bounds.x - rect.x);
+        rect.x = bounds.x;
+    }
+    if (rect.y < bounds.y) {
+        rect.h -= (bounds.y - rect.y);
+        rect.y = bounds.y;
+    }
+    if (rect.x > max_x) {
+        rect.x = max_x;
+    }
+    if (rect.y > max_y) {
+        rect.y = max_y;
+    }
+    if (rect.x + rect.w > max_x) {
+        rect.w = max_x - rect.x;
+    }
+    if (rect.y + rect.h > max_y) {
+        rect.h = max_y - rect.y;
+    }
+    if (rect.w < 0.0f) {
+        rect.w = 0.0f;
+    }
+    if (rect.h < 0.0f) {
+        rect.h = 0.0f;
+    }
+
+    return rect;
+}
+
+static int app_pointer_hits_canvas(const Application* app, Vec2 screen_pos)
+{
+    RectF canvas_bounds;
+
+    if (!app) {
+        return 1;
+    }
+
+    canvas_bounds = app->workspace.layout.canvas_content_bounds;
+    if (canvas_bounds.w <= 1.0f || canvas_bounds.h <= 1.0f) {
+        canvas_bounds = app_window_bounds(app);
+    }
+
+    return rectf_contains_point(&canvas_bounds, screen_pos);
+}
+
+static int app_pointer_hits_ui_region(const Application* app, Vec2 screen_pos)
+{
+    const WorkspaceLayout* layout;
+    RectF window_bounds;
+    RectF appbar_bounds;
+    RectF rail_bounds;
+    RectF panel_bounds;
+    RectF status_bounds;
+
+    if (!app) {
+        return 0;
+    }
+
+    layout = &app->workspace.layout;
+    window_bounds = app_window_bounds(app);
+    appbar_bounds = app_clamp_rect_to_bounds(layout->appbar_bounds, window_bounds);
+    rail_bounds = app_clamp_rect_to_bounds(layout->rail_bounds, window_bounds);
+    panel_bounds = app_clamp_rect_to_bounds(layout->panel_bounds, window_bounds);
+    status_bounds = app_clamp_rect_to_bounds(layout->status_bounds, window_bounds);
+
+    return rectf_contains_point(&appbar_bounds, screen_pos) ||
+           rectf_contains_point(&rail_bounds, screen_pos) ||
+           rectf_contains_point(&panel_bounds, screen_pos) ||
+           rectf_contains_point(&status_bounds, screen_pos);
+}
+
+static int app_pointer_blocks_canvas(const Application* app, Vec2 screen_pos)
+{
+    if (!app) {
+        return 0;
+    }
+
+    if (app->ui && ui_system_has_active_interaction(app->ui)) {
+        return 1;
+    }
+
+    return app_pointer_hits_ui_region(app, screen_pos) ||
+           !app_pointer_hits_canvas(app, screen_pos);
+}
+
+static void app_sync_tool_pointer_anchor(Application* app)
+{
+    if (!app) {
+        return;
+    }
+
+    app->workspace.tools.last_screen = app->cursor_screen;
+    app->workspace.tools.last_world =
+        canvas_view_screen_to_world(&app->workspace.canvas, app->cursor_screen);
+}
+
+static void app_sync_canvas_boundary(Application* app)
+{
+    int inside_canvas = 0;
+
+    if (!app || app->workspace.tools.pointer_captured) {
+        return;
+    }
+
+    inside_canvas = app_pointer_hits_canvas(app, app->cursor_screen);
+    if (inside_canvas != app->cursor_inside_canvas) {
+        app->cursor_inside_canvas = inside_canvas;
+        app_sync_tool_pointer_anchor(app);
+    }
+}
+
 static void update_canvas_viewport(Application* app)
 {
+    RectF window_bounds;
     RectF viewport;
-    viewport.x = 0.0f;
-    viewport.y = 0.0f;
-    viewport.w = (float)app->window.width;
-    viewport.h = (float)app->window.height;
+
+    if (!app) {
+        return;
+    }
+
+    window_bounds = app_window_bounds(app);
+    viewport = app_clamp_rect_to_bounds(app->workspace.layout.canvas_content_bounds, window_bounds);
+    if (viewport.w <= 1.0f || viewport.h <= 1.0f) {
+        viewport = window_bounds;
+    }
+
+    if (app->ui) {
+        app->workspace.canvas.background = ui_system_canvas_background(app->ui);
+    }
+
     canvas_view_set_viewport(&app->workspace.canvas, viewport);
+    app_sync_canvas_boundary(app);
 }
 
 static ToolEvent make_tool_event(Application* app, int button, int mods, float wheel_y)
@@ -237,13 +385,15 @@ static void cursor_pos_callback(GLFWwindow* handle, double xpos, double ypos)
     }
 
     app->cursor_screen = vec2_make((float)xpos, (float)ypos);
-    context = app_tool_context(app);
-    event = make_tool_event(app, -1, 0, 0.0f);
+    app_sync_canvas_boundary(app);
 
     if (!app->workspace.tools.pointer_captured &&
-        ui_system_blocks_pointer(app->ui, app->cursor_screen)) {
+        app_pointer_blocks_canvas(app, app->cursor_screen)) {
         return;
     }
+
+    context = app_tool_context(app);
+    event = make_tool_event(app, -1, 0, 0.0f);
 
     tool_controller_pointer_move(&app->workspace.tools, &context, &event);
 }
@@ -258,16 +408,23 @@ static void mouse_button_callback(GLFWwindow* handle, int button, int action, in
         return;
     }
 
-    context = app_tool_context(app);
-    event = make_tool_event(app, button, mods, 0.0f);
-
     if (action == GLFW_PRESS) {
         if (!app->workspace.tools.pointer_captured &&
-            ui_system_blocks_pointer(app->ui, app->cursor_screen)) {
+            app_pointer_blocks_canvas(app, app->cursor_screen)) {
             return;
         }
+        context = app_tool_context(app);
+        event = make_tool_event(app, button, mods, 0.0f);
         tool_controller_pointer_down(&app->workspace.tools, &context, &event);
     } else if (action == GLFW_RELEASE) {
+        if (!app->workspace.tools.pointer_captured) {
+            if (app_pointer_blocks_canvas(app, app->cursor_screen)) {
+                return;
+            }
+            return;
+        }
+        context = app_tool_context(app);
+        event = make_tool_event(app, button, mods, 0.0f);
         tool_controller_pointer_up(&app->workspace.tools, &context, &event);
     }
 }
@@ -344,7 +501,8 @@ static void scroll_callback(GLFWwindow* handle, double xoffset, double yoffset)
         return;
     }
 
-    if (ui_system_blocks_pointer(app->ui, app->cursor_screen)) {
+    if (!app->workspace.tools.pointer_captured &&
+        app_pointer_blocks_canvas(app, app->cursor_screen)) {
         return;
     }
 
@@ -355,8 +513,6 @@ static void scroll_callback(GLFWwindow* handle, double xoffset, double yoffset)
 static int app_init(Application* app)
 {
     RectF viewport = {0.0f, 0.0f, 1440.0f, 900.0f};
-
-    g_app = app;
 
     if (platform_window_init(&app->window, 1440, 900, "GLDraw Canvas") != 0) {
         LOG_ERROR("%s", "Failed to create window");
@@ -376,6 +532,8 @@ static int app_init(Application* app)
     app->workspace.command_user_data = app;
     workspace_mark_saved(&app->workspace);
     app_set_status(app, "Initializing editor");
+    app->cursor_screen = vec2_make(app->window.width * 0.5f, app->window.height * 0.5f);
+    app->cursor_inside_canvas = 1;
 
     app->renderer = render_system_create(&app->window);
     if (!app->renderer) {
@@ -399,7 +557,8 @@ static int app_init(Application* app)
 
     render_system_resize(app->renderer, app->window.width, app->window.height);
     update_canvas_viewport(app);
-    app->cursor_screen = vec2_make(app->window.width * 0.5f, app->window.height * 0.5f);
+    app->cursor_inside_canvas = app_pointer_hits_canvas(app, app->cursor_screen);
+    app_sync_tool_pointer_anchor(app);
     app_open_startup_document(app);
     return 0;
 }
@@ -409,8 +568,6 @@ static void app_shutdown(Application* app)
     if (!app) {
         return;
     }
-
-    g_app = NULL;
 
     ui_system_destroy(app->ui);
     render_system_destroy(app->renderer);
@@ -439,6 +596,7 @@ int app_run(void)
         platform_window_poll_events();
         ui_system_begin_frame(app->ui);
         ui_system_build(app->ui, &app->workspace);
+        update_canvas_viewport(app);
         render_system_draw(app->renderer,
                            &app->workspace.document,
                            &app->workspace.canvas,

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -529,6 +529,11 @@ static void mouse_button_callback(GLFWwindow* handle, int button, int action, in
 
 /**
  * @brief GLFW key callback for global shortcuts and active-tool keys.
+ * @param handle [in] GLFW window handle.
+ * @param key [in] Virtual key code.
+ * @param scancode [in] Platform-specific scan code (unused).
+ * @param action [in] Press/release/repeat.
+ * @param mods [in] Modifier key flags.
  *
  * Why shortcut-first:
  * - Global document/view commands must win over tool-specific key handlers
@@ -677,7 +682,15 @@ static int app_init(Application* app)
     return 0;
 }
 
-/** Shutdown runtime subsystems in reverse ownership order. */
+/**
+ * @brief Shutdown runtime subsystems in reverse ownership order.
+ * @param app [in,out] Application state to tear down; safe no-op when `NULL`.
+ * @return None.
+ *
+ * Risk note:
+ * - Best-effort cleanup; destruction order mirrors `app_init()` to avoid
+ *   dangling references to already-destroyed subsystems.
+ */
 static void app_shutdown(Application* app)
 {
     if (!app) {

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -1,3 +1,15 @@
+/**
+ * @file application.c
+ * @brief Runtime bootstrap, event wiring, and main loop orchestration.
+ *
+ * Role in project:
+ * - Owns application lifetime from initialization to shutdown.
+ * - Bridges GLFW events into tool/document/canvas operations.
+ *
+ * Module relationships:
+ * - Uses workspace as central state container.
+ * - Coordinates platform window, render system, UI system, tools, and persistence.
+ */
 #include <app/application.h>
 
 #include <app/workspace.h>
@@ -29,6 +41,20 @@ typedef struct {
 static int app_workspace_save(Workspace* workspace, void* user_data);
 static int app_workspace_load(Workspace* workspace, void* user_data);
 
+/**
+ * @brief Write formatted status text into workspace status buffer.
+ * @param app [in,out] Application state.
+ * @param fmt [in] `printf`-style format string.
+ * @param ... [in] Format arguments.
+ * @return None.
+ *
+ * Edge cases:
+ * - Safe no-op when `app` or `fmt` is null.
+ *
+ * Risk note:
+ * - Uses `vsnprintf` with explicit buffer size to avoid overflow.
+ * Time complexity: `O(L)` where `L` is formatted output length.
+ */
 static void app_set_status(Application* app, const char* fmt, ...)
 {
     va_list args;
@@ -45,6 +71,7 @@ static void app_set_status(Application* app, const char* fmt, ...)
     va_end(args);
 }
 
+/** Check if file exists by opening it in read-binary mode. Complexity: `O(1)` (metadata + open). */
 static int app_file_exists(const char* path)
 {
     FILE* file = NULL;
@@ -62,11 +89,13 @@ static int app_file_exists(const char* path)
     return 1;
 }
 
+/** Return fallback document path used when workspace path is empty. Complexity: `O(1)`. */
 static const char* app_default_document_path(void)
 {
     return "document.json";
 }
 
+/** Resolve active document path (workspace path or default). Complexity: `O(1)`. */
 static const char* app_current_document_path(const Application* app)
 {
     if (app->workspace.current_document_path[0] != '\0') {
@@ -75,6 +104,16 @@ static const char* app_current_document_path(const Application* app)
     return app_default_document_path();
 }
 
+/**
+ * @brief Copy document path into workspace path buffer.
+ * @param app [in,out] Application state.
+ * @param path [in] Source path string.
+ * @return None.
+ *
+ * Risk note:
+ * - Uses bounded copy and forced NUL termination.
+ * Time complexity: `O(min(len(path), capacity))`.
+ */
 static void app_set_document_path(Application* app, const char* path)
 {
     if (!app || !path) {
@@ -87,6 +126,7 @@ static void app_set_document_path(Application* app, const char* path)
     app->workspace.current_document_path[sizeof(app->workspace.current_document_path) - 1u] = '\0';
 }
 
+/** Reset tool controller runtime state after major document changes. Complexity: `O(tool_count)`. */
 static void app_reset_tool_state(Application* app)
 {
     if (!app) {
@@ -97,6 +137,16 @@ static void app_reset_tool_state(Application* app)
     tool_controller_init(&app->workspace.tools);
 }
 
+/**
+ * @brief Save current document to JSON and refresh dirty tracking.
+ * @param app [in,out] Application state.
+ * @return `1` on success, `0` on persistence failure.
+ *
+ * Edge cases:
+ * - Fails if serializer or file I/O fails.
+ *
+ * Time complexity: dominated by serialization, roughly `O(object_count)`.
+ */
 static int app_save_document(Application* app)
 {
     const char* path = app_current_document_path(app);
@@ -114,6 +164,17 @@ static int app_save_document(Application* app)
     return 1;
 }
 
+/**
+ * @brief Load document from current path and reset dependent runtime state.
+ * @param app [in,out] Application state.
+ * @return `1` on success, `0` on missing file/parse/init failure.
+ *
+ * Why this structure:
+ * - History and tool state are rebuilt after load so stale snapshots/pointers
+ *   cannot reference objects from the previous document.
+ *
+ * Time complexity: dominated by parse/build, roughly `O(file_size + object_count)`.
+ */
 static int app_load_document(Application* app)
 {
     const char* path = app_current_document_path(app);
@@ -130,6 +191,8 @@ static int app_load_document(Application* app)
         return 0;
     }
 
+    /* Rebuild history against the newly loaded object graph.
+       Reusing old snapshots would leave dangling object pointers. */
     document_history_shutdown(&app->workspace.history);
     if (!document_history_init(&app->workspace.history)) {
         LOG_ERROR("%s", "Failed to reinitialize history after document load");
@@ -144,18 +207,21 @@ static int app_load_document(Application* app)
     return 1;
 }
 
+/** Workspace save callback adapter. Complexity: same as `app_save_document`. */
 static int app_workspace_save(Workspace* workspace, void* user_data)
 {
     (void)workspace;
     return app_save_document((Application*)user_data);
 }
 
+/** Workspace load callback adapter. Complexity: same as `app_load_document`. */
 static int app_workspace_load(Workspace* workspace, void* user_data)
 {
     (void)workspace;
     return app_load_document((Application*)user_data);
 }
 
+/** Load startup document if present; otherwise keep empty document. Complexity: `O(file_size)` when file exists. */
 static void app_open_startup_document(Application* app)
 {
     const char* path = app_current_document_path(app);
@@ -174,6 +240,7 @@ static void app_open_startup_document(Application* app)
     app_set_status(app, "New empty document");
 }
 
+/** Build tool context struct from application-owned workspace pointers. Complexity: `O(1)`. */
 static ToolContext app_tool_context(Application* app)
 {
     ToolContext context;
@@ -184,6 +251,7 @@ static ToolContext app_tool_context(Application* app)
     return context;
 }
 
+/** Compute window bounds as non-empty rectangle to avoid zero-size math. Complexity: `O(1)`. */
 static RectF app_window_bounds(const Application* app)
 {
     RectF bounds = {0.0f, 0.0f, 1.0f, 1.0f};
@@ -203,6 +271,16 @@ static RectF app_window_bounds(const Application* app)
     return bounds;
 }
 
+/**
+ * @brief Clamp rectangle to window bounds.
+ * @return Clamped rectangle with non-negative size.
+ *
+ * Why:
+ * - UI layout can briefly produce out-of-window values during resize/animation.
+ *   Clamping prevents invalid viewport/scissor calculations downstream.
+ *
+ * Complexity: `O(1)`.
+ */
 static RectF app_clamp_rect_to_bounds(RectF rect, RectF bounds)
 {
     float max_x = bounds.x + bounds.w;
@@ -244,6 +322,7 @@ static RectF app_clamp_rect_to_bounds(RectF rect, RectF bounds)
     return rect;
 }
 
+/** Test whether a screen point lies in current canvas content region. Complexity: `O(1)`. */
 static int app_pointer_hits_canvas(const Application* app, Vec2 screen_pos)
 {
     RectF canvas_bounds;
@@ -260,6 +339,7 @@ static int app_pointer_hits_canvas(const Application* app, Vec2 screen_pos)
     return rectf_contains_point(&canvas_bounds, screen_pos);
 }
 
+/** Test whether a screen point lies in UI chrome regions (menu/rail/panel/status). Complexity: `O(1)`. */
 static int app_pointer_hits_ui_region(const Application* app, Vec2 screen_pos)
 {
     const WorkspaceLayout* layout;
@@ -286,6 +366,15 @@ static int app_pointer_hits_ui_region(const Application* app, Vec2 screen_pos)
            rectf_contains_point(&status_bounds, screen_pos);
 }
 
+/**
+ * @brief Decide whether pointer input should be blocked from canvas tools.
+ * @return Non-zero when UI interaction or non-canvas regions should consume input.
+ *
+ * Why:
+ * - Prevents accidental drawing/selection while interacting with UI widgets.
+ *
+ * Complexity: `O(1)`.
+ */
 static int app_pointer_blocks_canvas(const Application* app, Vec2 screen_pos)
 {
     if (!app) {
@@ -300,6 +389,7 @@ static int app_pointer_blocks_canvas(const Application* app, Vec2 screen_pos)
            !app_pointer_hits_canvas(app, screen_pos);
 }
 
+/** Sync tool controller's last pointer anchor with current cursor state. Complexity: `O(1)`. */
 static void app_sync_tool_pointer_anchor(Application* app)
 {
     if (!app) {
@@ -311,6 +401,7 @@ static void app_sync_tool_pointer_anchor(Application* app)
         canvas_view_screen_to_world(&app->workspace.canvas, app->cursor_screen);
 }
 
+/** Refresh cursor-in-canvas flag for uncaptured pointer movement. Complexity: `O(1)`. */
 static void app_sync_canvas_boundary(Application* app)
 {
     int inside_canvas = 0;
@@ -326,6 +417,7 @@ static void app_sync_canvas_boundary(Application* app)
     }
 }
 
+/** Update canvas viewport and theme background from latest UI layout. Complexity: `O(1)`. */
 static void update_canvas_viewport(Application* app)
 {
     RectF window_bounds;
@@ -349,6 +441,7 @@ static void update_canvas_viewport(Application* app)
     app_sync_canvas_boundary(app);
 }
 
+/** Build a `ToolEvent` from current cursor and previous anchor state. Complexity: `O(1)`. */
 static ToolEvent make_tool_event(Application* app, int button, int mods, float wheel_y)
 {
     ToolEvent event;
@@ -362,6 +455,7 @@ static ToolEvent make_tool_event(Application* app, int button, int mods, float w
     return event;
 }
 
+/** GLFW framebuffer resize callback: update viewport and renderer dimensions. */
 static void framebuffer_size_callback(GLFWwindow* handle, int width, int height)
 {
     Application* app = (Application*)glfwGetWindowUserPointer(handle);
@@ -374,6 +468,7 @@ static void framebuffer_size_callback(GLFWwindow* handle, int width, int height)
     render_system_resize(app->renderer, width, height);
 }
 
+/** GLFW cursor callback: route pointer-move to active tool when canvas is interactive. */
 static void cursor_pos_callback(GLFWwindow* handle, double xpos, double ypos)
 {
     Application* app = (Application*)glfwGetWindowUserPointer(handle);
@@ -398,6 +493,7 @@ static void cursor_pos_callback(GLFWwindow* handle, double xpos, double ypos)
     tool_controller_pointer_move(&app->workspace.tools, &context, &event);
 }
 
+/** GLFW mouse callback: route press/release with pointer capture semantics. */
 static void mouse_button_callback(GLFWwindow* handle, int button, int action, int mods)
 {
     Application* app = (Application*)glfwGetWindowUserPointer(handle);
@@ -417,6 +513,8 @@ static void mouse_button_callback(GLFWwindow* handle, int button, int action, in
         event = make_tool_event(app, button, mods, 0.0f);
         tool_controller_pointer_down(&app->workspace.tools, &context, &event);
     } else if (action == GLFW_RELEASE) {
+        /* Ignore release outside canvas unless we previously captured the pointer.
+           This keeps drag/end-state transitions consistent across window regions. */
         if (!app->workspace.tools.pointer_captured) {
             if (app_pointer_blocks_canvas(app, app->cursor_screen)) {
                 return;
@@ -429,6 +527,13 @@ static void mouse_button_callback(GLFWwindow* handle, int button, int action, in
     }
 }
 
+/**
+ * @brief GLFW key callback for global shortcuts and active-tool keys.
+ *
+ * Why shortcut-first:
+ * - Global document/view commands must win over tool-specific key handlers
+ *   for predictable editor behavior.
+ */
 static void key_callback(GLFWwindow* handle, int key, int scancode, int action, int mods)
 {
     Application* app = (Application*)glfwGetWindowUserPointer(handle);
@@ -491,6 +596,7 @@ static void key_callback(GLFWwindow* handle, int key, int scancode, int action, 
     tool_controller_key_down(&app->workspace.tools, &context, key, mods);
 }
 
+/** GLFW scroll callback: zoom canvas at cursor unless blocked by UI. */
 static void scroll_callback(GLFWwindow* handle, double xoffset, double yoffset)
 {
     Application* app = (Application*)glfwGetWindowUserPointer(handle);
@@ -510,6 +616,14 @@ static void scroll_callback(GLFWwindow* handle, double xoffset, double yoffset)
     tool_controller_scroll(&app->workspace.tools, &context, app->cursor_screen, (float)yoffset);
 }
 
+/**
+ * @brief Initialize all runtime subsystems in dependency order.
+ * @return `0` on success, `-1` on failure.
+ *
+ * Risk note:
+ * - This function has multiple allocation/init branches; each failure path must
+ *   leave state safe for `app_shutdown()` best-effort cleanup.
+ */
 static int app_init(Application* app)
 {
     RectF viewport = {0.0f, 0.0f, 1440.0f, 900.0f};
@@ -563,6 +677,7 @@ static int app_init(Application* app)
     return 0;
 }
 
+/** Shutdown runtime subsystems in reverse ownership order. */
 static void app_shutdown(Application* app)
 {
     if (!app) {
@@ -577,6 +692,13 @@ static void app_shutdown(Application* app)
     platform_window_shutdown(&app->window);
 }
 
+/**
+ * @brief Application entry implementation called by `main`.
+ * @return `0` on normal shutdown, `-1` on fatal startup failure.
+ *
+ * Time complexity:
+ * - Main loop performs per-frame `O(object_count + ui_work)` operations.
+ */
 int app_run(void)
 {
     Application* app = (Application*)calloc(1, sizeof(*app));

--- a/src/canvas/canvas_view.c
+++ b/src/canvas/canvas_view.c
@@ -4,6 +4,103 @@
 
 #include <stddef.h>
 
+static CanvasViewportState canvas_viewport_state_from_compat(const CanvasView* canvas)
+{
+    CanvasViewportState state;
+    state.viewport.x = 0.0f;
+    state.viewport.y = 0.0f;
+    state.viewport.w = 0.0f;
+    state.viewport.h = 0.0f;
+    state.center = vec2_make(0.0f, 0.0f);
+    state.zoom = 1.0f;
+
+    if (!canvas) {
+        return state;
+    }
+
+    state.viewport = canvas->viewport;
+    state.center = canvas->center;
+    state.zoom = (canvas->zoom > 0.0f) ? canvas->zoom : 1.0f;
+    return state;
+}
+
+static void canvas_view_sync_compat(CanvasView* canvas)
+{
+    if (!canvas) {
+        return;
+    }
+
+    canvas->viewport = canvas->viewport_state.viewport;
+    canvas->center = canvas->viewport_state.center;
+    canvas->zoom = canvas->viewport_state.zoom;
+}
+
+static Vec2 canvas_viewport_world_to_screen(const CanvasViewportState* state, Vec2 world)
+{
+    Vec2 screen = {0.0f, 0.0f};
+
+    if (!state) {
+        return screen;
+    }
+
+    screen.x = state->viewport.x + (state->viewport.w * 0.5f) + (world.x - state->center.x) * state->zoom;
+    screen.y = state->viewport.y + (state->viewport.h * 0.5f) - (world.y - state->center.y) * state->zoom;
+    return screen;
+}
+
+static Vec2 canvas_viewport_screen_to_world(const CanvasViewportState* state, Vec2 screen)
+{
+    Vec2 world = {0.0f, 0.0f};
+
+    if (!state || state->zoom <= 0.0f) {
+        return world;
+    }
+
+    world.x = state->center.x + (screen.x - (state->viewport.x + state->viewport.w * 0.5f)) / state->zoom;
+    world.y = state->center.y - (screen.y - (state->viewport.y + state->viewport.h * 0.5f)) / state->zoom;
+    return world;
+}
+
+static void canvas_viewport_pan_screen_delta(CanvasViewportState* state, Vec2 delta_screen)
+{
+    if (!state || state->zoom <= 0.0f) {
+        return;
+    }
+
+    state->center.x -= delta_screen.x / state->zoom;
+    state->center.y += delta_screen.y / state->zoom;
+}
+
+static void canvas_viewport_zoom_at_screen_point(CanvasViewportState* state, float factor, Vec2 screen_anchor)
+{
+    Vec2 before = {0.0f, 0.0f};
+    Vec2 after = {0.0f, 0.0f};
+
+    if (!state || factor <= 0.0f) {
+        return;
+    }
+
+    before = canvas_viewport_screen_to_world(state, screen_anchor);
+    state->zoom = clampf(state->zoom * factor, 0.1f, 12.0f);
+    after = canvas_viewport_screen_to_world(state, screen_anchor);
+    state->center = vec2_add(state->center, vec2_sub(before, after));
+}
+
+static RectF canvas_viewport_visible_world_rect(const CanvasViewportState* state)
+{
+    RectF rect = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    if (!state || state->zoom <= 0.0f) {
+        return rect;
+    }
+
+    rect.w = state->viewport.w / state->zoom;
+    rect.h = state->viewport.h / state->zoom;
+    rect.x = state->center.x - rect.w * 0.5f;
+    rect.y = state->center.y - rect.h * 0.5f;
+    return rect;
+}
+
 void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport)
 {
     if (!canvas) {
@@ -11,13 +108,14 @@ void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport)
     }
 
     canvas->document = document;
-    canvas->viewport = viewport;
-    canvas->center = vec2_make(0.0f, 0.0f);
-    canvas->zoom = 1.0f;
+    canvas->viewport_state.viewport = viewport;
+    canvas->viewport_state.center = vec2_make(0.0f, 0.0f);
+    canvas->viewport_state.zoom = 1.0f;
+    canvas_view_sync_compat(canvas);
     canvas->show_grid = 1;
-    canvas->background.r = 0.11f;
-    canvas->background.g = 0.12f;
-    canvas->background.b = 0.14f;
+    canvas->background.r = 218.0f / 255.0f;
+    canvas->background.g = 226.0f / 255.0f;
+    canvas->background.b = 236.0f / 255.0f;
     canvas->background.a = 1.0f;
 }
 
@@ -30,80 +128,131 @@ void canvas_view_set_document(CanvasView* canvas, Document* document)
 
 void canvas_view_set_viewport(CanvasView* canvas, RectF viewport)
 {
-    if (canvas) {
-        canvas->viewport = viewport;
+    CanvasViewportState state;
+
+    if (!canvas) {
+        return;
     }
+
+    state = canvas_viewport_state_from_compat(canvas);
+    state.viewport = viewport;
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
+}
+
+void canvas_view_set_center(CanvasView* canvas, Vec2 center)
+{
+    CanvasViewportState state;
+
+    if (!canvas) {
+        return;
+    }
+
+    state = canvas_viewport_state_from_compat(canvas);
+    state.center = center;
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
+}
+
+void canvas_view_set_zoom(CanvasView* canvas, float zoom)
+{
+    CanvasViewportState state;
+
+    if (!canvas) {
+        return;
+    }
+
+    state = canvas_viewport_state_from_compat(canvas);
+    state.zoom = clampf(zoom, 0.1f, 12.0f);
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
+}
+
+void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom)
+{
+    CanvasViewportState state;
+
+    if (!canvas) {
+        return;
+    }
+
+    state = canvas_viewport_state_from_compat(canvas);
+    state.center = center;
+    state.zoom = clampf(zoom, 0.1f, 12.0f);
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
+}
+
+RectF canvas_view_viewport(const CanvasView* canvas)
+{
+    return canvas_viewport_state_from_compat(canvas).viewport;
+}
+
+Vec2 canvas_view_center(const CanvasView* canvas)
+{
+    return canvas_viewport_state_from_compat(canvas).center;
+}
+
+float canvas_view_zoom(const CanvasView* canvas)
+{
+    return canvas_viewport_state_from_compat(canvas).zoom;
 }
 
 Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world)
 {
-    Vec2 screen = {0.0f, 0.0f};
-    if (!canvas) {
-        return screen;
-    }
-
-    screen.x = canvas->viewport.x + (canvas->viewport.w * 0.5f) + (world.x - canvas->center.x) * canvas->zoom;
-    screen.y = canvas->viewport.y + (canvas->viewport.h * 0.5f) - (world.y - canvas->center.y) * canvas->zoom;
-    return screen;
+    CanvasViewportState state = canvas_viewport_state_from_compat(canvas);
+    return canvas_viewport_world_to_screen(&state, world);
 }
 
 Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen)
 {
-    Vec2 world = {0.0f, 0.0f};
-    if (!canvas || canvas->zoom <= 0.0f) {
-        return world;
-    }
-
-    world.x = canvas->center.x + (screen.x - (canvas->viewport.x + canvas->viewport.w * 0.5f)) / canvas->zoom;
-    world.y = canvas->center.y - (screen.y - (canvas->viewport.y + canvas->viewport.h * 0.5f)) / canvas->zoom;
-    return world;
+    CanvasViewportState state = canvas_viewport_state_from_compat(canvas);
+    return canvas_viewport_screen_to_world(&state, screen);
 }
 
 void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen)
 {
-    if (!canvas || canvas->zoom <= 0.0f) {
+    CanvasViewportState state;
+
+    if (!canvas) {
         return;
     }
 
-    canvas->center.x -= delta_screen.x / canvas->zoom;
-    canvas->center.y += delta_screen.y / canvas->zoom;
+    state = canvas_viewport_state_from_compat(canvas);
+    canvas_viewport_pan_screen_delta(&state, delta_screen);
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
 }
 
 void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 screen_anchor)
 {
-    Vec2 before = {0.0f, 0.0f};
-    Vec2 after = {0.0f, 0.0f};
+    CanvasViewportState state;
 
-    if (!canvas || factor <= 0.0f) {
+    if (!canvas) {
         return;
     }
 
-    before = canvas_view_screen_to_world(canvas, screen_anchor);
-    canvas->zoom = clampf(canvas->zoom * factor, 0.1f, 12.0f);
-    after = canvas_view_screen_to_world(canvas, screen_anchor);
-    canvas->center = vec2_add(canvas->center, vec2_sub(before, after));
+    state = canvas_viewport_state_from_compat(canvas);
+    canvas_viewport_zoom_at_screen_point(&state, factor, screen_anchor);
+    canvas->viewport_state = state;
+    canvas_view_sync_compat(canvas);
 }
 
 float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pixels)
 {
-    if (!canvas || canvas->zoom <= 0.0f) {
+    float zoom = canvas_view_zoom(canvas);
+
+    if (zoom <= 0.0f) {
         return pixels;
     }
-    return pixels / canvas->zoom;
+
+    return pixels / zoom;
 }
 
 RectF canvas_view_visible_world_rect(const CanvasView* canvas)
 {
-    RectF rect = {0.0f, 0.0f, 0.0f, 0.0f};
-    if (!canvas || canvas->zoom <= 0.0f) {
-        return rect;
-    }
-
-    rect.w = canvas->viewport.w / canvas->zoom;
-    rect.h = canvas->viewport.h / canvas->zoom;
-    rect.x = canvas->center.x - rect.w * 0.5f;
-    rect.y = canvas->center.y - rect.h * 0.5f;
-    return rect;
+    CanvasViewportState state = canvas_viewport_state_from_compat(canvas);
+    return canvas_viewport_visible_world_rect(&state);
 }
 
 GraphicObject* canvas_view_pick_object(const CanvasView* canvas, Vec2 screen_point, float tolerance_pixels)

--- a/src/canvas/canvas_view.c
+++ b/src/canvas/canvas_view.c
@@ -1,9 +1,22 @@
+/**
+ * @file canvas_view.c
+ * @brief Canvas camera state and coordinate conversion implementation.
+ *
+ * Role in project:
+ * - Implements viewport/center/zoom updates and world/screen transforms.
+ * - Provides object picking against document geometry.
+ *
+ * Module relationships:
+ * - Uses `document` for object iteration and hit-testing.
+ * - Consumed by tools, renderer, and application input routing.
+ */
 #include <canvas/canvas_view.h>
 
 #include <base/math2d.h>
 
 #include <stddef.h>
 
+/** Build canonical viewport state from compatibility fields. Complexity: `O(1)`. */
 static CanvasViewportState canvas_viewport_state_from_compat(const CanvasView* canvas)
 {
     CanvasViewportState state;
@@ -24,6 +37,7 @@ static CanvasViewportState canvas_viewport_state_from_compat(const CanvasView* c
     return state;
 }
 
+/** Mirror canonical state back to legacy compatibility fields. Complexity: `O(1)`. */
 static void canvas_view_sync_compat(CanvasView* canvas)
 {
     if (!canvas) {
@@ -35,6 +49,7 @@ static void canvas_view_sync_compat(CanvasView* canvas)
     canvas->zoom = canvas->viewport_state.zoom;
 }
 
+/** Transform world point to screen coordinates. Complexity: `O(1)`. */
 static Vec2 canvas_viewport_world_to_screen(const CanvasViewportState* state, Vec2 world)
 {
     Vec2 screen = {0.0f, 0.0f};
@@ -48,6 +63,7 @@ static Vec2 canvas_viewport_world_to_screen(const CanvasViewportState* state, Ve
     return screen;
 }
 
+/** Transform screen point to world coordinates. Complexity: `O(1)`. */
 static Vec2 canvas_viewport_screen_to_world(const CanvasViewportState* state, Vec2 screen)
 {
     Vec2 world = {0.0f, 0.0f};
@@ -61,6 +77,7 @@ static Vec2 canvas_viewport_screen_to_world(const CanvasViewportState* state, Ve
     return world;
 }
 
+/** Pan center by screen delta while preserving zoom mapping. Complexity: `O(1)`. */
 static void canvas_viewport_pan_screen_delta(CanvasViewportState* state, Vec2 delta_screen)
 {
     if (!state || state->zoom <= 0.0f) {
@@ -71,6 +88,19 @@ static void canvas_viewport_pan_screen_delta(CanvasViewportState* state, Vec2 de
     state->center.y += delta_screen.y / state->zoom;
 }
 
+/**
+ * @brief Zoom around a screen anchor while keeping anchor's world point fixed.
+ * @param state [in,out] View state.
+ * @param factor [in] Multiplicative zoom factor.
+ * @param screen_anchor [in] Anchor in screen coordinates.
+ * @return None.
+ *
+ * Why:
+ * - Recomputes world point before/after zoom and shifts center by the delta.
+ *   This gives "zoom toward cursor" behavior instead of zooming to viewport center.
+ *
+ * Complexity: `O(1)`.
+ */
 static void canvas_viewport_zoom_at_screen_point(CanvasViewportState* state, float factor, Vec2 screen_anchor)
 {
     Vec2 before = {0.0f, 0.0f};
@@ -86,6 +116,7 @@ static void canvas_viewport_zoom_at_screen_point(CanvasViewportState* state, flo
     state->center = vec2_add(state->center, vec2_sub(before, after));
 }
 
+/** Compute visible world-space rectangle from viewport and zoom. Complexity: `O(1)`. */
 static RectF canvas_viewport_visible_world_rect(const CanvasViewportState* state)
 {
     RectF rect = {0.0f, 0.0f, 0.0f, 0.0f};
@@ -101,6 +132,7 @@ static RectF canvas_viewport_visible_world_rect(const CanvasViewportState* state
     return rect;
 }
 
+/** Initialize canvas defaults and bind document. Complexity: `O(1)`. */
 void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport)
 {
     if (!canvas) {
@@ -119,6 +151,7 @@ void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport)
     canvas->background.a = 1.0f;
 }
 
+/** Rebind document pointer. Complexity: `O(1)`. */
 void canvas_view_set_document(CanvasView* canvas, Document* document)
 {
     if (canvas) {
@@ -126,6 +159,7 @@ void canvas_view_set_document(CanvasView* canvas, Document* document)
     }
 }
 
+/** Set viewport rectangle. Complexity: `O(1)`. */
 void canvas_view_set_viewport(CanvasView* canvas, RectF viewport)
 {
     CanvasViewportState state;
@@ -140,6 +174,7 @@ void canvas_view_set_viewport(CanvasView* canvas, RectF viewport)
     canvas_view_sync_compat(canvas);
 }
 
+/** Set world center. Complexity: `O(1)`. */
 void canvas_view_set_center(CanvasView* canvas, Vec2 center)
 {
     CanvasViewportState state;
@@ -154,6 +189,7 @@ void canvas_view_set_center(CanvasView* canvas, Vec2 center)
     canvas_view_sync_compat(canvas);
 }
 
+/** Set zoom with clamp. Complexity: `O(1)`. */
 void canvas_view_set_zoom(CanvasView* canvas, float zoom)
 {
     CanvasViewportState state;
@@ -168,6 +204,7 @@ void canvas_view_set_zoom(CanvasView* canvas, float zoom)
     canvas_view_sync_compat(canvas);
 }
 
+/** Set center and zoom together. Complexity: `O(1)`. */
 void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom)
 {
     CanvasViewportState state;
@@ -183,33 +220,39 @@ void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom)
     canvas_view_sync_compat(canvas);
 }
 
+/** Return viewport rectangle. Complexity: `O(1)`. */
 RectF canvas_view_viewport(const CanvasView* canvas)
 {
     return canvas_viewport_state_from_compat(canvas).viewport;
 }
 
+/** Return world center. Complexity: `O(1)`. */
 Vec2 canvas_view_center(const CanvasView* canvas)
 {
     return canvas_viewport_state_from_compat(canvas).center;
 }
 
+/** Return zoom factor. Complexity: `O(1)`. */
 float canvas_view_zoom(const CanvasView* canvas)
 {
     return canvas_viewport_state_from_compat(canvas).zoom;
 }
 
+/** Public world->screen conversion wrapper. Complexity: `O(1)`. */
 Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world)
 {
     CanvasViewportState state = canvas_viewport_state_from_compat(canvas);
     return canvas_viewport_world_to_screen(&state, world);
 }
 
+/** Public screen->world conversion wrapper. Complexity: `O(1)`. */
 Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen)
 {
     CanvasViewportState state = canvas_viewport_state_from_compat(canvas);
     return canvas_viewport_screen_to_world(&state, screen);
 }
 
+/** Pan camera from screen delta. Complexity: `O(1)`. */
 void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen)
 {
     CanvasViewportState state;
@@ -224,6 +267,7 @@ void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen)
     canvas_view_sync_compat(canvas);
 }
 
+/** Zoom camera around cursor/specified anchor. Complexity: `O(1)`. */
 void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 screen_anchor)
 {
     CanvasViewportState state;
@@ -238,6 +282,7 @@ void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 scr
     canvas_view_sync_compat(canvas);
 }
 
+/** Convert pixel tolerance to world units based on zoom. Complexity: `O(1)`. */
 float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pixels)
 {
     float zoom = canvas_view_zoom(canvas);
@@ -249,12 +294,22 @@ float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pix
     return pixels / zoom;
 }
 
+/** Get visible world rectangle. Complexity: `O(1)`. */
 RectF canvas_view_visible_world_rect(const CanvasView* canvas)
 {
     CanvasViewportState state = canvas_viewport_state_from_compat(canvas);
     return canvas_viewport_visible_world_rect(&state);
 }
 
+/**
+ * @brief Pick top-most object under a screen point.
+ * @return Pointer to hit object or `NULL`.
+ *
+ * Why reverse loop:
+ * - Newer objects are drawn later and visually on top, so picking scans from end.
+ *
+ * Time complexity: `O(n)` where `n` is document object count.
+ */
 GraphicObject* canvas_view_pick_object(const CanvasView* canvas, Vec2 screen_point, float tolerance_pixels)
 {
     Vec2 world_point = {0.0f, 0.0f};

--- a/src/canvas/canvas_view.c
+++ b/src/canvas/canvas_view.c
@@ -16,7 +16,7 @@
 
 #include <stddef.h>
 
-/** Build canonical viewport state from compatibility fields. Complexity: `O(1)`. */
+/** Build canonical viewport state from legacy compatibility fields. Complexity: `O(1)`. */
 static CanvasViewportState canvas_viewport_state_from_compat(const CanvasView* canvas)
 {
     CanvasViewportState state;

--- a/src/document/document.c
+++ b/src/document/document.c
@@ -1,7 +1,20 @@
+/**
+ * @file document.c
+ * @brief In-memory document storage and selection operations.
+ *
+ * Role in project:
+ * - Owns bounded object array and selection list mutation logic.
+ * - Maintains revision counters used for dirty tracking and history commits.
+ *
+ * Module relationships:
+ * - Uses object create/destroy helpers from `object.c`.
+ * - Used by tools, UI, history, persistence, and renderer.
+ */
 #include <document/document.h>
 
 #include <string.h>
 
+/** Initialize document fields to empty defaults. Complexity: `O(1)`. */
 void document_init(Document* document)
 {
     if (!document) {
@@ -13,6 +26,7 @@ void document_init(Document* document)
     document->revision = 1;
 }
 
+/** Destroy all objects and clear selection while preserving struct storage. Complexity: `O(n)`. */
 void document_shutdown(Document* document)
 {
     int i = 0;
@@ -31,6 +45,7 @@ void document_shutdown(Document* document)
     document->revision++;
 }
 
+/** Reset document to pristine empty state. Complexity: `O(n)`. */
 void document_reset(Document* document)
 {
     int i = 0;
@@ -50,6 +65,7 @@ void document_reset(Document* document)
     document->revision = 1;
 }
 
+/** Append object with auto-assigned ID. Complexity: `O(1)`. */
 int document_add_object(Document* document, GraphicObject* object)
 {
     if (!document || !object || document->count >= DOCUMENT_MAX_OBJECTS) {
@@ -62,6 +78,7 @@ int document_add_object(Document* document, GraphicObject* object)
     return 1;
 }
 
+/** Append object with explicit ID and duplicate check. Complexity: `O(n)`. */
 int document_append_object_with_id(Document* document, GraphicObject* object, ObjectId id)
 {
     if (!document || !object || id == 0 || document->count >= DOCUMENT_MAX_OBJECTS) {
@@ -81,6 +98,7 @@ int document_append_object_with_id(Document* document, GraphicObject* object, Ob
     return 1;
 }
 
+/** Find object by ID by linear scan. Complexity: `O(n)`. */
 GraphicObject* document_find_object(const Document* document, ObjectId id)
 {
     int i = 0;
@@ -98,6 +116,7 @@ GraphicObject* document_find_object(const Document* document, ObjectId id)
     return NULL;
 }
 
+/** Access object by index. Complexity: `O(1)`. */
 GraphicObject* document_get_object_at(const Document* document, int index)
 {
     if (!document || index < 0 || index >= document->count) {
@@ -106,6 +125,7 @@ GraphicObject* document_get_object_at(const Document* document, int index)
     return document->objects[index];
 }
 
+/** Check whether ID is in selection set. Complexity: `O(s)`. */
 int document_selection_contains(const Document* document, ObjectId id)
 {
     int i = 0;
@@ -123,6 +143,7 @@ int document_selection_contains(const Document* document, ObjectId id)
     return 0;
 }
 
+/** Clear selection count only (IDs remain irrelevant beyond count). Complexity: `O(1)`. */
 void document_clear_selection(Document* document)
 {
     if (document) {
@@ -130,6 +151,7 @@ void document_clear_selection(Document* document)
     }
 }
 
+/** Add ID to selection if missing and capacity permits. Complexity: `O(s)`. */
 int document_selection_add(Document* document, ObjectId id)
 {
     if (!document || id == 0) {
@@ -148,6 +170,7 @@ int document_selection_add(Document* document, ObjectId id)
     return 1;
 }
 
+/** Remove one ID from selection and compact array. Complexity: `O(s)`. */
 void document_selection_remove(Document* document, ObjectId id)
 {
     int i = 0;
@@ -168,6 +191,7 @@ void document_selection_remove(Document* document, ObjectId id)
     }
 }
 
+/** Toggle selection membership for ID. Complexity: `O(s)`. */
 void document_selection_toggle(Document* document, ObjectId id)
 {
     if (!document) {
@@ -181,6 +205,7 @@ void document_selection_toggle(Document* document, ObjectId id)
     }
 }
 
+/** Resolve first selected object. Complexity: `O(n)` due to ID lookup. */
 GraphicObject* document_primary_selection(const Document* document)
 {
     if (!document || document->selection.count <= 0) {
@@ -189,6 +214,7 @@ GraphicObject* document_primary_selection(const Document* document)
     return document_find_object(document, document->selection.ids[0]);
 }
 
+/** Remove object by ID, destroy it, and compact object array. Complexity: `O(n)`. */
 int document_remove_object(Document* document, ObjectId id)
 {
     int i = 0;
@@ -215,6 +241,15 @@ int document_remove_object(Document* document, ObjectId id)
     return 0;
 }
 
+/**
+ * @brief Delete all currently selected objects.
+ *
+ * Why copy IDs first:
+ * - Removing objects mutates selection/order, so direct iteration over
+ *   `selection.ids` while deleting would skip or misread entries.
+ *
+ * Complexity: up to `O(s*n)`.
+ */
 void document_delete_selection(Document* document)
 {
     ObjectId ids[DOCUMENT_MAX_SELECTION];
@@ -237,6 +272,7 @@ void document_delete_selection(Document* document)
     document_clear_selection(document);
 }
 
+/** Increment document revision marker. Complexity: `O(1)`. */
 void document_touch(Document* document)
 {
     if (document) {
@@ -244,6 +280,7 @@ void document_touch(Document* document)
     }
 }
 
+/** Return max object ID currently present. Complexity: `O(n)`. */
 ObjectId document_max_id(const Document* document)
 {
     ObjectId max_id = 0;

--- a/src/document/history.c
+++ b/src/document/history.c
@@ -330,7 +330,7 @@ int document_history_undo(DocumentHistory* history, Document* document)
     return 1;
 }
 
-/** Redo latest reverted transaction and move entry back to undo stack. Complexity: `O(n + capacity)` worst-case. */
+/** Redo latest undone transaction and move entry back to undo stack. Complexity: `O(n + capacity)` worst-case. */
 int document_history_redo(DocumentHistory* history, Document* document)
 {
     DocumentHistoryEntry entry;

--- a/src/document/history.c
+++ b/src/document/history.c
@@ -1,3 +1,15 @@
+/**
+ * @file history.c
+ * @brief Snapshot-based undo/redo implementation.
+ *
+ * Role in project:
+ * - Captures deep document snapshots before/after edits.
+ * - Applies snapshots for undo and redo with bounded stack capacity.
+ *
+ * Module relationships:
+ * - Depends on document/object cloning and destruction.
+ * - Called by tools/UI commit paths for user-visible edits.
+ */
 #include <document/history.h>
 
 #include <base/log.h>
@@ -5,6 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+/** Move snapshot ownership from `src` to `dst`. Complexity: `O(1)`. */
 static void snapshot_move(DocumentSnapshot* dst, DocumentSnapshot* src)
 {
     document_snapshot_free(dst);
@@ -17,12 +30,14 @@ static void snapshot_move(DocumentSnapshot* dst, DocumentSnapshot* src)
     src->selection.count = 0;
 }
 
+/** Free both snapshots in a history entry. Complexity: `O(n_before + n_after)`. */
 static void history_entry_free(DocumentHistoryEntry* entry)
 {
     document_snapshot_free(&entry->before);
     document_snapshot_free(&entry->after);
 }
 
+/** Reset history entry to empty snapshots. Complexity: `O(1)`. */
 static void history_entry_reset(DocumentHistoryEntry* entry)
 {
     if (!entry) {
@@ -33,6 +48,7 @@ static void history_entry_reset(DocumentHistoryEntry* entry)
     document_snapshot_init(&entry->after);
 }
 
+/** Allocate and initialize history entry array. Complexity: `O(capacity)`. */
 static DocumentHistoryEntry* history_alloc_entries(int capacity)
 {
     DocumentHistoryEntry* entries = NULL;
@@ -54,6 +70,12 @@ static DocumentHistoryEntry* history_alloc_entries(int capacity)
     return entries;
 }
 
+/**
+ * @brief Drop oldest entry from bounded stack.
+ * Why shift:
+ * - Keeps chronological order while enforcing fixed capacity.
+ * Complexity: `O(count)`.
+ */
 static void history_shift_left(DocumentHistoryEntry* entries, int* count)
 {
     int i = 0;
@@ -70,6 +92,16 @@ static void history_shift_left(DocumentHistoryEntry* entries, int* count)
     (*count)--;
 }
 
+/**
+ * @brief Replace document contents with deep-cloned snapshot objects.
+ * @return `1` on success, `0` on validation/allocation/clone failure.
+ *
+ * Risk note:
+ * - Uses temporary clone array first; document is only replaced after all clones
+ *   succeed, avoiding partial state corruption on failure.
+ *
+ * Complexity: `O(n)`.
+ */
 static int document_restore_snapshot(Document* document, const DocumentSnapshot* snapshot)
 {
     GraphicObject** clones = NULL;
@@ -114,6 +146,7 @@ static int document_restore_snapshot(Document* document, const DocumentSnapshot*
     return 1;
 }
 
+/** Initialize snapshot to zeroed state. Complexity: `O(1)`. */
 void document_snapshot_init(DocumentSnapshot* snapshot)
 {
     if (snapshot) {
@@ -121,6 +154,7 @@ void document_snapshot_init(DocumentSnapshot* snapshot)
     }
 }
 
+/** Free heap memory owned by snapshot. Complexity: `O(n)`. */
 void document_snapshot_free(DocumentSnapshot* snapshot)
 {
     int i = 0;
@@ -141,6 +175,7 @@ void document_snapshot_free(DocumentSnapshot* snapshot)
     snapshot->next_id = 0;
 }
 
+/** Capture deep copy of document into snapshot. Complexity: `O(n)`. */
 int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* document)
 {
     int i = 0;
@@ -176,6 +211,7 @@ int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* docume
     return 1;
 }
 
+/** Initialize history stacks and capacity. Complexity: `O(capacity)`. */
 int document_history_init(DocumentHistory* history)
 {
     if (!history) {
@@ -196,6 +232,7 @@ int document_history_init(DocumentHistory* history)
     return 1;
 }
 
+/** Free all history entries and internal arrays. Complexity: `O(total_snapshots)`. */
 void document_history_shutdown(DocumentHistory* history)
 {
     int i = 0;
@@ -219,6 +256,15 @@ void document_history_shutdown(DocumentHistory* history)
     history->capacity = 0;
 }
 
+/**
+ * @brief Push edit transaction (`before` + captured `after`) to undo stack.
+ * @return `1` on success, `0` on failure.
+ *
+ * Why clear redo:
+ * - Any new forward edit invalidates previous redo chain by definition.
+ *
+ * Complexity: `O(n + capacity)` worst-case.
+ */
 int document_history_push(DocumentHistory* history, DocumentSnapshot* before, const Document* after_document)
 {
     DocumentHistoryEntry entry;
@@ -257,6 +303,7 @@ int document_history_push(DocumentHistory* history, DocumentSnapshot* before, co
     return 1;
 }
 
+/** Undo latest transaction and move entry to redo stack. Complexity: `O(n + capacity)` worst-case. */
 int document_history_undo(DocumentHistory* history, Document* document)
 {
     DocumentHistoryEntry entry;
@@ -283,6 +330,7 @@ int document_history_undo(DocumentHistory* history, Document* document)
     return 1;
 }
 
+/** Redo latest reverted transaction and move entry back to undo stack. Complexity: `O(n + capacity)` worst-case. */
 int document_history_redo(DocumentHistory* history, Document* document)
 {
     DocumentHistoryEntry entry;
@@ -309,11 +357,13 @@ int document_history_redo(DocumentHistory* history, Document* document)
     return 1;
 }
 
+/** Check if undo stack has entries. Complexity: `O(1)`. */
 int document_history_can_undo(const DocumentHistory* history)
 {
     return history && history->undo_count > 0;
 }
 
+/** Check if redo stack has entries. Complexity: `O(1)`. */
 int document_history_can_redo(const DocumentHistory* history)
 {
     return history && history->redo_count > 0;

--- a/src/document/object.c
+++ b/src/document/object.c
@@ -92,8 +92,8 @@ static RectF line_bounds(const GraphicObject* object)
 }
 
 /**
- * @brief Distance from point to segment AB.
- * Why projection:
+ * @brief Compute shortest distance from point to line segment AB.
+ * Why:
  * - Projecting onto AB and clamping `t` gives nearest on-segment point robustly.
  * Complexity: `O(1)`.
  */
@@ -120,14 +120,14 @@ static int line_hit_test(const GraphicObject* object, Vec2 point, float toleranc
     return line_distance_to_segment(point, line->p1, line->p2) <= tolerance;
 }
 
-/** Line path emits two points. */
+/** Returns 2 (the line segment endpoints p1 and p2). */
 static int line_get_path_point_count(const GraphicObject* object)
 {
     (void)object;
     return 2;
 }
 
-/** Write line path points into caller buffer. */
+/** Write line path points (p1, p2) into caller buffer (caller must provide at least 2 elements). */
 static void line_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
     const LineData* line = (const LineData*)object->impl;
@@ -190,7 +190,7 @@ static int rect_hit_test(const GraphicObject* object, Vec2 point, float toleranc
     return rectf_contains_point(&bounds, point);
 }
 
-/** Rectangle polyline is closed with 5 points. */
+/** Returns 5 (4 corners plus closing repeat of first corner to close the polyline). */
 static int rect_get_path_point_count(const GraphicObject* object)
 {
     (void)object;
@@ -252,7 +252,7 @@ static RectF ellipse_bounds(const GraphicObject* object)
     return ellipse->bounds;
 }
 
-/** Ellipse hit-test in normalized ellipse space. Complexity: `O(1)`. */
+/** Hit-test in ellipse's normalized unit-circle coordinate space. Complexity: `O(1)`. */
 static int ellipse_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
     RectF bounds = ellipse_bounds(object);
@@ -322,6 +322,7 @@ static int ellipse_set_scalar(GraphicObject* object, const char* key, float valu
     return style_set_scalar(object, key, value);
 }
 
+/** Line vtable dispatch table. */
 static const GraphicObjectVTable g_line_vtable = {
     "Line",
     line_destroy,
@@ -334,6 +335,7 @@ static const GraphicObjectVTable g_line_vtable = {
     line_set_scalar
 };
 
+/** Rectangle vtable dispatch table. */
 static const GraphicObjectVTable g_rect_vtable = {
     "Rectangle",
     rect_destroy,
@@ -346,6 +348,7 @@ static const GraphicObjectVTable g_rect_vtable = {
     rect_set_scalar
 };
 
+/** Ellipse vtable dispatch table. */
 static const GraphicObjectVTable g_ellipse_vtable = {
     "Ellipse",
     ellipse_destroy,

--- a/src/document/object.c
+++ b/src/document/object.c
@@ -1,3 +1,16 @@
+/**
+ * @file object.c
+ * @brief Polymorphic drawable object implementations (line/rect/ellipse).
+ *
+ * Role in project:
+ * - Implements per-shape vtable functions: bounds, hit test, path extraction,
+ *   scalar property access, and translation.
+ * - Provides factory and wrapper APIs used throughout the editor.
+ *
+ * Module relationships:
+ * - Consumed by document/history/render/canvas/persistence modules.
+ * - Uses math helpers for geometry operations.
+ */
 #include <document/object.h>
 
 #include <base/math2d.h>
@@ -21,6 +34,7 @@ typedef struct {
     RectF bounds;
 } EllipseData;
 
+/** Bump per-object revision after successful mutations. Complexity: `O(1)`. */
 static void object_bump_revision(GraphicObject* object)
 {
     if (object) {
@@ -28,6 +42,7 @@ static void object_bump_revision(GraphicObject* object)
     }
 }
 
+/** Read style scalar by key. Complexity: `O(1)` with small fixed key set. */
 static int style_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
     if (strcmp(key, "stroke_r") == 0) { *out_value = object->style.stroke_color.r; return 1; }
@@ -38,6 +53,7 @@ static int style_get_scalar(const GraphicObject* object, const char* key, float*
     return 0;
 }
 
+/** Write style scalar by key. Complexity: `O(1)` with small fixed key set. */
 static int style_set_scalar(GraphicObject* object, const char* key, float value)
 {
     if (strcmp(key, "stroke_r") == 0) { object->style.stroke_color.r = value; return 1; }
@@ -48,12 +64,14 @@ static int style_set_scalar(GraphicObject* object, const char* key, float value)
     return 0;
 }
 
+/** Line object destructor; releases `impl` then wrapper object. */
 static void line_destroy(GraphicObject* object)
 {
     free(object->impl);
     free(object);
 }
 
+/** Translate line endpoints by world delta. Complexity: `O(1)`. */
 static void line_translate(GraphicObject* object, Vec2 delta)
 {
     LineData* line = (LineData*)object->impl;
@@ -61,6 +79,7 @@ static void line_translate(GraphicObject* object, Vec2 delta)
     line->p2 = vec2_add(line->p2, delta);
 }
 
+/** Axis-aligned bounds for line segment. Complexity: `O(1)`. */
 static RectF line_bounds(const GraphicObject* object)
 {
     const LineData* line = (const LineData*)object->impl;
@@ -72,6 +91,12 @@ static RectF line_bounds(const GraphicObject* object)
     return bounds;
 }
 
+/**
+ * @brief Distance from point to segment AB.
+ * Why projection:
+ * - Projecting onto AB and clamping `t` gives nearest on-segment point robustly.
+ * Complexity: `O(1)`.
+ */
 static float line_distance_to_segment(Vec2 point, Vec2 a, Vec2 b)
 {
     Vec2 ab = vec2_sub(b, a);
@@ -88,18 +113,21 @@ static float line_distance_to_segment(Vec2 point, Vec2 a, Vec2 b)
     return vec2_length(vec2_sub(point, nearest));
 }
 
+/** Line hit-test uses geometric point-to-segment distance. Complexity: `O(1)`. */
 static int line_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
     const LineData* line = (const LineData*)object->impl;
     return line_distance_to_segment(point, line->p1, line->p2) <= tolerance;
 }
 
+/** Line path emits two points. */
 static int line_get_path_point_count(const GraphicObject* object)
 {
     (void)object;
     return 2;
 }
 
+/** Write line path points into caller buffer. */
 static void line_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
     const LineData* line = (const LineData*)object->impl;
@@ -107,6 +135,7 @@ static void line_write_path_points(const GraphicObject* object, Vec2* out_points
     out_points[1] = line->p2;
 }
 
+/** Read line scalar property or fallback to style scalar. */
 static int line_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
     const LineData* line = (const LineData*)object->impl;
@@ -117,6 +146,7 @@ static int line_get_scalar(const GraphicObject* object, const char* key, float* 
     return style_get_scalar(object, key, out_value);
 }
 
+/** Write line scalar property or fallback to style scalar. */
 static int line_set_scalar(GraphicObject* object, const char* key, float value)
 {
     LineData* line = (LineData*)object->impl;
@@ -127,12 +157,14 @@ static int line_set_scalar(GraphicObject* object, const char* key, float value)
     return style_set_scalar(object, key, value);
 }
 
+/** Rectangle object destructor. */
 static void rect_destroy(GraphicObject* object)
 {
     free(object->impl);
     free(object);
 }
 
+/** Translate rectangle origin by world delta. */
 static void rect_translate(GraphicObject* object, Vec2 delta)
 {
     RectData* rect = (RectData*)object->impl;
@@ -140,12 +172,14 @@ static void rect_translate(GraphicObject* object, Vec2 delta)
     rect->rect.y += delta.y;
 }
 
+/** Return rectangle bounds directly from payload. */
 static RectF rect_bounds(const GraphicObject* object)
 {
     const RectData* rect = (const RectData*)object->impl;
     return rect->rect;
 }
 
+/** Rectangle hit-test expands bounds by tolerance for easier selection. */
 static int rect_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
     RectF bounds = rect_bounds(object);
@@ -156,12 +190,14 @@ static int rect_hit_test(const GraphicObject* object, Vec2 point, float toleranc
     return rectf_contains_point(&bounds, point);
 }
 
+/** Rectangle polyline is closed with 5 points. */
 static int rect_get_path_point_count(const GraphicObject* object)
 {
     (void)object;
     return 5;
 }
 
+/** Emit rectangle corners plus closing point. */
 static void rect_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
     const RectData* rect = (const RectData*)object->impl;
@@ -172,6 +208,7 @@ static void rect_write_path_points(const GraphicObject* object, Vec2* out_points
     out_points[4] = out_points[0];
 }
 
+/** Read rectangle scalar property or style scalar. */
 static int rect_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
     const RectData* rect = (const RectData*)object->impl;
@@ -182,6 +219,7 @@ static int rect_get_scalar(const GraphicObject* object, const char* key, float* 
     return style_get_scalar(object, key, out_value);
 }
 
+/** Write rectangle scalar property or style scalar. */
 static int rect_set_scalar(GraphicObject* object, const char* key, float value)
 {
     RectData* rect = (RectData*)object->impl;
@@ -192,12 +230,14 @@ static int rect_set_scalar(GraphicObject* object, const char* key, float value)
     return style_set_scalar(object, key, value);
 }
 
+/** Ellipse object destructor. */
 static void ellipse_destroy(GraphicObject* object)
 {
     free(object->impl);
     free(object);
 }
 
+/** Translate ellipse bounds origin by world delta. */
 static void ellipse_translate(GraphicObject* object, Vec2 delta)
 {
     EllipseData* ellipse = (EllipseData*)object->impl;
@@ -205,12 +245,14 @@ static void ellipse_translate(GraphicObject* object, Vec2 delta)
     ellipse->bounds.y += delta.y;
 }
 
+/** Return ellipse axis-aligned bounds. */
 static RectF ellipse_bounds(const GraphicObject* object)
 {
     const EllipseData* ellipse = (const EllipseData*)object->impl;
     return ellipse->bounds;
 }
 
+/** Ellipse hit-test in normalized ellipse space. Complexity: `O(1)`. */
 static int ellipse_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
     RectF bounds = ellipse_bounds(object);
@@ -229,12 +271,18 @@ static int ellipse_hit_test(const GraphicObject* object, Vec2 point, float toler
     return (nx * nx + ny * ny) <= 1.0f;
 }
 
+/** Ellipse polyline uses fixed segment count plus closure point. */
 static int ellipse_get_path_point_count(const GraphicObject* object)
 {
     (void)object;
     return ELLIPSE_SEGMENTS + 1;
 }
 
+/**
+ * @brief Emit sampled ellipse perimeter.
+ * Risk note:
+ * - Caller must provide at least `ELLIPSE_SEGMENTS + 1` output points.
+ */
 static void ellipse_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
     const EllipseData* ellipse = (const EllipseData*)object->impl;
@@ -252,6 +300,7 @@ static void ellipse_write_path_points(const GraphicObject* object, Vec2* out_poi
     out_points[ELLIPSE_SEGMENTS] = out_points[0];
 }
 
+/** Read ellipse scalar property or style scalar. */
 static int ellipse_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
     const EllipseData* ellipse = (const EllipseData*)object->impl;
@@ -262,6 +311,7 @@ static int ellipse_get_scalar(const GraphicObject* object, const char* key, floa
     return style_get_scalar(object, key, out_value);
 }
 
+/** Write ellipse scalar property or style scalar. */
 static int ellipse_set_scalar(GraphicObject* object, const char* key, float value)
 {
     EllipseData* ellipse = (EllipseData*)object->impl;
@@ -308,6 +358,7 @@ static const GraphicObjectVTable g_ellipse_vtable = {
     ellipse_set_scalar
 };
 
+/** Allocate common object wrapper; takes ownership of `impl` on success. */
 static GraphicObject* object_alloc(GraphicObjectType type,
                                    const GraphicObjectVTable* vtable,
                                    void* impl,
@@ -327,6 +378,7 @@ static GraphicObject* object_alloc(GraphicObjectType type,
     return object;
 }
 
+/** Return default stroke style for new objects. */
 GraphicStyle object_default_style(void)
 {
     GraphicStyle style;
@@ -338,6 +390,7 @@ GraphicStyle object_default_style(void)
     return style;
 }
 
+/** Return debug/display name by object type. */
 const char* object_type_name(GraphicObjectType type)
 {
     switch (type) {
@@ -352,6 +405,7 @@ const char* object_type_name(GraphicObjectType type)
     }
 }
 
+/** Create line object from two endpoints. */
 GraphicObject* object_create_line(Vec2 p1, Vec2 p2, GraphicStyle style)
 {
     LineData* line = (LineData*)calloc(1, sizeof(*line));
@@ -363,6 +417,7 @@ GraphicObject* object_create_line(Vec2 p1, Vec2 p2, GraphicStyle style)
     return object_alloc(GRAPHIC_OBJECT_LINE, &g_line_vtable, line, style);
 }
 
+/** Create rectangle object from bounds. */
 GraphicObject* object_create_rect(RectF rect, GraphicStyle style)
 {
     RectData* data = (RectData*)calloc(1, sizeof(*data));
@@ -373,6 +428,7 @@ GraphicObject* object_create_rect(RectF rect, GraphicStyle style)
     return object_alloc(GRAPHIC_OBJECT_RECT, &g_rect_vtable, data, style);
 }
 
+/** Create ellipse object from bounds. */
 GraphicObject* object_create_ellipse(RectF bounds, GraphicStyle style)
 {
     EllipseData* data = (EllipseData*)calloc(1, sizeof(*data));
@@ -383,6 +439,10 @@ GraphicObject* object_create_ellipse(RectF bounds, GraphicStyle style)
     return object_alloc(GRAPHIC_OBJECT_ELLIPSE, &g_ellipse_vtable, data, style);
 }
 
+/**
+ * @brief Deep clone object by concrete type.
+ * @return New object with copied ID/style/revision, or `NULL` on failure.
+ */
 GraphicObject* object_clone(const GraphicObject* object)
 {
     GraphicObject* clone = NULL;
@@ -423,6 +483,7 @@ GraphicObject* object_clone(const GraphicObject* object)
     return clone;
 }
 
+/** Dispatch destruction through vtable. */
 void object_destroy(GraphicObject* object)
 {
     if (object && object->vtable && object->vtable->destroy) {
@@ -430,6 +491,7 @@ void object_destroy(GraphicObject* object)
     }
 }
 
+/** Translate object and bump revision on success. */
 void object_translate(GraphicObject* object, Vec2 delta)
 {
     if (!object || !object->vtable || !object->vtable->translate) {
@@ -439,6 +501,7 @@ void object_translate(GraphicObject* object, Vec2 delta)
     object_bump_revision(object);
 }
 
+/** Query object bounds via vtable, fallback to empty rect. */
 RectF object_get_bounds(const GraphicObject* object)
 {
     RectF empty = {0.0f, 0.0f, 0.0f, 0.0f};
@@ -448,6 +511,7 @@ RectF object_get_bounds(const GraphicObject* object)
     return object->vtable->get_bounds(object);
 }
 
+/** Hit-test object via vtable. */
 int object_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
     if (!object || !object->vtable || !object->vtable->hit_test) {
@@ -456,6 +520,7 @@ int object_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
     return object->vtable->hit_test(object, point, tolerance);
 }
 
+/** Query path sample count via vtable. */
 int object_get_path_point_count(const GraphicObject* object)
 {
     if (!object || !object->vtable || !object->vtable->get_path_point_count) {
@@ -464,6 +529,7 @@ int object_get_path_point_count(const GraphicObject* object)
     return object->vtable->get_path_point_count(object);
 }
 
+/** Write path points via vtable. */
 void object_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
     if (!object || !object->vtable || !object->vtable->write_path_points) {
@@ -472,6 +538,7 @@ void object_write_path_points(const GraphicObject* object, Vec2* out_points)
     object->vtable->write_path_points(object, out_points);
 }
 
+/** Query scalar property via vtable. */
 int object_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
     if (!object || !object->vtable || !object->vtable->get_scalar) {
@@ -480,6 +547,7 @@ int object_get_scalar(const GraphicObject* object, const char* key, float* out_v
     return object->vtable->get_scalar(object, key, out_value);
 }
 
+/** Set scalar property via vtable and bump revision on success. */
 int object_set_scalar(GraphicObject* object, const char* key, float value)
 {
     if (!object || !object->vtable || !object->vtable->set_scalar) {
@@ -492,6 +560,7 @@ int object_set_scalar(GraphicObject* object, const char* key, float value)
     return 1;
 }
 
+/** Update stroke color and revision. */
 void object_set_stroke_color(GraphicObject* object, Color color)
 {
     if (!object) {
@@ -501,6 +570,7 @@ void object_set_stroke_color(GraphicObject* object, Color color)
     object_bump_revision(object);
 }
 
+/** Update stroke width and revision. */
 void object_set_stroke_width(GraphicObject* object, float stroke_width)
 {
     if (!object) {

--- a/src/document/persistence.c
+++ b/src/document/persistence.c
@@ -1,3 +1,15 @@
+/**
+ * @file persistence.c
+ * @brief JSON serialization/deserialization for document files.
+ *
+ * Role in project:
+ * - Writes stable document JSON format (`version=1`) for save.
+ * - Parses JSON into validated runtime objects on load.
+ *
+ * Module relationships:
+ * - Uses document/object APIs for model construction and ID handling.
+ * - Called by application save/load commands.
+ */
 #include <document/persistence.h>
 
 #include <base/log.h>
@@ -67,6 +79,7 @@ typedef struct {
     int has_height;
 } LoadedObjectData;
 
+/** Read entire file into heap buffer (NUL-terminated). Caller owns returned memory. */
 static char* read_text_file(const char* path)
 {
     FILE* file = NULL;
@@ -106,6 +119,7 @@ static char* read_text_file(const char* path)
     return buffer;
 }
 
+/** Allocate `path + suffix` string. Caller owns returned memory. */
 static char* duplicate_path_with_suffix(const char* path, const char* suffix)
 {
     size_t path_length = 0;
@@ -129,6 +143,7 @@ static char* duplicate_path_with_suffix(const char* path, const char* suffix)
     return result;
 }
 
+/** Cheap file-exists check via open attempt. */
 static int file_exists_at_path(const char* path)
 {
     FILE* file = NULL;
@@ -146,6 +161,7 @@ static int file_exists_at_path(const char* path)
     return 1;
 }
 
+/** Map object type enum to persisted JSON tag. */
 static const char* object_type_tag(GraphicObjectType type)
 {
     switch (type) {
@@ -160,6 +176,11 @@ static const char* object_type_tag(GraphicObjectType type)
     }
 }
 
+/**
+ * @brief Atomically replace target file with temp file.
+ * Why:
+ * - Write-then-replace avoids corrupting existing file on partial write failure.
+ */
 static int replace_file_with_temp(const char* temp_path, const char* target_path)
 {
     if (!temp_path || !target_path) {
@@ -187,6 +208,11 @@ static int replace_file_with_temp(const char* temp_path, const char* target_path
 #endif
 }
 
+/**
+ * Serialize document as JSON into already-open file handle.
+ * Risk note: individual `fprintf` returns are not checked line-by-line; final
+ * `ferror(file)` is used as aggregate write-failure detection.
+ */
 static int write_document_json(FILE* file, const Document* document)
 {
     int i = 0;
@@ -247,6 +273,7 @@ static int write_document_json(FILE* file, const Document* document)
     return ferror(file) == 0;
 }
 
+/** Check whether parser position matches keyword and token boundary. */
 static int json_match_keyword(const JsonParser* parser, const char* keyword)
 {
     size_t length = 0;
@@ -273,6 +300,7 @@ static int json_match_keyword(const JsonParser* parser, const char* keyword)
     return !(isalnum((unsigned char)next) || next == '_');
 }
 
+/** Skip JSON whitespace from current parser position. */
 static void json_parser_skip_ws(JsonParser* parser)
 {
     while (parser->pos < parser->length &&
@@ -281,6 +309,12 @@ static void json_parser_skip_ws(JsonParser* parser)
     }
 }
 
+/**
+ * @brief Advance parser to next token.
+ * Risk note:
+ * - Keeps implementation intentionally strict; malformed escape/number forms
+ *   become `JSON_TOKEN_INVALID` to fail-fast during load.
+ */
 static void json_parser_next(JsonParser* parser)
 {
     const char* start = NULL;
@@ -386,6 +420,7 @@ static void json_parser_next(JsonParser* parser)
     parser->type = JSON_TOKEN_INVALID;
 }
 
+/** Compare current string token with literal. */
 static int json_token_is_string(const JsonParser* parser, const char* literal)
 {
     size_t literal_length = 0;
@@ -399,11 +434,13 @@ static int json_token_is_string(const JsonParser* parser, const char* literal)
            strncmp(parser->token_start, literal, literal_length) == 0;
 }
 
+/** Check expected token type. */
 static int json_expect(JsonParser* parser, JsonTokenType type)
 {
     return parser && parser->type == type;
 }
 
+/** Parse unsigned integer token with range/integrality validation. */
 static int json_parse_u32(JsonParser* parser, unsigned int* out_value)
 {
     double value = 0.0;
@@ -423,6 +460,7 @@ static int json_parse_u32(JsonParser* parser, unsigned int* out_value)
     return 1;
 }
 
+/** Parse float token and advance parser. */
 static int json_parse_float(JsonParser* parser, float* out_value)
 {
     if (!parser || !out_value || parser->type != JSON_TOKEN_NUMBER) {
@@ -436,6 +474,7 @@ static int json_parse_float(JsonParser* parser, float* out_value)
 
 static int json_skip_value(JsonParser* parser);
 
+/** Skip unknown JSON object recursively. */
 static int json_skip_object(JsonParser* parser)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACE)) {
@@ -472,6 +511,7 @@ static int json_skip_object(JsonParser* parser)
     }
 }
 
+/** Skip unknown JSON array recursively. */
 static int json_skip_array(JsonParser* parser)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACKET)) {
@@ -500,6 +540,7 @@ static int json_skip_array(JsonParser* parser)
     }
 }
 
+/** Skip arbitrary JSON value recursively. */
 static int json_skip_value(JsonParser* parser)
 {
     switch (parser->type) {
@@ -519,6 +560,7 @@ static int json_skip_value(JsonParser* parser)
     }
 }
 
+/** Parse `"stroke"` sub-object into loaded object staging struct. */
 static int parse_stroke_object(JsonParser* parser, LoadedObjectData* data)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACE)) {
@@ -585,6 +627,7 @@ static int parse_stroke_object(JsonParser* parser, LoadedObjectData* data)
     }
 }
 
+/** Parse `"geometry"` sub-object into loaded object staging struct. */
 static int parse_geometry_object(JsonParser* parser, LoadedObjectData* data)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACE)) {
@@ -669,6 +712,7 @@ static int parse_geometry_object(JsonParser* parser, LoadedObjectData* data)
     }
 }
 
+/** Parse and validate object `"type"` token. */
 static int parse_object_type(JsonParser* parser, LoadedObjectData* data)
 {
     if (!json_expect(parser, JSON_TOKEN_STRING)) {
@@ -692,6 +736,7 @@ static int parse_object_type(JsonParser* parser, LoadedObjectData* data)
     return 1;
 }
 
+/** Build runtime object from parsed staged fields; returns `NULL` on missing required data. */
 static GraphicObject* build_loaded_object(const LoadedObjectData* data)
 {
     if (!data || !data->has_id || !data->has_type ||
@@ -725,6 +770,11 @@ static GraphicObject* build_loaded_object(const LoadedObjectData* data)
     }
 }
 
+/**
+ * @brief Parse one object entry and append it to document.
+ * Risk note:
+ * - On append failure, allocated object is destroyed immediately to prevent leaks.
+ */
 static int parse_object_entry(JsonParser* parser, Document* document)
 {
     LoadedObjectData data;
@@ -801,6 +851,7 @@ static int parse_object_entry(JsonParser* parser, Document* document)
     return 1;
 }
 
+/** Parse selection ID array (extra IDs beyond max are ignored safely). */
 static int parse_selection_array(JsonParser* parser, ObjectId* selection_ids, int* selection_count)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACKET)) {
@@ -838,6 +889,7 @@ static int parse_selection_array(JsonParser* parser, ObjectId* selection_ids, in
     }
 }
 
+/** Parse objects array and append all parsed entries to document. */
 static int parse_objects_array(JsonParser* parser, Document* document)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACKET)) {
@@ -866,6 +918,10 @@ static int parse_objects_array(JsonParser* parser, Document* document)
     }
 }
 
+/**
+ * @brief Parse top-level document JSON object.
+ * @return `1` on valid schema/content, `0` on parse/schema mismatch.
+ */
 static int parse_document_root(JsonParser* parser, Document* document)
 {
     int got_format = 0;
@@ -965,6 +1021,10 @@ static int parse_document_root(JsonParser* parser, Document* document)
     return 1;
 }
 
+/**
+ * @brief Save document to JSON path using temp-file replacement.
+ * @return `1` on success, `0` on allocation/I/O/serialization failure.
+ */
 int document_save_json(const Document* document, const char* path)
 {
     FILE* file = NULL;
@@ -1018,6 +1078,14 @@ int document_save_json(const Document* document, const char* path)
     return 1;
 }
 
+/**
+ * @brief Load document from JSON file into runtime model.
+ * @return `1` on success, `0` on I/O/parse/validation failure.
+ *
+ * Why staged load:
+ * - Parses into a temporary `loaded_document` first; current document is only
+ *   replaced after full success, preserving previous state on failure.
+ */
 int document_load_json(Document* document, const char* path)
 {
     char* text = NULL;

--- a/src/document/persistence.c
+++ b/src/document/persistence.c
@@ -50,6 +50,12 @@ typedef struct {
     double number_value;
 } JsonParser;
 
+/**
+ * @brief Intermediate staging struct for JSON deserialization.
+ *
+ * Holds all parsed fields for one object with companion `has_*` flags
+ * indicating which fields were actually present in the JSON.
+ */
 typedef struct {
     ObjectId id;
     int has_id;
@@ -440,7 +446,7 @@ static int json_expect(JsonParser* parser, JsonTokenType type)
     return parser && parser->type == type;
 }
 
-/** Parse unsigned integer token with range/integrality validation. */
+/** Parse unsigned integer token with integer range validation. */
 static int json_parse_u32(JsonParser* parser, unsigned int* out_value)
 {
     double value = 0.0;
@@ -851,7 +857,7 @@ static int parse_object_entry(JsonParser* parser, Document* document)
     return 1;
 }
 
-/** Parse selection ID array (extra IDs beyond max are ignored safely). */
+/** Parse selection ID array (extra IDs beyond max are safely ignored). */
 static int parse_selection_array(JsonParser* parser, ObjectId* selection_ids, int* selection_count)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACKET)) {

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,25 @@
+/**
+ * @file main.c
+ * @brief Process entry point.
+ *
+ * Role in project:
+ * - Minimal bridge from OS runtime into `app_run()`.
+ *
+ * Module relationships:
+ * - Delegates all real lifecycle work to `app/application`.
+ */
 #include <app/application.h>
 
+/**
+ * @brief Program entry.
+ * @param None.
+ * @return Propagates `app_run()` result.
+ *
+ * Edge cases:
+ * - None here; failures are handled inside `app_run()`.
+ *
+ * Time complexity: `O(1)` for this wrapper.
+ */
 int main(void)
 {
     return app_run();

--- a/src/main.c
+++ b/src/main.c
@@ -12,13 +12,10 @@
 
 /**
  * @brief Program entry.
- * @param None.
  * @return Propagates `app_run()` result.
  *
  * Edge cases:
- * - None here; failures are handled inside `app_run()`.
- *
- * Time complexity: `O(1)` for this wrapper.
+ * - Failures are handled inside `app_run()`.
  */
 int main(void)
 {

--- a/src/platform/window.c
+++ b/src/platform/window.c
@@ -12,7 +12,24 @@
  */
 #include <platform/window.h>
 
-/** Initialize GLFW and create window/context. Returns 0 on success, -1 on failure. */
+/**
+ * @brief Initialize GLFW and create an OpenGL 3.3 Core Profile window and context.
+ * @param window [in,out] Window structure to populate.
+ * @param width [in] Requested window width in pixels.
+ * @param height [in] Requested window height in pixels.
+ * @param title [in] Window title string.
+ * @return `0` on success; `-1` on GLFW init failure or window creation failure.
+ *
+ * Error conditions:
+ * - Returns `-1` if `window` is `NULL`.
+ * - Returns `-1` if GLFW fails to initialize.
+ * - Returns `-1` if window or OpenGL context creation fails.
+ *
+ * Side effects:
+ * - Makes the OpenGL context current for the created window.
+ * - Sets swap interval to 1 (vsync enabled).
+ * - Enforces a minimum window size of 800×600 pixels.
+ */
 int platform_window_init(PlatformWindow* window, int width, int height, const char* title)
 {
     if (!window) {
@@ -44,7 +61,15 @@ int platform_window_init(PlatformWindow* window, int width, int height, const ch
     return 0;
 }
 
-/** Destroy window handle if it exists. */
+/**
+ * @brief Destroy window handle if present.
+ * @param window [in,out] Window to destroy; safe no-op when `NULL`.
+ * @return None.
+ *
+ * Note:
+ * - Does NOT call `glfwTerminate()`; GLFW lifetime is managed separately.
+ * - Safe to call multiple times (idempotent after first call).
+ */
 void platform_window_shutdown(PlatformWindow* window)
 {
     if (!window) {

--- a/src/platform/window.c
+++ b/src/platform/window.c
@@ -1,5 +1,18 @@
+/**
+ * @file window.c
+ * @brief GLFW window lifecycle wrapper implementation.
+ *
+ * Role in project:
+ * - Initializes OpenGL-compatible GLFW window/context.
+ * - Provides small wrapper calls used by the app loop.
+ *
+ * Module relationships:
+ * - Called by `application.c`.
+ * - Provides valid context required by renderer/UI init.
+ */
 #include <platform/window.h>
 
+/** Initialize GLFW and create window/context. Returns 0 on success, -1 on failure. */
 int platform_window_init(PlatformWindow* window, int width, int height, const char* title)
 {
     if (!window) {
@@ -31,6 +44,7 @@ int platform_window_init(PlatformWindow* window, int width, int height, const ch
     return 0;
 }
 
+/** Destroy window handle if it exists. */
 void platform_window_shutdown(PlatformWindow* window)
 {
     if (!window) {
@@ -43,11 +57,13 @@ void platform_window_shutdown(PlatformWindow* window)
     }
 }
 
+/** Poll pending OS events. */
 void platform_window_poll_events(void)
 {
     glfwPollEvents();
 }
 
+/** Swap front/back buffers for valid window handle. */
 void platform_window_swap_buffers(PlatformWindow* window)
 {
     if (window && window->handle) {
@@ -55,6 +71,7 @@ void platform_window_swap_buffers(PlatformWindow* window)
     }
 }
 
+/** Return close-state (treat invalid window as closed). */
 int platform_window_should_close(const PlatformWindow* window)
 {
     if (!window || !window->handle) {

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -1,3 +1,15 @@
+/**
+ * @file render_system.c
+ * @brief OpenGL-based canvas rendering implementation.
+ *
+ * Role in project:
+ * - Compiles shaders, owns VAO/VBO buffers, and renders each frame.
+ * - Draws grid, axes, document objects, and transient tool overlays.
+ *
+ * Module relationships:
+ * - Consumes `Document` geometry and `CanvasView` transforms.
+ * - Invoked by application once per frame.
+ */
 #include <render/render_system.h>
 
 #include <base/math2d.h>
@@ -8,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/** Renderer-owned GL and CPU-side buffer state. */
 struct RenderSystem {
     GLuint program;
     GLuint vao;
@@ -20,6 +33,7 @@ struct RenderSystem {
     size_t path_buffer_capacity;
 };
 
+/** Read shader source text file into heap buffer. */
 static char* read_text_file(const char* path)
 {
     FILE* file = fopen(path, "rb");
@@ -47,6 +61,7 @@ static char* read_text_file(const char* path)
     return buffer;
 }
 
+/** Compile one shader stage from source; returns 0 on compile failure. */
 static GLuint compile_shader(GLenum type, const char* source)
 {
     GLuint shader = glCreateShader(type);
@@ -65,6 +80,7 @@ static GLuint compile_shader(GLenum type, const char* source)
     return shader;
 }
 
+/** Load, compile, and link shader program; returns 0 on failure. */
 static GLuint load_program(const char* vertex_path, const char* fragment_path)
 {
     char* vertex_source = read_text_file(vertex_path);
@@ -108,6 +124,13 @@ static GLuint load_program(const char* vertex_path, const char* fragment_path)
     return program;
 }
 
+/**
+ * @brief Ensure CPU buffers can store requested point count.
+ * @return `1` on success, `0` on allocation failure.
+ *
+ * Risk note:
+ * - Uses `realloc`; on failure old buffers remain valid and unchanged.
+ */
 static int ensure_vertex_capacity(RenderSystem* renderer, size_t point_count)
 {
     size_t required_vertex_capacity = point_count * 6u;
@@ -133,6 +156,7 @@ static int ensure_vertex_capacity(RenderSystem* renderer, size_t point_count)
     return 1;
 }
 
+/** Upload world points converted to screen-space colored vertices. */
 static void upload_points(RenderSystem* renderer, const CanvasView* canvas, const Vec2* points, int count, Color color)
 {
     int i = 0;
@@ -152,6 +176,7 @@ static void upload_points(RenderSystem* renderer, const CanvasView* canvas, cons
     glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)(count * 6 * sizeof(float)), renderer->vertex_buffer, GL_DYNAMIC_DRAW);
 }
 
+/** Draw one polyline path. */
 static void draw_polyline(RenderSystem* renderer,
                           const CanvasView* canvas,
                           const Vec2* points,
@@ -168,6 +193,7 @@ static void draw_polyline(RenderSystem* renderer,
     glDrawArrays(GL_LINE_STRIP, 0, count);
 }
 
+/** Draw world grid and axis lines in currently visible world rectangle. */
 static void draw_grid(RenderSystem* renderer, const CanvasView* canvas)
 {
     RectF visible = canvas_view_visible_world_rect(canvas);
@@ -203,6 +229,7 @@ static void draw_grid(RenderSystem* renderer, const CanvasView* canvas)
     draw_polyline(renderer, canvas, line, 2, axis_color, 1.5f);
 }
 
+/** Draw one object path with optional selection highlight underlay. */
 static void draw_object(RenderSystem* renderer,
                         const CanvasView* canvas,
                         const GraphicObject* object,
@@ -222,6 +249,10 @@ static void draw_object(RenderSystem* renderer,
     draw_polyline(renderer, canvas, renderer->path_buffer, point_count, object->style.stroke_color, object->style.stroke_width);
 }
 
+/**
+ * @brief Convert canvas viewport to GL scissor box.
+ * @return `1` when resulting scissor area is valid and non-empty, else `0`.
+ */
 static int render_canvas_scissor_box(const RectF* viewport, int framebuffer_width, int framebuffer_height, GLint out_scissor[4])
 {
     int x = 0;
@@ -269,6 +300,7 @@ static int render_canvas_scissor_box(const RectF* viewport, int framebuffer_widt
     return 1;
 }
 
+/** Create renderer resources and configure OpenGL state. */
 RenderSystem* render_system_create(PlatformWindow* window)
 {
     RenderSystem* renderer = (RenderSystem*)calloc(1, sizeof(*renderer));
@@ -312,6 +344,7 @@ RenderSystem* render_system_create(PlatformWindow* window)
     return renderer;
 }
 
+/** Destroy renderer-owned GL objects and heap buffers. */
 void render_system_destroy(RenderSystem* renderer)
 {
     if (!renderer) {
@@ -326,6 +359,7 @@ void render_system_destroy(RenderSystem* renderer)
     free(renderer);
 }
 
+/** Update viewport and shader uniform after framebuffer resize. */
 void render_system_resize(RenderSystem* renderer, int width, int height)
 {
     GLint screen_size_loc = -1;
@@ -345,6 +379,13 @@ void render_system_resize(RenderSystem* renderer, int width, int height)
     glUseProgram(0);
 }
 
+/**
+ * @brief Render full canvas frame.
+ *
+ * Why preserve scissor state:
+ * - UI and renderer may share context state; previous scissor state is restored
+ *   to avoid leaking render-state changes into other draw passes.
+ */
 void render_system_draw(RenderSystem* renderer,
                         const Document* document,
                         const CanvasView* canvas,

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -222,6 +222,53 @@ static void draw_object(RenderSystem* renderer,
     draw_polyline(renderer, canvas, renderer->path_buffer, point_count, object->style.stroke_color, object->style.stroke_width);
 }
 
+static int render_canvas_scissor_box(const RectF* viewport, int framebuffer_width, int framebuffer_height, GLint out_scissor[4])
+{
+    int x = 0;
+    int y_top = 0;
+    int w = 0;
+    int h = 0;
+    int y = 0;
+
+    if (!viewport || !out_scissor || framebuffer_width <= 0 || framebuffer_height <= 0) {
+        return 0;
+    }
+
+    if (viewport->w <= 0.0f || viewport->h <= 0.0f) {
+        return 0;
+    }
+
+    x = (int)floorf(viewport->x);
+    y_top = (int)floorf(viewport->y);
+    w = (int)ceilf(viewport->w);
+    h = (int)ceilf(viewport->h);
+    y = framebuffer_height - y_top - h;
+
+    if (x < 0) {
+        w += x;
+        x = 0;
+    }
+    if (y < 0) {
+        h += y;
+        y = 0;
+    }
+    if (x + w > framebuffer_width) {
+        w = framebuffer_width - x;
+    }
+    if (y + h > framebuffer_height) {
+        h = framebuffer_height - y;
+    }
+    if (w <= 0 || h <= 0) {
+        return 0;
+    }
+
+    out_scissor[0] = (GLint)x;
+    out_scissor[1] = (GLint)y;
+    out_scissor[2] = (GLint)w;
+    out_scissor[3] = (GLint)h;
+    return 1;
+}
+
 RenderSystem* render_system_create(PlatformWindow* window)
 {
     RenderSystem* renderer = (RenderSystem*)calloc(1, sizeof(*renderer));
@@ -304,12 +351,35 @@ void render_system_draw(RenderSystem* renderer,
                         const GraphicObject* overlay_object)
 {
     int i = 0;
+    GLboolean scissor_was_enabled = GL_FALSE;
+    GLint previous_scissor_box[4] = {0, 0, 0, 0};
+    GLint canvas_scissor_box[4] = {0, 0, 0, 0};
+    RectF viewport;
+    int has_canvas_area = 0;
 
     if (!renderer || !document || !canvas) {
         return;
     }
 
+    viewport = canvas_view_viewport(canvas);
+    has_canvas_area = render_canvas_scissor_box(&viewport,
+                                                renderer->width,
+                                                renderer->height,
+                                                canvas_scissor_box);
+
     glViewport(0, 0, renderer->width, renderer->height);
+    scissor_was_enabled = glIsEnabled(GL_SCISSOR_TEST);
+    glGetIntegerv(GL_SCISSOR_BOX, previous_scissor_box);
+
+    if (!has_canvas_area) {
+        if (!scissor_was_enabled) {
+            glDisable(GL_SCISSOR_TEST);
+        }
+        return;
+    }
+
+    glEnable(GL_SCISSOR_TEST);
+    glScissor(canvas_scissor_box[0], canvas_scissor_box[1], canvas_scissor_box[2], canvas_scissor_box[3]);
     glClearColor(canvas->background.r, canvas->background.g, canvas->background.b, canvas->background.a);
     glClear(GL_COLOR_BUFFER_BIT);
 
@@ -333,4 +403,13 @@ void render_system_draw(RenderSystem* renderer,
     glLineWidth(1.0f);
     glBindVertexArray(0);
     glUseProgram(0);
+
+    if (scissor_was_enabled) {
+        glScissor(previous_scissor_box[0],
+                  previous_scissor_box[1],
+                  previous_scissor_box[2],
+                  previous_scissor_box[3]);
+    } else {
+        glDisable(GL_SCISSOR_TEST);
+    }
 }

--- a/src/tools/tool_controller.c
+++ b/src/tools/tool_controller.c
@@ -1,3 +1,15 @@
+/**
+ * @file tool_controller.c
+ * @brief Built-in tool implementations and controller dispatch logic.
+ *
+ * Role in project:
+ * - Implements Select/Pan/Line/Rect/Ellipse tools.
+ * - Routes pointer/keyboard/scroll events to active tool vtable.
+ *
+ * Module relationships:
+ * - Uses document, history, canvas, and workspace dirty-tracking APIs.
+ * - Called by application event callbacks and UI tool rail.
+ */
 #include <tools/tool_controller.h>
 
 #include <app/workspace.h>
@@ -12,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+/** Runtime state for select tool drag/selection/history behavior. */
 typedef struct {
     int dragging;
     int history_pending;
@@ -21,22 +34,26 @@ typedef struct {
     DocumentSnapshot before_snapshot;
 } SelectToolState;
 
+/** Runtime state for pan tool. */
 typedef struct {
     int panning;
 } PanToolState;
 
+/** Runtime state for shape-creation tools. */
 typedef struct {
     int drawing;
     Vec2 anchor;
     Vec2 current;
 } ShapeToolState;
 
+/** Free and re-init snapshot for reuse. */
 static void snapshot_reset(DocumentSnapshot* snapshot)
 {
     document_snapshot_free(snapshot);
     document_snapshot_init(snapshot);
 }
 
+/** Destroy active overlay object preview if present. */
 static void destroy_overlay(Tool* tool)
 {
     if (tool && tool->overlay_object) {
@@ -45,6 +62,7 @@ static void destroy_overlay(Tool* tool)
     }
 }
 
+/** Build axis-aligned rect from two arbitrary points. */
 static RectF rect_from_points(Vec2 a, Vec2 b)
 {
     RectF rect;
@@ -55,6 +73,7 @@ static RectF rect_from_points(Vec2 a, Vec2 b)
     return rect;
 }
 
+/** Create shape object for current shape tool kind. */
 static GraphicObject* build_shape_object(ToolKind kind, Vec2 anchor, Vec2 current, GraphicStyle style)
 {
     if (kind == TOOL_KIND_LINE) {
@@ -69,6 +88,7 @@ static GraphicObject* build_shape_object(ToolKind kind, Vec2 anchor, Vec2 curren
     return NULL;
 }
 
+/** Compare document selection against snapshot selection (order-sensitive). */
 static int selection_matches_snapshot(const Document* document, const DocumentSnapshot* snapshot)
 {
     int i = 0;
@@ -90,6 +110,10 @@ static int selection_matches_snapshot(const Document* document, const DocumentSn
     return 1;
 }
 
+/**
+ * @brief Push document edit to history and sync dirty flag.
+ * Edge case: safely resets snapshot even when context/history is invalid.
+ */
 static void tool_commit_document_change(ToolContext* context, DocumentSnapshot* before_snapshot)
 {
     if (!context || !context->history || !before_snapshot) {
@@ -107,12 +131,14 @@ static void tool_commit_document_change(ToolContext* context, DocumentSnapshot* 
     workspace_sync_document_dirty(context->workspace);
 }
 
+/** Select tool UI label. */
 static const char* select_tool_label(const Tool* tool)
 {
     (void)tool;
     return "Select";
 }
 
+/** Deactivate select tool and clear transient state. */
 static void select_tool_deactivate(Tool* tool, ToolContext* context)
 {
     SelectToolState* state = (SelectToolState*)tool->state;
@@ -124,6 +150,13 @@ static void select_tool_deactivate(Tool* tool, ToolContext* context)
     snapshot_reset(&state->before_snapshot);
 }
 
+/**
+ * @brief Handle select tool pointer press.
+ *
+ * Why snapshot first:
+ * - Captures "before" state before selection/drag mutations so history entry
+ *   can represent either move edits or selection-only edits consistently.
+ */
 static void select_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     SelectToolState* state = (SelectToolState*)tool->state;
@@ -166,6 +199,7 @@ static void select_tool_pointer_down(Tool* tool, ToolContext* context, const Too
     state->moved = 0;
 }
 
+/** Move all selected objects by world delta while dragging. */
 static void select_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     SelectToolState* state = (SelectToolState*)tool->state;
@@ -193,6 +227,7 @@ static void select_tool_pointer_move(Tool* tool, ToolContext* context, const Too
     document_touch(context->document);
 }
 
+/** Finalize select drag/selection change and commit history when needed. */
 static void select_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     SelectToolState* state = (SelectToolState*)tool->state;
@@ -213,6 +248,7 @@ static void select_tool_pointer_up(Tool* tool, ToolContext* context, const ToolE
     state->selection_changed = 0;
 }
 
+/** Handle select tool keyboard shortcuts (currently Escape clear-selection). */
 static void select_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)
 {
     (void)tool;
@@ -242,12 +278,14 @@ static const ToolVTable g_select_tool_vtable = {
     select_tool_key_down
 };
 
+/** Pan tool label. */
 static const char* pan_tool_label(const Tool* tool)
 {
     (void)tool;
     return "Hand";
 }
 
+/** Stop panning when tool deactivates. */
 static void pan_tool_deactivate(Tool* tool, ToolContext* context)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -255,6 +293,7 @@ static void pan_tool_deactivate(Tool* tool, ToolContext* context)
     state->panning = 0;
 }
 
+/** Start panning on left press. */
 static void pan_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -266,6 +305,7 @@ static void pan_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEv
     state->panning = 1;
 }
 
+/** Apply screen delta pan while active. */
 static void pan_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -276,6 +316,7 @@ static void pan_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEv
     canvas_view_pan_screen_delta(context->canvas, event->delta_screen);
 }
 
+/** End panning on release. */
 static void pan_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -295,6 +336,7 @@ static const ToolVTable g_pan_tool_vtable = {
     NULL
 };
 
+/** Return label by shape kind. */
 static const char* shape_tool_label(const Tool* tool)
 {
     switch (tool->kind) {
@@ -309,6 +351,7 @@ static const char* shape_tool_label(const Tool* tool)
     }
 }
 
+/** Cancel shape drawing and clear overlay when tool deactivates. */
 static void shape_tool_deactivate(Tool* tool, ToolContext* context)
 {
     ShapeToolState* state = (ShapeToolState*)tool->state;
@@ -317,6 +360,7 @@ static void shape_tool_deactivate(Tool* tool, ToolContext* context)
     destroy_overlay(tool);
 }
 
+/** Start shape draw interaction and create translucent overlay preview. */
 static void shape_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     ShapeToolState* state = (ShapeToolState*)tool->state;
@@ -336,6 +380,7 @@ static void shape_tool_pointer_down(Tool* tool, ToolContext* context, const Tool
     tool->overlay_object = build_shape_object(tool->kind, state->anchor, state->current, style);
 }
 
+/** Update shape overlay as pointer moves. */
 static void shape_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     ShapeToolState* state = (ShapeToolState*)tool->state;
@@ -352,6 +397,12 @@ static void shape_tool_pointer_move(Tool* tool, ToolContext* context, const Tool
     tool->overlay_object = build_shape_object(tool->kind, state->anchor, state->current, style);
 }
 
+/**
+ * @brief Finalize shape creation on pointer release.
+ * Risk note:
+ * - Captures history snapshot before append; allocation/add failures clean up
+ *   object/snapshot to avoid leaks and partial commits.
+ */
 static void shape_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     ShapeToolState* state = (ShapeToolState*)tool->state;
@@ -386,6 +437,7 @@ static void shape_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEv
     tool_commit_document_change(context, &before_snapshot);
 }
 
+/** Escape cancels in-progress shape drawing. */
 static void shape_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)
 {
     (void)mods;
@@ -404,6 +456,7 @@ static const ToolVTable g_shape_tool_vtable = {
     shape_tool_key_down
 };
 
+/** Initialize one tool slot and allocate optional state block. */
 static void tool_init_slot(Tool* tool, ToolKind kind, const ToolVTable* vtable, size_t state_size)
 {
     memset(tool, 0, sizeof(*tool));
@@ -414,6 +467,7 @@ static void tool_init_slot(Tool* tool, ToolKind kind, const ToolVTable* vtable, 
     }
 }
 
+/** Initialize all built-in tools and default active tool. */
 void tool_controller_init(ToolController* controller)
 {
     if (!controller) {
@@ -430,6 +484,7 @@ void tool_controller_init(ToolController* controller)
     document_snapshot_init(&((SelectToolState*)controller->tools[TOOL_KIND_SELECT].state)->before_snapshot);
 }
 
+/** Shutdown all tool states and overlays. */
 void tool_controller_shutdown(ToolController* controller)
 {
     int i = 0;
@@ -449,6 +504,7 @@ void tool_controller_shutdown(ToolController* controller)
     }
 }
 
+/** Return active tool pointer. */
 Tool* tool_controller_get_active(ToolController* controller)
 {
     if (!controller) {
@@ -457,6 +513,7 @@ Tool* tool_controller_get_active(ToolController* controller)
     return &controller->tools[controller->active_kind];
 }
 
+/** Return active tool label. */
 const char* tool_controller_active_label(const ToolController* controller)
 {
     const Tool* tool = NULL;
@@ -467,6 +524,7 @@ const char* tool_controller_active_label(const ToolController* controller)
     return tool->vtable->label(tool);
 }
 
+/** Return active tool overlay object if any. */
 GraphicObject* tool_controller_overlay_object(const ToolController* controller)
 {
     if (!controller) {
@@ -475,6 +533,7 @@ GraphicObject* tool_controller_overlay_object(const ToolController* controller)
     return controller->tools[controller->active_kind].overlay_object;
 }
 
+/** Switch active tool with proper deactivate/activate callbacks. */
 void tool_controller_set_active(ToolController* controller, ToolContext* context, ToolKind kind)
 {
     Tool* current = NULL;
@@ -496,6 +555,7 @@ void tool_controller_set_active(ToolController* controller, ToolContext* context
     }
 }
 
+/** Dispatch pointer-down and capture pointer. */
 void tool_controller_pointer_down(ToolController* controller, ToolContext* context, const ToolEvent* event)
 {
     Tool* tool = tool_controller_get_active(controller);
@@ -508,6 +568,7 @@ void tool_controller_pointer_down(ToolController* controller, ToolContext* conte
     tool->vtable->pointer_down(tool, context, event);
 }
 
+/** Dispatch pointer-move to active tool. */
 void tool_controller_pointer_move(ToolController* controller, ToolContext* context, const ToolEvent* event)
 {
     Tool* tool = tool_controller_get_active(controller);
@@ -519,6 +580,7 @@ void tool_controller_pointer_move(ToolController* controller, ToolContext* conte
     tool->vtable->pointer_move(tool, context, event);
 }
 
+/** Dispatch pointer-up and release pointer capture. */
 void tool_controller_pointer_up(ToolController* controller, ToolContext* context, const ToolEvent* event)
 {
     Tool* tool = tool_controller_get_active(controller);
@@ -531,6 +593,11 @@ void tool_controller_pointer_up(ToolController* controller, ToolContext* context
     controller->last_world = event->world_pos;
 }
 
+/**
+ * @brief Dispatch key-down to global shortcuts or active tool.
+ * Why global-first:
+ * - Undo/redo/delete/tool-switch shortcuts must be deterministic regardless of tool.
+ */
 void tool_controller_key_down(ToolController* controller, ToolContext* context, int key, int mods)
 {
     Tool* tool = NULL;
@@ -600,6 +667,7 @@ void tool_controller_key_down(ToolController* controller, ToolContext* context, 
     }
 }
 
+/** Apply wheel zoom around current cursor screen point. */
 void tool_controller_scroll(ToolController* controller, ToolContext* context, Vec2 screen_pos, float yoffset)
 {
     float factor = 1.0f;

--- a/src/tools/tool_controller.c
+++ b/src/tools/tool_controller.c
@@ -112,7 +112,7 @@ static int selection_matches_snapshot(const Document* document, const DocumentSn
 
 /**
  * @brief Push document edit to history and sync dirty flag.
- * Edge case: safely resets snapshot even when context/history is invalid.
+ * @remark Safely resets snapshot even when context/history is invalid.
  */
 static void tool_commit_document_change(ToolContext* context, DocumentSnapshot* before_snapshot)
 {
@@ -248,7 +248,7 @@ static void select_tool_pointer_up(Tool* tool, ToolContext* context, const ToolE
     state->selection_changed = 0;
 }
 
-/** Handle select tool keyboard shortcuts (currently Escape clear-selection). */
+/** Handle select tool keyboard input (Escape clears selection). */
 static void select_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)
 {
     (void)tool;

--- a/src/ui/ui_menu_actions.c
+++ b/src/ui/ui_menu_actions.c
@@ -1,3 +1,15 @@
+/**
+ * @file ui_menu_actions.c
+ * @brief Menu action dispatch implementation.
+ *
+ * Role in project:
+ * - Maps menu IDs to workspace/document/canvas operations.
+ * - Centralizes shortcut-equivalent command behavior.
+ *
+ * Module relationships:
+ * - Called by menu bar and application shortcut handling.
+ * - Uses workspace callbacks for save/load and document/history APIs for edits.
+ */
 #include "ui_menu_actions.h"
 
 #include <app/workspace.h>

--- a/src/ui/ui_menu_actions.c
+++ b/src/ui/ui_menu_actions.c
@@ -22,34 +22,24 @@
 
 #include <GLFW/glfw3.h>
 
-#include <stdio.h>
-#include <string.h>
-
 static void app_workspace_new(Workspace* workspace)
 {
     if (!workspace) {
         return;
     }
 
-    /* Check for unsaved changes if needed in future */
-
-    /* Reset document */
     document_reset(&workspace->document);
 
-    /* Reset history */
     document_history_shutdown(&workspace->history);
     if (!document_history_init(&workspace->history)) {
         LOG_ERROR("%s", "Failed to reinitialize history");
         return;
     }
 
-    /* Reset canvas zoom and center */
     canvas_view_set_center_zoom(&workspace->canvas, vec2_make(0.0f, 0.0f), 1.0f);
 
-    /* Clear document path */
     workspace->current_document_path[0] = '\0';
 
-    /* Mark as saved */
     workspace->saved_revision = workspace->document.revision;
     workspace->document_dirty = 0;
 
@@ -66,12 +56,10 @@ static void app_zoom_to_fit(Workspace* workspace)
     CanvasView* canvas = &workspace->canvas;
 
     if (doc->count == 0) {
-        /* No objects, reset to default view */
         canvas_view_set_center_zoom(canvas, vec2_make(0.0f, 0.0f), 1.0f);
         return;
     }
 
-    /* Calculate bounding box of all objects */
     float min_x = 0.0f, max_x = 0.0f, min_y = 0.0f, max_y = 0.0f;
     int first = 1;
 
@@ -95,31 +83,25 @@ static void app_zoom_to_fit(Workspace* workspace)
     }
 
     if (first) {
-        /* No valid objects */
         return;
     }
 
-    /* Add padding */
     float pad = 50.0f;
     min_x -= pad;
     min_y -= pad;
     max_x += pad;
     max_y += pad;
 
-    /* Calculate content size */
     float content_w = max_x - min_x;
     float content_h = max_y - min_y;
 
-    /* Calculate zoom to fit */
     RectF canvas_viewport = canvas_view_viewport(canvas);
     float zoom_x = canvas_viewport.w / content_w;
     float zoom_y = canvas_viewport.h / content_h;
     float new_zoom = (zoom_x < zoom_y) ? zoom_x : zoom_y;
 
-    /* Clamp zoom to valid range */
     new_zoom = (new_zoom < 0.1f) ? 0.1f : (new_zoom > 12.0f) ? 12.0f : new_zoom;
 
-    /* Set new zoom and center */
     canvas_view_set_center_zoom(canvas,
                                 vec2_make((min_x + max_x) * 0.5f, (min_y + max_y) * 0.5f),
                                 new_zoom);
@@ -135,32 +117,24 @@ static void app_toggle_grid(Workspace* workspace)
 
 static void app_toggle_inspector(Workspace* workspace)
 {
-    if (!workspace) {
-        return;
-    }
-    /* This will be handled by ui_system, so we use a status message */
-    /* The actual toggle is done in ui_system */
+    (void)workspace;
     LOG_INFO("%s", "Inspector panel toggled");
 }
 
 static void app_show_shortcuts(Workspace* workspace)
 {
     (void)workspace;
-    /* This will show a dialog - placeholder for now */
     LOG_INFO("%s", "Keyboard shortcuts dialog requested");
 }
 
 static void app_show_about(Workspace* workspace)
 {
     (void)workspace;
-    /* This will show a dialog - placeholder for now */
     LOG_INFO("%s", "About dialog requested");
 }
 
 static int app_save_as(Workspace* workspace)
 {
-    /* For now, just use the same save path */
-    /* In future, this would open a file dialog */
     if (workspace->save_document) {
         return workspace->save_document(workspace, workspace->command_user_data);
     }
@@ -170,7 +144,7 @@ static int app_save_as(Workspace* workspace)
 static int app_export_png(Workspace* workspace)
 {
     (void)workspace;
-    /* TODO: Implement PNG export using framebuffer capture */
+    // TODO: Implement PNG export via framebuffer capture
     LOG_INFO("%s", "Export PNG requested");
     return 0;
 }
@@ -239,7 +213,6 @@ void ui_menu_execute(Workspace* workspace, MenuId id)
         break;
 
     case MENU_ID_EDIT_SELECT_ALL:
-        /* Select all objects */
         for (int i = 0; i < workspace->document.count; i++) {
             document_selection_add(&workspace->document,
                                    workspace->document.objects[i]->id);
@@ -250,7 +223,7 @@ void ui_menu_execute(Workspace* workspace, MenuId id)
     case MENU_ID_EDIT_CUT:
     case MENU_ID_EDIT_COPY:
     case MENU_ID_EDIT_PASTE:
-        /* TODO: Implement in issue #27 */
+        // TODO: cut/copy/paste/delete operations not yet implemented
         LOG_INFO("Menu action %d not yet implemented", id);
         break;
 

--- a/src/ui/ui_menu_actions.c
+++ b/src/ui/ui_menu_actions.c
@@ -2,6 +2,7 @@
 
 #include <app/workspace.h>
 #include <base/log.h>
+#include <base/math2d.h>
 #include <canvas/canvas_view.h>
 #include <document/document.h>
 #include <document/history.h>
@@ -31,9 +32,7 @@ static void app_workspace_new(Workspace* workspace)
     }
 
     /* Reset canvas zoom and center */
-    workspace->canvas.zoom = 1.0f;
-    workspace->canvas.center.x = 0.0f;
-    workspace->canvas.center.y = 0.0f;
+    canvas_view_set_center_zoom(&workspace->canvas, vec2_make(0.0f, 0.0f), 1.0f);
 
     /* Clear document path */
     workspace->current_document_path[0] = '\0';
@@ -56,9 +55,7 @@ static void app_zoom_to_fit(Workspace* workspace)
 
     if (doc->count == 0) {
         /* No objects, reset to default view */
-        canvas->zoom = 1.0f;
-        canvas->center.x = 0.0f;
-        canvas->center.y = 0.0f;
+        canvas_view_set_center_zoom(canvas, vec2_make(0.0f, 0.0f), 1.0f);
         return;
     }
 
@@ -102,17 +99,18 @@ static void app_zoom_to_fit(Workspace* workspace)
     float content_h = max_y - min_y;
 
     /* Calculate zoom to fit */
-    float zoom_x = canvas->viewport.w / content_w;
-    float zoom_y = canvas->viewport.h / content_h;
+    RectF canvas_viewport = canvas_view_viewport(canvas);
+    float zoom_x = canvas_viewport.w / content_w;
+    float zoom_y = canvas_viewport.h / content_h;
     float new_zoom = (zoom_x < zoom_y) ? zoom_x : zoom_y;
 
     /* Clamp zoom to valid range */
     new_zoom = (new_zoom < 0.1f) ? 0.1f : (new_zoom > 12.0f) ? 12.0f : new_zoom;
 
     /* Set new zoom and center */
-    canvas->zoom = new_zoom;
-    canvas->center.x = (min_x + max_x) * 0.5f;
-    canvas->center.y = (min_y + max_y) * 0.5f;
+    canvas_view_set_center_zoom(canvas,
+                                vec2_make((min_x + max_x) * 0.5f, (min_y + max_y) * 0.5f),
+                                new_zoom);
 }
 
 static void app_toggle_grid(Workspace* workspace)
@@ -246,14 +244,20 @@ void ui_menu_execute(Workspace* workspace, MenuId id)
 
     /* View menu */
     case MENU_ID_VIEW_ZOOM_IN:
+    {
+        Vec2 center = canvas_view_center(&workspace->canvas);
         canvas_view_zoom_at_screen_point(&workspace->canvas, 1.25f,
-                                        canvas_view_world_to_screen(&workspace->canvas, workspace->canvas.center));
+                                         canvas_view_world_to_screen(&workspace->canvas, center));
         break;
+    }
 
     case MENU_ID_VIEW_ZOOM_OUT:
+    {
+        Vec2 center = canvas_view_center(&workspace->canvas);
         canvas_view_zoom_at_screen_point(&workspace->canvas, 0.8f,
-                                        canvas_view_world_to_screen(&workspace->canvas, workspace->canvas.center));
+                                         canvas_view_world_to_screen(&workspace->canvas, center));
         break;
+    }
 
     case MENU_ID_VIEW_ZOOM_FIT:
         app_zoom_to_fit(workspace);

--- a/src/ui/ui_menu_actions.h
+++ b/src/ui/ui_menu_actions.h
@@ -10,14 +10,14 @@ struct Workspace;
  * @brief Menu action handler interface.
  *
  * This module provides centralized menu action handling.
- * All menu item clicks are routed through ui_menu_execute()
+ * All menu item clicks are routed through `ui_menu_execute()`
  * which dispatches to the appropriate handler.
  */
 
 /**
- * @brief Execute a menu action
- * @param workspace The workspace to operate on
- * @param id The menu item ID to execute
+ * @brief Execute a menu action.
+ * @param workspace [in,out] The workspace to operate on.
+ * @param id [in] The menu item ID to execute.
  *
  * Routes the menu ID to the appropriate handler function.
  * This is the single entry point for all menu actions.
@@ -26,8 +26,8 @@ void ui_menu_execute(struct Workspace* workspace, MenuId id);
 
 /**
  * @brief Check whether a menu action is currently implemented and available.
- * @param id Menu item ID
- * @return non-zero if available, zero if it should be disabled in UI
+ * @param id [in] Menu item ID.
+ * @return Non-zero if available, zero if it should be disabled in UI.
  */
 int ui_menu_is_action_available(MenuId id);
 

--- a/src/ui/ui_menu_def.c
+++ b/src/ui/ui_menu_def.c
@@ -16,105 +16,77 @@
  * keyboard shortcut, ID, and parent menu ID.
  */
 static MenuItemDef g_menu_items[] = {
-    /* File menu (top-level) */
     { MENU_ITEM_SUBMENU, "File", "", MENU_ID_FILE, -1 },
 
-    /* File > New */
     { MENU_ITEM_ACTION, "New", "Ctrl+N", MENU_ID_FILE_NEW, MENU_ID_FILE },
-
-    /* File > Open */
     { MENU_ITEM_ACTION, "Open", "Ctrl+O", MENU_ID_FILE_OPEN, MENU_ID_FILE },
-
-    /* File > Save */
     { MENU_ITEM_ACTION, "Save", "Ctrl+S", MENU_ID_FILE_SAVE, MENU_ID_FILE },
-
-    /* File > Save As... */
     { MENU_ITEM_ACTION, "Save As...", "", MENU_ID_FILE_SAVE_AS, MENU_ID_FILE },
 
     /* Separator */
     { MENU_ITEM_SEPARATOR, "", "", -1, MENU_ID_FILE },
 
-    /* File > Export as PNG */
     { MENU_ITEM_ACTION, "Export as PNG", "", MENU_ID_FILE_EXPORT_PNG, MENU_ID_FILE },
 
     /* Separator */
     { MENU_ITEM_SEPARATOR, "", "", -1, MENU_ID_FILE },
 
-    /* File > Recent Files (submenu placeholder) */
     { MENU_ITEM_SUBMENU, "Recent Files", "", MENU_ID_FILE_RECENT, MENU_ID_FILE },
 
     /* Separator */
     { MENU_ITEM_SEPARATOR, "", "", -1, MENU_ID_FILE },
 
-    /* File > Exit */
     { MENU_ITEM_ACTION, "Exit", "Alt+F4", MENU_ID_FILE_EXIT, MENU_ID_FILE },
 
-    /* Edit menu (top-level) */
     { MENU_ITEM_SUBMENU, "Edit", "", MENU_ID_EDIT, -1 },
 
-    /* Edit > Undo */
     { MENU_ITEM_ACTION, "Undo", "Ctrl+Z", MENU_ID_EDIT_UNDO, MENU_ID_EDIT },
-
-    /* Edit > Redo */
     { MENU_ITEM_ACTION, "Redo", "Ctrl+Y", MENU_ID_EDIT_REDO, MENU_ID_EDIT },
 
     /* Separator */
     { MENU_ITEM_SEPARATOR, "", "", -1, MENU_ID_EDIT },
 
-    /* Edit > Cut */
     { MENU_ITEM_ACTION, "Cut", "Ctrl+X", MENU_ID_EDIT_CUT, MENU_ID_EDIT },
-
-    /* Edit > Copy */
     { MENU_ITEM_ACTION, "Copy", "Ctrl+C", MENU_ID_EDIT_COPY, MENU_ID_EDIT },
-
-    /* Edit > Paste */
     { MENU_ITEM_ACTION, "Paste", "Ctrl+V", MENU_ID_EDIT_PASTE, MENU_ID_EDIT },
-
-    /* Edit > Delete */
     { MENU_ITEM_ACTION, "Delete", "Del", MENU_ID_EDIT_DELETE, MENU_ID_EDIT },
 
     /* Separator */
     { MENU_ITEM_SEPARATOR, "", "", -1, MENU_ID_EDIT },
 
-    /* Edit > Select All */
     { MENU_ITEM_ACTION, "Select All", "Ctrl+A", MENU_ID_EDIT_SELECT_ALL, MENU_ID_EDIT },
 
-    /* View menu (top-level) */
     { MENU_ITEM_SUBMENU, "View", "", MENU_ID_VIEW, -1 },
 
-    /* View > Zoom In */
     { MENU_ITEM_ACTION, "Zoom In", "Ctrl++", MENU_ID_VIEW_ZOOM_IN, MENU_ID_VIEW },
-
-    /* View > Zoom Out */
     { MENU_ITEM_ACTION, "Zoom Out", "Ctrl+-", MENU_ID_VIEW_ZOOM_OUT, MENU_ID_VIEW },
-
-    /* View > Zoom to Fit */
     { MENU_ITEM_ACTION, "Zoom to Fit", "Ctrl+0", MENU_ID_VIEW_ZOOM_FIT, MENU_ID_VIEW },
 
     /* Separator */
     { MENU_ITEM_SEPARATOR, "", "", -1, MENU_ID_VIEW },
 
-    /* View > Toggle Grid */
     { MENU_ITEM_ACTION, "Toggle Grid", "", MENU_ID_VIEW_TOGGLE_GRID, MENU_ID_VIEW },
-
-    /* View > Toggle Inspector Panel */
     { MENU_ITEM_ACTION, "Toggle Inspector Panel", "", MENU_ID_VIEW_TOGGLE_INSPECTOR, MENU_ID_VIEW },
 
-    /* Help menu (top-level) */
     { MENU_ITEM_SUBMENU, "Help", "", MENU_ID_HELP, -1 },
 
-    /* Help > Keyboard Shortcuts */
     { MENU_ITEM_ACTION, "Keyboard Shortcuts", "?", MENU_ID_HELP_SHORTCUTS, MENU_ID_HELP },
-
-    /* Help > About */
     { MENU_ITEM_ACTION, "About", "", MENU_ID_HELP_ABOUT, MENU_ID_HELP },
 };
 
+/**
+ * @brief Get the number of menu item definitions.
+ * @return Total count of entries in the menu definition table.
+ */
 int ui_menu_def_count(void)
 {
     return (int)(sizeof(g_menu_items) / sizeof(g_menu_items[0]));
 }
 
+/**
+ * @brief Get the menu item definition table.
+ * @return Pointer to the static menu item array.
+ */
 const MenuItemDef* ui_menu_def_items(void)
 {
     return g_menu_items;

--- a/src/ui/ui_menubar.c
+++ b/src/ui/ui_menubar.c
@@ -84,6 +84,11 @@ static void ui_build_menu_item_text(char* out_text, size_t out_size, const MenuI
     }
 }
 
+/**
+ * @brief Create a new menu bar instance.
+ * @param ctx [in] Nuklear context pointer.
+ * @return Newly allocated menu bar, or `NULL` on allocation failure.
+ */
 UiMenuBar* ui_menubar_create(void* ctx)
 {
     UiMenuBar* menubar = (UiMenuBar*)calloc(1, sizeof(*menubar));
@@ -101,21 +106,42 @@ UiMenuBar* ui_menubar_create(void* ctx)
     return menubar;
 }
 
+/**
+ * @brief Release menu bar resources.
+ * @param menubar [in] Menu bar to destroy; no-op when `NULL`.
+ * @return None.
+ */
 void ui_menubar_destroy(UiMenuBar* menubar)
 {
     free(menubar);
 }
 
+/**
+ * @brief Query whether the inspector panel is visible.
+ * @param menubar [in] Menu bar instance; defaults to `true` when `NULL`.
+ * @return `true` if inspector is visible, `false` otherwise.
+ */
 bool ui_menubar_inspector_visible(const UiMenuBar* menubar)
 {
     return menubar ? menubar->show_inspector : true;
 }
 
+/**
+ * @brief Get the current menu bar height.
+ * @param menubar [in] Menu bar instance; defaults to `MENU_BAR_HEIGHT` when `NULL`.
+ * @return Menu bar height in pixels.
+ */
 float ui_menubar_height(const UiMenuBar* menubar)
 {
     return menubar ? menubar->menu_height : MENU_BAR_HEIGHT;
 }
 
+/**
+ * @brief Set the menu bar height.
+ * @param menubar [in,out] Menu bar instance; no-op when `NULL`.
+ * @param height [in] New height in pixels; minimum enforced to `MENU_BAR_HEIGHT`.
+ * @return None.
+ */
 void ui_menubar_set_height(UiMenuBar* menubar, float height)
 {
     if (!menubar) {
@@ -125,6 +151,13 @@ void ui_menubar_set_height(UiMenuBar* menubar, float height)
     menubar->menu_height = (height > 10.0f) ? height : MENU_BAR_HEIGHT;
 }
 
+/**
+ * @brief Assign the available theme registry to the menu bar.
+ * @param menubar [in,out] Menu bar instance; no-op when `NULL`.
+ * @param themes [in] Array of theme descriptors; may be `NULL` when `theme_count` is zero.
+ * @param theme_count [in] Number of themes in `themes` array; treated as zero when negative.
+ * @return None.
+ */
 void ui_menubar_set_themes(UiMenuBar* menubar, const UiThemeDescriptor* themes, int theme_count)
 {
     if (!menubar) {
@@ -142,6 +175,12 @@ void ui_menubar_set_themes(UiMenuBar* menubar, const UiThemeDescriptor* themes, 
     }
 }
 
+/**
+ * @brief Set the active theme by index.
+ * @param menubar [in,out] Menu bar instance; no-op when `NULL`.
+ * @param theme_index [in] Theme index to activate; clamped to valid range.
+ * @return None.
+ */
 void ui_menubar_set_active_theme_index(UiMenuBar* menubar, int theme_index)
 {
     if (!menubar) {
@@ -165,6 +204,11 @@ void ui_menubar_set_active_theme_index(UiMenuBar* menubar, int theme_index)
     menubar->active_theme_index = theme_index;
 }
 
+/**
+ * @brief Atomically consume any pending theme change request.
+ * @param menubar [in,out] Menu bar instance; returns `-1` when `NULL`.
+ * @return Requested theme index, or `-1` if no request is pending.
+ */
 int ui_menubar_take_theme_request(UiMenuBar* menubar)
 {
     int requested_theme_index = -1;
@@ -178,6 +222,11 @@ int ui_menubar_take_theme_request(UiMenuBar* menubar)
     return requested_theme_index;
 }
 
+/**
+ * @brief Atomically consume any pending theme reload request.
+ * @param menubar [in,out] Menu bar instance; returns `0` when `NULL`.
+ * @return `1` if reload was requested, `0` otherwise.
+ */
 int ui_menubar_take_theme_reload_request(UiMenuBar* menubar)
 {
     int requested = 0;
@@ -192,7 +241,10 @@ int ui_menubar_take_theme_reload_request(UiMenuBar* menubar)
 }
 
 /**
- * @brief Render dropdown menu items
+ * @brief Render all dropdown menu items under a given parent ID.
+ * @param ctx [in] Nuklear context.
+ * @param parent_id [in] Parent menu ID to render children for.
+ * @return Clicked menu item ID, or `-1` if no item was clicked.
  */
 static int ui_render_dropdown(struct nk_context* ctx, int parent_id)
 {

--- a/src/ui/ui_menubar.c
+++ b/src/ui/ui_menubar.c
@@ -17,11 +17,13 @@
 
 #include "nuklear/nuklear.h"
 #include "nuklear/nuklear_glfw_gl3.h"
+#include <ui/ui_theme.h>
 
 #include <stdio.h>
 #include <stdlib.h>
 
 #define MENU_BAR_HEIGHT 30.0f
+#define MENU_PARENT_THEME 900
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
 typedef struct UiTopMenuDef {
@@ -35,6 +37,7 @@ static const UiTopMenuDef g_top_menus[] = {
     { "File", MENU_ID_FILE, {210.0f, 300.0f}, 58.0f },
     { "Edit", MENU_ID_EDIT, {210.0f, 300.0f}, 58.0f },
     { "View", MENU_ID_VIEW, {220.0f, 300.0f}, 62.0f },
+    { "Theme", MENU_PARENT_THEME, {260.0f, 280.0f}, 76.0f },
     { "Help", MENU_ID_HELP, {220.0f, 220.0f}, 62.0f },
 };
 
@@ -79,6 +82,9 @@ UiMenuBar* ui_menubar_create(void* ctx)
     menubar->ctx = (struct nk_context*)ctx;
     menubar->show_inspector = true;
     menubar->menu_height = MENU_BAR_HEIGHT;
+    menubar->active_theme_index = 0;
+    menubar->requested_theme_index = -1;
+    menubar->requested_theme_reload = 0;
 
     return menubar;
 }
@@ -105,6 +111,72 @@ void ui_menubar_set_height(UiMenuBar* menubar, float height)
     }
 
     menubar->menu_height = (height > 10.0f) ? height : MENU_BAR_HEIGHT;
+}
+
+void ui_menubar_set_themes(UiMenuBar* menubar, const UiThemeDescriptor* themes, int theme_count)
+{
+    if (!menubar) {
+        return;
+    }
+
+    menubar->themes = themes;
+    menubar->theme_count = (theme_count > 0) ? theme_count : 0;
+
+    if (menubar->theme_count == 0) {
+        menubar->active_theme_index = -1;
+    } else if (menubar->active_theme_index < 0 ||
+               menubar->active_theme_index >= menubar->theme_count) {
+        menubar->active_theme_index = 0;
+    }
+}
+
+void ui_menubar_set_active_theme_index(UiMenuBar* menubar, int theme_index)
+{
+    if (!menubar) {
+        return;
+    }
+
+    if (menubar->theme_count <= 0) {
+        menubar->active_theme_index = -1;
+        return;
+    }
+
+    if (theme_index < 0) {
+        menubar->active_theme_index = 0;
+        return;
+    }
+    if (theme_index >= menubar->theme_count) {
+        menubar->active_theme_index = menubar->theme_count - 1;
+        return;
+    }
+
+    menubar->active_theme_index = theme_index;
+}
+
+int ui_menubar_take_theme_request(UiMenuBar* menubar)
+{
+    int requested_theme_index = -1;
+
+    if (!menubar) {
+        return -1;
+    }
+
+    requested_theme_index = menubar->requested_theme_index;
+    menubar->requested_theme_index = -1;
+    return requested_theme_index;
+}
+
+int ui_menubar_take_theme_reload_request(UiMenuBar* menubar)
+{
+    int requested = 0;
+
+    if (!menubar) {
+        return 0;
+    }
+
+    requested = menubar->requested_theme_reload;
+    menubar->requested_theme_reload = 0;
+    return requested;
 }
 
 /**
@@ -159,17 +231,67 @@ static int ui_render_dropdown(struct nk_context* ctx, int parent_id)
     return clicked_id;
 }
 
-static int ui_render_top_menu(struct nk_context* ctx, const UiTopMenuDef* menu)
+static int ui_render_theme_dropdown(UiMenuBar* menubar)
 {
+    struct nk_context* ctx = NULL;
+
+    if (!menubar) {
+        return -1;
+    }
+
+    ctx = menubar->ctx;
+    if (!ctx) {
+        return -1;
+    }
+
+    if (!menubar->themes || menubar->theme_count <= 0) {
+        nk_label(ctx, "No themes available", NK_TEXT_LEFT);
+        return -1;
+    }
+
+    if (nk_menu_item_label(ctx, "Reload Themes", NK_TEXT_LEFT)) {
+        menubar->requested_theme_reload = 1;
+    }
+    nk_labelf(ctx, NK_TEXT_CENTERED, "----------------");
+
+    for (int i = 0; i < menubar->theme_count; ++i) {
+        const UiThemeDescriptor* theme = &menubar->themes[i];
+        char item_label[128];
+        const char* label = (theme->label && theme->label[0] != '\0') ? theme->label : "Unnamed Theme";
+        const char* marker = (i == menubar->active_theme_index) ? "[x]" : "[ ]";
+
+        snprintf(item_label, sizeof(item_label), "%s %s", marker, label);
+        if (nk_menu_item_label(ctx, item_label, NK_TEXT_LEFT)) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+static int ui_render_top_menu(UiMenuBar* menubar, const UiTopMenuDef* menu)
+{
+    struct nk_context* ctx = NULL;
     int clicked_id = -1;
 
-    if (!ctx || !menu || !menu->label) {
+    if (!menubar || !menu || !menu->label) {
+        return -1;
+    }
+    ctx = menubar->ctx;
+    if (!ctx) {
         return -1;
     }
 
     if (nk_menu_begin_label(ctx, menu->label, NK_TEXT_LEFT, menu->popup_size)) {
         nk_layout_row_dynamic(ctx, 25.0f, 1);
-        clicked_id = ui_render_dropdown(ctx, menu->parent_id);
+        if (menu->parent_id == MENU_PARENT_THEME) {
+            int theme_index = ui_render_theme_dropdown(menubar);
+            if (theme_index >= 0) {
+                menubar->requested_theme_index = theme_index;
+            }
+        } else {
+            clicked_id = ui_render_dropdown(ctx, menu->parent_id);
+        }
         nk_menu_end(ctx);
     }
 
@@ -243,7 +365,7 @@ void ui_menubar_build(UiMenuBar* menubar, Workspace* workspace, int window_width
         for (size_t i = 0; i < menu_count; i++) {
             int id;
             nk_layout_row_push(ctx, g_top_menus[i].item_width);
-            id = ui_render_top_menu(ctx, &g_top_menus[i]);
+            id = ui_render_top_menu(menubar, &g_top_menus[i]);
             if (id != -1) {
                 clicked_id = id;
             }

--- a/src/ui/ui_menubar.c
+++ b/src/ui/ui_menubar.c
@@ -1,3 +1,15 @@
+/**
+ * @file ui_menubar.c
+ * @brief Top menu bar rendering and menu interaction handling.
+ *
+ * Role in project:
+ * - Renders top-level menus, quick action buttons, and theme menu.
+ * - Converts UI clicks into menu action dispatch requests.
+ *
+ * Module relationships:
+ * - Uses static menu definitions and action executor modules.
+ * - Called by `ui_system` once per frame.
+ */
 #include "ui_menubar.h"
 
 #include "ui_menu_def.h"

--- a/src/ui/ui_menubar.h
+++ b/src/ui/ui_menubar.h
@@ -6,6 +6,8 @@
 
 struct nk_context;
 struct Workspace;
+struct UiThemeDescriptor;
+typedef struct UiThemeDescriptor UiThemeDescriptor;
 
 /**
  * @file ui_menubar.h
@@ -22,6 +24,11 @@ typedef struct UiMenuBar {
     struct nk_context* ctx;
     bool show_inspector;        /**< Inspector panel visibility */
     float menu_height;          /**< Height of the menu bar */
+    const UiThemeDescriptor* themes;
+    int theme_count;
+    int active_theme_index;
+    int requested_theme_index;
+    int requested_theme_reload;
 } UiMenuBar;
 
 /**
@@ -65,5 +72,9 @@ float ui_menubar_height(const UiMenuBar* menubar);
  * @param height Height in pixels
  */
 void ui_menubar_set_height(UiMenuBar* menubar, float height);
+void ui_menubar_set_themes(UiMenuBar* menubar, const UiThemeDescriptor* themes, int theme_count);
+void ui_menubar_set_active_theme_index(UiMenuBar* menubar, int theme_index);
+int ui_menubar_take_theme_request(UiMenuBar* menubar);
+int ui_menubar_take_theme_reload_request(UiMenuBar* menubar);
 
 #endif /* GLDRAW_UI_UI_MENUBAR_H */

--- a/src/ui/ui_menubar.h
+++ b/src/ui/ui_menubar.h
@@ -18,63 +18,95 @@ typedef struct UiThemeDescriptor UiThemeDescriptor;
  */
 
 /**
- * @brief Menu bar state structure
+ * @brief Menu bar state structure.
+ *
+ * Owns Nuklear context reference, layout metrics, and pending theme request flags.
  */
 typedef struct UiMenuBar {
-    struct nk_context* ctx;
-    bool show_inspector;        /**< Inspector panel visibility */
-    float menu_height;          /**< Height of the menu bar */
-    const UiThemeDescriptor* themes;
-    int theme_count;
-    int active_theme_index;
-    int requested_theme_index;
-    int requested_theme_reload;
+    struct nk_context* ctx;              /**< Nuklear context (not owned) */
+    bool show_inspector;                /**< Inspector panel visibility */
+    float menu_height;                  /**< Height of the menu bar */
+    const UiThemeDescriptor* themes;     /**< Available theme registry (not owned) */
+    int theme_count;                    /**< Number of themes in registry */
+    int active_theme_index;             /**< Currently active theme index */
+    int requested_theme_index;          /**< Pending theme change request (-1 = none) */
+    int requested_theme_reload;         /**< Non-zero when theme reload is requested */
 } UiMenuBar;
 
 /**
- * @brief Create a new menu bar
- * @param ctx Nuklear context
- * @return New menu bar, or NULL on failure
+ * @brief Create a new menu bar instance.
+ * @param ctx [in] Nuklear context pointer.
+ * @return Newly allocated menu bar, or `NULL` on allocation failure.
  */
 UiMenuBar* ui_menubar_create(void* ctx);
 
 /**
- * @brief Destroy a menu bar
- * @param menubar Menu bar to destroy
+ * @brief Release menu bar resources.
+ * @param menubar [in] Menu bar to destroy; no-op when `NULL`.
+ * @return None.
  */
 void ui_menubar_destroy(UiMenuBar* menubar);
 
 /**
- * @brief Build and render the menu bar
- * @param menubar Menu bar instance
- * @param workspace Workspace to operate on
- * @param window_width Current window width
+ * @brief Build and render the menu bar.
+ * @param menubar [in,out] Menu bar instance; no-op when `NULL`.
+ * @param workspace [in,out] Workspace to operate on; used for menu action dispatch.
+ * @param window_width [in] Current window width in pixels.
+ * @return None.
  */
 void ui_menubar_build(UiMenuBar* menubar, struct Workspace* workspace, int window_width);
 
 /**
- * @brief Check if inspector is visible
- * @param menubar Menu bar instance
- * @return true if inspector should be shown
+ * @brief Query whether the inspector panel is visible.
+ * @param menubar [in] Menu bar instance; defaults to `true` when `NULL`.
+ * @return `true` if inspector is visible, `false` otherwise.
  */
 bool ui_menubar_inspector_visible(const UiMenuBar* menubar);
 
 /**
- * @brief Get menu bar height
- * @param menubar Menu bar instance
- * @return Height in pixels
+ * @brief Get the current menu bar height.
+ * @param menubar [in] Menu bar instance; defaults to `MENU_BAR_HEIGHT` when `NULL`.
+ * @return Menu bar height in pixels.
  */
 float ui_menubar_height(const UiMenuBar* menubar);
 
 /**
- * @brief Set menu bar height
- * @param menubar Menu bar instance
- * @param height Height in pixels
+ * @brief Set the menu bar height.
+ * @param menubar [in,out] Menu bar instance; no-op when `NULL`.
+ * @param height [in] New height in pixels; minimum enforced to `MENU_BAR_HEIGHT`.
+ * @return None.
  */
 void ui_menubar_set_height(UiMenuBar* menubar, float height);
+
+/**
+ * @brief Assign the available theme registry to the menu bar.
+ * @param menubar [in,out] Menu bar instance; no-op when `NULL`.
+ * @param themes [in] Array of theme descriptors; may be `NULL` when `theme_count` is zero.
+ * @param theme_count [in] Number of themes in `themes` array; treated as zero when negative.
+ * @return None.
+ */
 void ui_menubar_set_themes(UiMenuBar* menubar, const UiThemeDescriptor* themes, int theme_count);
+
+/**
+ * @brief Set the active theme by index.
+ * @param menubar [in,out] Menu bar instance; no-op when `NULL`.
+ * @param theme_index [in] Theme index to activate; clamped to valid range.
+ * @return None.
+ */
 void ui_menubar_set_active_theme_index(UiMenuBar* menubar, int theme_index);
+
+/**
+ * @brief Atomically consume any pending theme change request.
+ * @param menubar [in,out] Menu bar instance; returns `-1` when `NULL`.
+ * @return Requested theme index, or `-1` if no request is pending.
+ */
 int ui_menubar_take_theme_request(UiMenuBar* menubar);
+
+/**
+ * @brief Atomically consume any pending theme reload request.
+ * @param menubar [in,out] Menu bar instance; returns `0` when `NULL`.
+ * @return `1` if reload was requested, `0` otherwise.
+ */
 int ui_menubar_take_theme_reload_request(UiMenuBar* menubar);
 
 #endif /* GLDRAW_UI_UI_MENUBAR_H */

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -27,16 +27,27 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define UI_MAX_VERTEX_BUFFER (512 * 1024)
 #define UI_MAX_ELEMENT_BUFFER (128 * 1024)
 #define UI_MIN_CANVAS_WIDTH 320.0f
+#define UI_THEME_ID_CAPACITY 64
+#define UI_THEME_SETTINGS_PATH "gldraw.settings.json"
+#define UI_THEME_DIRECTORY_PATH "themes"
+#define UI_THEME_DESCRIPTOR_CACHE_MAX 64
+#define UI_THEME_WATCH_INTERVAL_SECONDS 0.35
 
 struct UiSystem {
     struct nk_glfw glfw;
     struct nk_context* ctx;
     UiMenuBar* menu_bar;
     UiThemeTokens theme;
+    char active_theme_id[UI_THEME_ID_CAPACITY];
+    char theme_settings_path[260];
+    UiThemeDescriptor theme_descriptors_cache[UI_THEME_DESCRIPTOR_CACHE_MAX];
+    unsigned long long theme_directory_signature;
+    double theme_watch_last_check_seconds;
     RectF appbar_bounds;
     RectF rail_bounds;
     RectF panel_bounds;
@@ -49,6 +60,12 @@ struct UiSystem {
     double last_frame_seconds;
 };
 
+typedef enum UiThemeReloadReason {
+    UI_THEME_RELOAD_REASON_STARTUP = 0,
+    UI_THEME_RELOAD_REASON_AUTO,
+    UI_THEME_RELOAD_REASON_MANUAL
+} UiThemeReloadReason;
+
 static float ui_clampf(float value, float min_value, float max_value)
 {
     if (value < min_value) {
@@ -58,6 +75,171 @@ static float ui_clampf(float value, float min_value, float max_value)
         return max_value;
     }
     return value;
+}
+
+static const char* ui_theme_reload_reason_label(UiThemeReloadReason reason)
+{
+    switch (reason) {
+    case UI_THEME_RELOAD_REASON_MANUAL:
+        return "manually";
+    case UI_THEME_RELOAD_REASON_AUTO:
+        return "auto";
+    case UI_THEME_RELOAD_REASON_STARTUP:
+    default:
+        return "startup";
+    }
+}
+
+static void ui_system_sync_menubar_themes(UiSystem* ui)
+{
+    int theme_count = 0;
+    int active_theme_index = 0;
+
+    if (!ui || !ui->menu_bar) {
+        return;
+    }
+
+    theme_count = ui_theme_count();
+    if (theme_count < 0) {
+        theme_count = 0;
+    }
+    if (theme_count > UI_THEME_DESCRIPTOR_CACHE_MAX) {
+        theme_count = UI_THEME_DESCRIPTOR_CACHE_MAX;
+    }
+
+    for (int i = 0; i < theme_count; ++i) {
+        const UiThemeDescriptor* descriptor = ui_theme_descriptor_at(i);
+        ui->theme_descriptors_cache[i].id = descriptor ? descriptor->id : "";
+        ui->theme_descriptors_cache[i].label = descriptor ? descriptor->label : "";
+    }
+
+    ui_menubar_set_themes(ui->menu_bar, ui->theme_descriptors_cache, theme_count);
+
+    active_theme_index = ui_theme_index_of_id(ui->active_theme_id);
+    if (active_theme_index < 0 || active_theme_index >= theme_count) {
+        active_theme_index = ui_theme_index_of_id(ui_theme_default_id());
+    }
+    if (active_theme_index < 0) {
+        active_theme_index = 0;
+    }
+    ui_menubar_set_active_theme_index(ui->menu_bar, active_theme_index);
+}
+
+static int ui_system_set_theme(UiSystem* ui, const char* theme_id, int persist_selection)
+{
+    int theme_index = -1;
+    const UiThemeDescriptor* descriptor = NULL;
+
+    if (!ui || !ui->ctx) {
+        return 0;
+    }
+
+    theme_index = ui_theme_index_of_id(theme_id);
+    if (theme_index < 0) {
+        theme_index = ui_theme_index_of_id(ui_theme_default_id());
+    }
+    descriptor = ui_theme_descriptor_at(theme_index);
+    if (!descriptor || !descriptor->id) {
+        return 0;
+    }
+
+    snprintf(ui->active_theme_id,
+             sizeof(ui->active_theme_id),
+             "%s",
+             descriptor->id);
+
+    ui->theme = ui_theme_tokens_for_id(ui->active_theme_id);
+    ui_theme_apply(ui->ctx, &ui->theme);
+
+    if (ui->menu_bar) {
+        ui_menubar_set_height(ui->menu_bar, ui->theme.menu_height);
+        ui_system_sync_menubar_themes(ui);
+    }
+
+    if (persist_selection) {
+        ui_theme_save_selected_id(ui->theme_settings_path, ui->active_theme_id);
+    }
+
+    return 1;
+}
+
+static void ui_system_reload_themes(UiSystem* ui,
+                                    Workspace* workspace,
+                                    int notify_status,
+                                    UiThemeReloadReason reason)
+{
+    char previous_theme_id[UI_THEME_ID_CAPACITY];
+    int custom_theme_count = 0;
+    int fallback_to_default = 0;
+
+    if (!ui) {
+        return;
+    }
+
+    snprintf(previous_theme_id, sizeof(previous_theme_id), "%s", ui->active_theme_id);
+    custom_theme_count = ui_theme_reload_external(UI_THEME_DIRECTORY_PATH);
+    ui->theme_directory_signature = ui_theme_external_signature(UI_THEME_DIRECTORY_PATH);
+
+    /* Keep current theme id if still present; otherwise fall back through ui_system_set_theme. */
+    ui_system_set_theme(ui, previous_theme_id, 0);
+    fallback_to_default = (strcmp(previous_theme_id, ui->active_theme_id) != 0);
+
+    if (notify_status && workspace) {
+        const char* reason_label = ui_theme_reload_reason_label(reason);
+        if (fallback_to_default) {
+            snprintf(workspace->status_message,
+                     sizeof(workspace->status_message),
+                     "Themes %s reloaded (%d custom), active theme missing -> fallback",
+                     reason_label,
+                     custom_theme_count);
+        } else {
+            snprintf(workspace->status_message,
+                     sizeof(workspace->status_message),
+                     "Themes %s reloaded (%d custom)",
+                     reason_label,
+                     custom_theme_count);
+        }
+    }
+}
+
+static void ui_system_load_theme_from_settings(UiSystem* ui)
+{
+    char loaded_theme_id[UI_THEME_ID_CAPACITY];
+
+    if (!ui) {
+        return;
+    }
+
+    if (ui_theme_load_selected_id(ui->theme_settings_path,
+                                  loaded_theme_id,
+                                  sizeof(loaded_theme_id))) {
+        if (ui_system_set_theme(ui, loaded_theme_id, 0)) {
+            return;
+        }
+    }
+
+    ui_system_set_theme(ui, ui_theme_default_id(), 0);
+}
+
+static void ui_system_poll_theme_hot_reload(UiSystem* ui, Workspace* workspace, double now_seconds)
+{
+    unsigned long long signature = 0ull;
+
+    if (!ui) {
+        return;
+    }
+
+    if ((now_seconds - ui->theme_watch_last_check_seconds) < UI_THEME_WATCH_INTERVAL_SECONDS) {
+        return;
+    }
+    ui->theme_watch_last_check_seconds = now_seconds;
+
+    signature = ui_theme_external_signature(UI_THEME_DIRECTORY_PATH);
+    if (signature == ui->theme_directory_signature) {
+        return;
+    }
+
+    ui_system_reload_themes(ui, workspace, 1, UI_THEME_RELOAD_REASON_AUTO);
 }
 
 static float ui_smoothstep(float t)
@@ -464,13 +646,19 @@ UiSystem* ui_system_create(PlatformWindow* window)
     nk_glfw3_font_stash_begin(&ui->glfw, &atlas);
     nk_glfw3_font_stash_end(&ui->glfw);
 
-    ui->theme = ui_theme_default_tokens();
-    ui_theme_apply(ui->ctx, &ui->theme);
+    snprintf(ui->theme_settings_path,
+             sizeof(ui->theme_settings_path),
+             "%s",
+             UI_THEME_SETTINGS_PATH);
+
+    ui_system_reload_themes(ui, NULL, 0, UI_THEME_RELOAD_REASON_STARTUP);
+    ui->theme_watch_last_check_seconds = glfwGetTime();
 
     ui->menu_bar = ui_menubar_create(ui->ctx);
     if (ui->menu_bar) {
-        ui_menubar_set_height(ui->menu_bar, ui->theme.menu_height);
+        ui_system_sync_menubar_themes(ui);
     }
+    ui_system_load_theme_from_settings(ui);
 
     ui->inspector_anim_t = 1.0f;
     ui->inspector_target_visible = 1;
@@ -532,10 +720,31 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
     dt_seconds = (float)(now_seconds - ui->last_frame_seconds);
     ui->last_frame_seconds = now_seconds;
     dt_seconds = ui_clampf(dt_seconds, 0.0f, 0.10f);
+    ui_system_poll_theme_hot_reload(ui, workspace, now_seconds);
 
     if (ui->menu_bar) {
+        int requested_theme_index = -1;
+        int requested_theme_reload = 0;
+        const UiThemeDescriptor* requested_theme = NULL;
+
         ui_menubar_set_height(ui->menu_bar, ui->theme.menu_height);
         ui_menubar_build(ui->menu_bar, workspace, width);
+
+        requested_theme_reload = ui_menubar_take_theme_reload_request(ui->menu_bar);
+        if (requested_theme_reload) {
+            ui_system_reload_themes(ui, workspace, 1, UI_THEME_RELOAD_REASON_MANUAL);
+        }
+
+        requested_theme_index = ui_menubar_take_theme_request(ui->menu_bar);
+        if (requested_theme_index >= 0) {
+            requested_theme = ui_theme_descriptor_at(requested_theme_index);
+            if (requested_theme && ui_system_set_theme(ui, requested_theme->id, 1)) {
+                snprintf(workspace->status_message,
+                         sizeof(workspace->status_message),
+                         "Theme: %s",
+                         requested_theme->label ? requested_theme->label : requested_theme->id);
+            }
+        }
     }
 
     ui->appbar_bounds.x = 0.0f;

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -41,6 +41,8 @@ struct UiSystem {
     RectF rail_bounds;
     RectF panel_bounds;
     RectF status_bounds;
+    RectF content_bounds;
+    WorkspaceLayout layout_snapshot;
     float inspector_anim_t;
     int inspector_target_visible;
     int inspector_anim_initialized;
@@ -62,6 +64,94 @@ static float ui_smoothstep(float t)
 {
     float clamped = ui_clampf(t, 0.0f, 1.0f);
     return clamped * clamped * (3.0f - 2.0f * clamped);
+}
+
+static int ui_rectf_equals(RectF a, RectF b)
+{
+    const float eps = 1e-3f;
+    return fabsf(a.x - b.x) <= eps &&
+           fabsf(a.y - b.y) <= eps &&
+           fabsf(a.w - b.w) <= eps &&
+           fabsf(a.h - b.h) <= eps;
+}
+
+static RectF ui_clamp_rect_to_window(RectF rect, RectF window_bounds)
+{
+    float max_x = window_bounds.x + window_bounds.w;
+    float max_y = window_bounds.y + window_bounds.h;
+
+    if (rect.w < 0.0f) {
+        rect.w = 0.0f;
+    }
+    if (rect.h < 0.0f) {
+        rect.h = 0.0f;
+    }
+    if (rect.x < window_bounds.x) {
+        rect.w -= (window_bounds.x - rect.x);
+        rect.x = window_bounds.x;
+    }
+    if (rect.y < window_bounds.y) {
+        rect.h -= (window_bounds.y - rect.y);
+        rect.y = window_bounds.y;
+    }
+    if (rect.x > max_x) {
+        rect.x = max_x;
+    }
+    if (rect.y > max_y) {
+        rect.y = max_y;
+    }
+    if (rect.x + rect.w > max_x) {
+        rect.w = max_x - rect.x;
+    }
+    if (rect.y + rect.h > max_y) {
+        rect.h = max_y - rect.y;
+    }
+    if (rect.w < 0.0f) {
+        rect.w = 0.0f;
+    }
+    if (rect.h < 0.0f) {
+        rect.h = 0.0f;
+    }
+
+    return rect;
+}
+
+static void ui_publish_layout(UiSystem* ui, Workspace* workspace, int width, int height)
+{
+    WorkspaceLayout next_layout;
+    RectF window_bounds;
+    int changed = 0;
+
+    if (!ui || !workspace) {
+        return;
+    }
+
+    window_bounds.x = 0.0f;
+    window_bounds.y = 0.0f;
+    window_bounds.w = (float)width;
+    window_bounds.h = (float)height;
+
+    next_layout = workspace->layout;
+    next_layout.window_bounds = window_bounds;
+    next_layout.appbar_bounds = ui_clamp_rect_to_window(ui->appbar_bounds, window_bounds);
+    next_layout.rail_bounds = ui_clamp_rect_to_window(ui->rail_bounds, window_bounds);
+    next_layout.panel_bounds = ui_clamp_rect_to_window(ui->panel_bounds, window_bounds);
+    next_layout.status_bounds = ui_clamp_rect_to_window(ui->status_bounds, window_bounds);
+    next_layout.canvas_content_bounds = ui_clamp_rect_to_window(ui->content_bounds, window_bounds);
+
+    changed = !ui_rectf_equals(workspace->layout.window_bounds, next_layout.window_bounds) ||
+              !ui_rectf_equals(workspace->layout.appbar_bounds, next_layout.appbar_bounds) ||
+              !ui_rectf_equals(workspace->layout.rail_bounds, next_layout.rail_bounds) ||
+              !ui_rectf_equals(workspace->layout.panel_bounds, next_layout.panel_bounds) ||
+              !ui_rectf_equals(workspace->layout.status_bounds, next_layout.status_bounds) ||
+              !ui_rectf_equals(workspace->layout.canvas_content_bounds, next_layout.canvas_content_bounds);
+
+    if (changed) {
+        next_layout.layout_revision = workspace->layout.layout_revision + 1u;
+        workspace->layout = next_layout;
+    }
+
+    ui->layout_snapshot = workspace->layout;
 }
 
 static ToolContext ui_tool_context(Workspace* workspace)
@@ -319,22 +409,21 @@ static void ui_selection_panel(UiSystem* ui, Workspace* workspace, RectF bounds)
 static void ui_status_bar(UiSystem* ui, Workspace* workspace, int window_width, int window_height)
 {
     struct nk_context* ctx = ui->ctx;
-    const float margin = ui->theme.margin;
     const float status_h = ui->theme.status_height;
     const char* status_text = workspace->status_message[0] ? workspace->status_message : "Ready";
     float status_row_h = ui->theme.row_height * 0.65f;
     char zoom_text[24];
 
-    ui->status_bounds.x = margin;
-    ui->status_bounds.w = (float)window_width - (margin * 2.0f);
+    ui->status_bounds.x = 0.0f;
+    ui->status_bounds.w = (float)window_width;
     ui->status_bounds.h = status_h;
-    ui->status_bounds.y = (float)window_height - margin - status_h;
+    ui->status_bounds.y = (float)window_height - status_h;
 
     if (ui->status_bounds.w <= 32.0f || ui->status_bounds.h <= 14.0f) {
         return;
     }
 
-    snprintf(zoom_text, sizeof(zoom_text), "Zoom: %.0f%%", workspace->canvas.zoom * 100.0f);
+    snprintf(zoom_text, sizeof(zoom_text), "Zoom: %.0f%%", canvas_view_zoom(&workspace->canvas) * 100.0f);
 
     if (nk_begin(ctx, "Status",
                  nk_rect(ui->status_bounds.x, ui->status_bounds.y, ui->status_bounds.w, ui->status_bounds.h),
@@ -454,26 +543,23 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
     ui->appbar_bounds.w = (float)width;
     ui->appbar_bounds.h = ui_menubar_height(ui->menu_bar);
 
-    content_top = ui->appbar_bounds.h + ui->theme.margin;
-    content_bottom = (float)height - ui->theme.margin - ui->theme.status_height;
+    content_top = ui->appbar_bounds.h;
+    content_bottom = (float)height - ui->theme.status_height;
     content_height = content_bottom - content_top;
-    if (content_height < 80.0f) {
-        content_height = 80.0f;
+    if (content_height < 1.0f) {
+        content_height = 1.0f;
     }
 
-    rail_bounds.x = ui->theme.margin;
+    rail_bounds.x = 0.0f;
     rail_bounds.y = content_top;
     rail_bounds.w = ui->theme.tool_rail_width;
     rail_bounds.h = content_height;
     ui_tool_rail(ui, workspace, rail_bounds);
 
     inspector_requested = ui_menubar_inspector_visible(ui->menu_bar);
-    needed_width = ui->theme.margin * 2.0f +
-                   ui->theme.tool_rail_width +
-                   ui->theme.gap +
-                   UI_MIN_CANVAS_WIDTH;
+    needed_width = ui->theme.tool_rail_width + UI_MIN_CANVAS_WIDTH;
     if (inspector_requested) {
-        needed_width += ui->theme.gap + ui->theme.panel_width;
+        needed_width += ui->theme.panel_width;
     }
     inspector_target_visible = inspector_requested && ((float)width >= needed_width);
     ui->inspector_target_visible = inspector_target_visible;
@@ -497,8 +583,8 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
         inspector_eased_t = ui_smoothstep(ui->inspector_anim_t);
         inspector_bounds.w = ui->theme.panel_width;
         inspector_bounds.h = content_height;
-        inspector_hidden_x = (float)width + ui->theme.gap;
-        inspector_shown_x = (float)width - ui->theme.margin - inspector_bounds.w;
+        inspector_hidden_x = (float)width;
+        inspector_shown_x = (float)width - inspector_bounds.w;
         inspector_bounds.x = inspector_hidden_x + (inspector_shown_x - inspector_hidden_x) * inspector_eased_t;
         inspector_bounds.y = content_top;
         ui_selection_panel(ui, workspace, inspector_bounds);
@@ -510,6 +596,24 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
     }
 
     ui_status_bar(ui, workspace, width, height);
+
+    ui->content_bounds.x = ui->rail_bounds.x + ui->rail_bounds.w;
+    ui->content_bounds.y = ui->appbar_bounds.y + ui->appbar_bounds.h;
+    if (ui->panel_bounds.w > 1e-3f) {
+        ui->content_bounds.w = ui->panel_bounds.x - ui->content_bounds.x;
+    } else {
+        ui->content_bounds.w = (float)width - ui->content_bounds.x;
+    }
+    ui->content_bounds.h = ui->status_bounds.y - ui->content_bounds.y;
+
+    if (ui->content_bounds.w < 1.0f) {
+        ui->content_bounds.w = 1.0f;
+    }
+    if (ui->content_bounds.h < 1.0f) {
+        ui->content_bounds.h = 1.0f;
+    }
+
+    ui_publish_layout(ui, workspace, width, height);
 }
 
 void ui_system_render(UiSystem* ui)
@@ -520,18 +624,53 @@ void ui_system_render(UiSystem* ui)
     nk_glfw3_render(&ui->glfw, NK_ANTI_ALIASING_ON, UI_MAX_VERTEX_BUFFER, UI_MAX_ELEMENT_BUFFER);
 }
 
+int ui_system_has_active_interaction(const UiSystem* ui)
+{
+    if (!ui || !ui->ctx) {
+        return 0;
+    }
+
+    return nk_item_is_any_active(ui->ctx);
+}
+
 int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos)
 {
     if (!ui || !ui->ctx) {
         return 0;
     }
 
-    if (nk_item_is_any_active(ui->ctx)) {
+    if (ui_system_has_active_interaction(ui)) {
         return 1;
     }
 
-    return rectf_contains_point(&ui->appbar_bounds, screen_pos) ||
-           rectf_contains_point(&ui->rail_bounds, screen_pos) ||
-           rectf_contains_point(&ui->panel_bounds, screen_pos) ||
-           rectf_contains_point(&ui->status_bounds, screen_pos);
+    return rectf_contains_point(&ui->layout_snapshot.appbar_bounds, screen_pos) ||
+           rectf_contains_point(&ui->layout_snapshot.rail_bounds, screen_pos) ||
+           rectf_contains_point(&ui->layout_snapshot.panel_bounds, screen_pos) ||
+           rectf_contains_point(&ui->layout_snapshot.status_bounds, screen_pos);
+}
+
+RectF ui_system_content_bounds(const UiSystem* ui)
+{
+    RectF bounds = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    if (!ui) {
+        return bounds;
+    }
+
+    return ui->layout_snapshot.canvas_content_bounds;
+}
+
+Color ui_system_canvas_background(const UiSystem* ui)
+{
+    Color background = {0.11f, 0.12f, 0.14f, 1.0f};
+
+    if (!ui) {
+        return background;
+    }
+
+    background.r = (float)ui->theme.canvas_background.r / 255.0f;
+    background.g = (float)ui->theme.canvas_background.g / 255.0f;
+    background.b = (float)ui->theme.canvas_background.b / 255.0f;
+    background.a = (float)ui->theme.canvas_background.a / 255.0f;
+    return background;
 }

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -1,3 +1,15 @@
+/**
+ * @file ui_system.c
+ * @brief Nuklear UI system implementation (menu, tool rail, inspector, status).
+ *
+ * Role in project:
+ * - Builds all editor UI panels and theme behavior each frame.
+ * - Publishes layout bounds that drive canvas viewport and pointer blocking.
+ *
+ * Module relationships:
+ * - Uses workspace/document/tools for editable UI actions.
+ * - Cooperates with application input loop and theme subsystem.
+ */
 #include <ui/ui_system.h>
 #include <ui/ui_menubar.h>
 

--- a/src/ui/ui_theme.c
+++ b/src/ui/ui_theme.c
@@ -1,6 +1,55 @@
 #include <nuklear/nuklear.h>
 #include <ui/ui_theme.h>
 
+#include <ctype.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dirent.h>
+#include <sys/stat.h>
+#endif
+
+#define UI_THEME_CONFIG_KEY "workbench.colorTheme"
+#define UI_THEME_COMPAT_KEY "theme"
+#define UI_THEME_MAX_CUSTOM 32
+#define UI_THEME_MAX_ID_LEN 64
+#define UI_THEME_MAX_LABEL_LEN 96
+#define UI_THEME_MAX_PATH_LEN 512
+#define UI_THEME_HASH_OFFSET_BASIS 1469598103934665603ull
+#define UI_THEME_HASH_PRIME 1099511628211ull
+
+enum {
+    UI_THEME_LIGHT_INDEX = 0,
+    UI_THEME_DARK_PLUS_INDEX = 1,
+    UI_THEME_HIGH_CONTRAST_INDEX = 2
+};
+
+typedef struct UiCustomThemeEntry {
+    UiThemeDescriptor descriptor;
+    UiThemeTokens tokens;
+    char id[UI_THEME_MAX_ID_LEN];
+    char label[UI_THEME_MAX_LABEL_LEN];
+} UiCustomThemeEntry;
+
+static const UiThemeDescriptor g_builtin_theme_descriptors[] = {
+    {"gldraw-light", "GLDraw Light"},
+    {"gldraw-dark-plus", "GLDraw Dark+"},
+    {"gldraw-high-contrast", "GLDraw High Contrast"},
+};
+
+static UiCustomThemeEntry g_custom_theme_entries[UI_THEME_MAX_CUSTOM];
+static int g_custom_theme_count = 0;
+
+static UiThemeTokens ui_theme_light_tokens(void);
+static UiThemeTokens ui_theme_dark_plus_tokens(void);
+static UiThemeTokens ui_theme_high_contrast_tokens(void);
+static int ui_theme_builtin_count(void);
+
 static struct nk_color ui_theme_mix_channel(struct nk_color a, struct nk_color b, float t)
 {
     struct nk_color out;
@@ -19,7 +68,7 @@ static struct nk_color ui_theme_mix_channel(struct nk_color a, struct nk_color b
     return out;
 }
 
-UiThemeTokens ui_theme_default_tokens(void)
+static UiThemeTokens ui_theme_light_tokens(void)
 {
     UiThemeTokens tokens;
 
@@ -58,6 +107,1053 @@ UiThemeTokens ui_theme_default_tokens(void)
     tokens.enable_transitions = nk_true;
     tokens.transition_duration = 0.12f;
     return tokens;
+}
+
+static UiThemeTokens ui_theme_dark_plus_tokens(void)
+{
+    UiThemeTokens tokens;
+
+    tokens.primary = nk_rgba(86, 156, 214, 255);
+    tokens.primary_hover = nk_rgba(104, 173, 228, 255);
+    tokens.primary_active = nk_rgba(63, 138, 203, 255);
+
+    tokens.background = nk_rgba(25, 28, 34, 255);
+    tokens.panel = nk_rgba(37, 41, 49, 255);
+    tokens.panel_hover = nk_rgba(48, 54, 64, 255);
+    tokens.canvas_background = nk_rgba(20, 23, 30, 255);
+
+    tokens.text = nk_rgba(228, 233, 241, 255);
+    tokens.text_secondary = nk_rgba(164, 172, 186, 255);
+    tokens.text_disabled = nk_rgba(113, 121, 138, 255);
+
+    tokens.border = nk_rgba(72, 79, 92, 255);
+    tokens.border_hover = nk_rgba(103, 113, 130, 255);
+
+    tokens.success = nk_rgba(99, 186, 120, 255);
+    tokens.warning = nk_rgba(214, 167, 87, 255);
+    tokens.error = nk_rgba(218, 102, 102, 255);
+
+    tokens.row_height = 30.0f;
+    tokens.panel_width = 292.0f;
+    tokens.menu_height = 34.0f;
+    tokens.status_height = 32.0f;
+    tokens.tool_rail_width = 96.0f;
+
+    tokens.padding = 5.0f;
+    tokens.margin = 0.0f;
+    tokens.gap = 0.0f;
+
+    tokens.border_radius = 2.0f;
+
+    tokens.enable_transitions = nk_true;
+    tokens.transition_duration = 0.12f;
+    return tokens;
+}
+
+static UiThemeTokens ui_theme_high_contrast_tokens(void)
+{
+    UiThemeTokens tokens;
+
+    tokens.primary = nk_rgba(0, 157, 255, 255);
+    tokens.primary_hover = nk_rgba(79, 193, 255, 255);
+    tokens.primary_active = nk_rgba(0, 121, 204, 255);
+
+    tokens.background = nk_rgba(12, 12, 12, 255);
+    tokens.panel = nk_rgba(0, 0, 0, 255);
+    tokens.panel_hover = nk_rgba(24, 24, 24, 255);
+    tokens.canvas_background = nk_rgba(8, 8, 8, 255);
+
+    tokens.text = nk_rgba(255, 255, 255, 255);
+    tokens.text_secondary = nk_rgba(222, 222, 222, 255);
+    tokens.text_disabled = nk_rgba(148, 148, 148, 255);
+
+    tokens.border = nk_rgba(255, 255, 255, 210);
+    tokens.border_hover = nk_rgba(255, 255, 255, 255);
+
+    tokens.success = nk_rgba(0, 255, 136, 255);
+    tokens.warning = nk_rgba(255, 204, 0, 255);
+    tokens.error = nk_rgba(255, 95, 95, 255);
+
+    tokens.row_height = 30.0f;
+    tokens.panel_width = 292.0f;
+    tokens.menu_height = 34.0f;
+    tokens.status_height = 32.0f;
+    tokens.tool_rail_width = 96.0f;
+
+    tokens.padding = 5.0f;
+    tokens.margin = 0.0f;
+    tokens.gap = 0.0f;
+
+    tokens.border_radius = 0.0f;
+
+    tokens.enable_transitions = nk_true;
+    tokens.transition_duration = 0.12f;
+    return tokens;
+}
+
+UiThemeTokens ui_theme_default_tokens(void)
+{
+    return ui_theme_light_tokens();
+}
+
+static int ui_theme_builtin_count(void)
+{
+    return (int)(sizeof(g_builtin_theme_descriptors) / sizeof(g_builtin_theme_descriptors[0]));
+}
+
+static const UiThemeDescriptor* ui_theme_builtin_descriptor_at(int index)
+{
+    if (index < 0 || index >= ui_theme_builtin_count()) {
+        return NULL;
+    }
+    return &g_builtin_theme_descriptors[index];
+}
+
+static UiThemeTokens ui_theme_builtin_tokens_at(int index)
+{
+    switch (index) {
+    case UI_THEME_DARK_PLUS_INDEX:
+        return ui_theme_dark_plus_tokens();
+    case UI_THEME_HIGH_CONTRAST_INDEX:
+        return ui_theme_high_contrast_tokens();
+    case UI_THEME_LIGHT_INDEX:
+    default:
+        return ui_theme_light_tokens();
+    }
+}
+
+static int ui_theme_custom_index_of_id(const char* theme_id)
+{
+    if (!theme_id || theme_id[0] == '\0') {
+        return -1;
+    }
+
+    for (int i = 0; i < g_custom_theme_count; ++i) {
+        if (strcmp(theme_id, g_custom_theme_entries[i].descriptor.id) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int ui_theme_count(void)
+{
+    return ui_theme_builtin_count() + g_custom_theme_count;
+}
+
+const UiThemeDescriptor* ui_theme_descriptor_at(int index)
+{
+    int builtin_count = ui_theme_builtin_count();
+    int custom_index = index - builtin_count;
+
+    if (index < 0 || index >= ui_theme_count()) {
+        return NULL;
+    }
+    if (index < builtin_count) {
+        return ui_theme_builtin_descriptor_at(index);
+    }
+    return &g_custom_theme_entries[custom_index].descriptor;
+}
+
+int ui_theme_index_of_id(const char* theme_id)
+{
+    int builtin_count = ui_theme_builtin_count();
+    int custom_index = -1;
+
+    if (!theme_id || theme_id[0] == '\0') {
+        return UI_THEME_LIGHT_INDEX;
+    }
+
+    for (int i = 0; i < builtin_count; ++i) {
+        if (strcmp(theme_id, g_builtin_theme_descriptors[i].id) == 0) {
+            return i;
+        }
+    }
+
+    custom_index = ui_theme_custom_index_of_id(theme_id);
+    if (custom_index >= 0) {
+        return builtin_count + custom_index;
+    }
+
+    return -1;
+}
+
+const char* ui_theme_default_id(void)
+{
+    return g_builtin_theme_descriptors[UI_THEME_LIGHT_INDEX].id;
+}
+
+UiThemeTokens ui_theme_tokens_for_id(const char* theme_id)
+{
+    int theme_index = ui_theme_index_of_id(theme_id);
+    int builtin_count = ui_theme_builtin_count();
+
+    if (theme_index < 0) {
+        return ui_theme_default_tokens();
+    }
+    if (theme_index < builtin_count) {
+        return ui_theme_builtin_tokens_at(theme_index);
+    }
+    return g_custom_theme_entries[theme_index - builtin_count].tokens;
+}
+
+static char* ui_read_text_file(const char* path)
+{
+    FILE* file = NULL;
+    char* buffer = NULL;
+    long size = 0;
+    size_t read_size = 0;
+
+    if (!path || path[0] == '\0') {
+        return NULL;
+    }
+
+    file = fopen(path, "rb");
+    if (!file) {
+        return NULL;
+    }
+
+    if (fseek(file, 0, SEEK_END) != 0) {
+        fclose(file);
+        return NULL;
+    }
+    size = ftell(file);
+    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        return NULL;
+    }
+
+    buffer = (char*)malloc((size_t)size + 1u);
+    if (!buffer) {
+        fclose(file);
+        return NULL;
+    }
+
+    read_size = fread(buffer, 1u, (size_t)size, file);
+    if (read_size != (size_t)size && ferror(file)) {
+        free(buffer);
+        fclose(file);
+        return NULL;
+    }
+    buffer[read_size] = '\0';
+    fclose(file);
+    return buffer;
+}
+
+static int ui_extract_json_string_value(const char* text,
+                                        const char* key,
+                                        char* out_value,
+                                        size_t out_value_size)
+{
+    char key_pattern[96];
+    const char* cursor = NULL;
+    int key_pattern_length = 0;
+    size_t out_length = 0u;
+
+    if (!text || !key || !out_value || out_value_size == 0u) {
+        return 0;
+    }
+
+    key_pattern_length = snprintf(key_pattern, sizeof(key_pattern), "\"%s\"", key);
+    if (key_pattern_length <= 0 || (size_t)key_pattern_length >= sizeof(key_pattern)) {
+        return 0;
+    }
+
+    cursor = strstr(text, key_pattern);
+    if (!cursor) {
+        return 0;
+    }
+
+    cursor += (size_t)key_pattern_length;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+    if (*cursor != ':') {
+        return 0;
+    }
+
+    cursor++;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+    if (*cursor != '"') {
+        return 0;
+    }
+
+    cursor++;
+    while (*cursor != '\0') {
+        if (*cursor == '"') {
+            out_value[out_length] = '\0';
+            return 1;
+        }
+
+        if (*cursor == '\\') {
+            cursor++;
+            if (*cursor == '\0') {
+                return 0;
+            }
+        }
+
+        if (out_length + 1u >= out_value_size) {
+            return 0;
+        }
+
+        out_value[out_length++] = *cursor;
+        cursor++;
+    }
+
+    return 0;
+}
+
+static int ui_extract_json_number_value(const char* text, const char* key, float* out_value)
+{
+    char key_pattern[96];
+    const char* cursor = NULL;
+    char* number_end = NULL;
+    int key_pattern_length = 0;
+    double number_value = 0.0;
+
+    if (!text || !key || !out_value) {
+        return 0;
+    }
+
+    key_pattern_length = snprintf(key_pattern, sizeof(key_pattern), "\"%s\"", key);
+    if (key_pattern_length <= 0 || (size_t)key_pattern_length >= sizeof(key_pattern)) {
+        return 0;
+    }
+
+    cursor = strstr(text, key_pattern);
+    if (!cursor) {
+        return 0;
+    }
+
+    cursor += (size_t)key_pattern_length;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+    if (*cursor != ':') {
+        return 0;
+    }
+
+    cursor++;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+
+    number_value = strtod(cursor, &number_end);
+    if (number_end == cursor) {
+        return 0;
+    }
+
+    *out_value = (float)number_value;
+    return 1;
+}
+
+static int ui_extract_json_bool_value(const char* text, const char* key, int* out_value)
+{
+    char key_pattern[96];
+    const char* cursor = NULL;
+    int key_pattern_length = 0;
+
+    if (!text || !key || !out_value) {
+        return 0;
+    }
+
+    key_pattern_length = snprintf(key_pattern, sizeof(key_pattern), "\"%s\"", key);
+    if (key_pattern_length <= 0 || (size_t)key_pattern_length >= sizeof(key_pattern)) {
+        return 0;
+    }
+
+    cursor = strstr(text, key_pattern);
+    if (!cursor) {
+        return 0;
+    }
+
+    cursor += (size_t)key_pattern_length;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+    if (*cursor != ':') {
+        return 0;
+    }
+
+    cursor++;
+    while (*cursor != '\0' && isspace((unsigned char)*cursor)) {
+        cursor++;
+    }
+
+    if (strncmp(cursor, "true", 4) == 0) {
+        *out_value = 1;
+        return 1;
+    }
+    if (strncmp(cursor, "false", 5) == 0) {
+        *out_value = 0;
+        return 1;
+    }
+    return 0;
+}
+
+static int ui_hex_digit_value(char c)
+{
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+    if (c >= 'a' && c <= 'f') {
+        return 10 + (c - 'a');
+    }
+    if (c >= 'A' && c <= 'F') {
+        return 10 + (c - 'A');
+    }
+    return -1;
+}
+
+static int ui_parse_hex_byte(const char* text, unsigned char* out_value)
+{
+    int hi = 0;
+    int lo = 0;
+
+    if (!text || !out_value) {
+        return 0;
+    }
+
+    hi = ui_hex_digit_value(text[0]);
+    lo = ui_hex_digit_value(text[1]);
+    if (hi < 0 || lo < 0) {
+        return 0;
+    }
+
+    *out_value = (unsigned char)((hi << 4) | lo);
+    return 1;
+}
+
+static int ui_parse_hex_color(const char* hex_text, struct nk_color* out_color)
+{
+    size_t length = 0u;
+    unsigned char r = 0u;
+    unsigned char g = 0u;
+    unsigned char b = 0u;
+    unsigned char a = 255u;
+
+    if (!hex_text || !out_color || hex_text[0] != '#') {
+        return 0;
+    }
+
+    length = strlen(hex_text);
+    if (length != 7u && length != 9u) {
+        return 0;
+    }
+
+    if (!ui_parse_hex_byte(hex_text + 1, &r) ||
+        !ui_parse_hex_byte(hex_text + 3, &g) ||
+        !ui_parse_hex_byte(hex_text + 5, &b)) {
+        return 0;
+    }
+    if (length == 9u && !ui_parse_hex_byte(hex_text + 7, &a)) {
+        return 0;
+    }
+
+    out_color->r = (nk_byte)r;
+    out_color->g = (nk_byte)g;
+    out_color->b = (nk_byte)b;
+    out_color->a = (nk_byte)a;
+    return 1;
+}
+
+static int ui_theme_path_has_json_extension(const char* path)
+{
+    size_t length = 0u;
+    const char* ext = NULL;
+
+    if (!path) {
+        return 0;
+    }
+
+    length = strlen(path);
+    if (length < 5u) {
+        return 0;
+    }
+
+    ext = path + length - 5u;
+    return (tolower((unsigned char)ext[0]) == '.') &&
+           (tolower((unsigned char)ext[1]) == 'j') &&
+           (tolower((unsigned char)ext[2]) == 's') &&
+           (tolower((unsigned char)ext[3]) == 'o') &&
+           (tolower((unsigned char)ext[4]) == 'n');
+}
+
+static unsigned long long ui_theme_hash_bytes(unsigned long long seed, const void* data, size_t size)
+{
+    const unsigned char* bytes = (const unsigned char*)data;
+    unsigned long long hash = seed;
+
+    if (!bytes) {
+        return hash;
+    }
+
+    for (size_t i = 0u; i < size; ++i) {
+        hash ^= (unsigned long long)bytes[i];
+        hash *= UI_THEME_HASH_PRIME;
+    }
+    return hash;
+}
+
+static unsigned long long ui_theme_hash_cstring(unsigned long long seed, const char* text)
+{
+    if (!text) {
+        return seed;
+    }
+    return ui_theme_hash_bytes(seed, text, strlen(text));
+}
+
+static unsigned long long ui_theme_hash_u64(unsigned long long seed, unsigned long long value)
+{
+    return ui_theme_hash_bytes(seed, &value, sizeof(value));
+}
+
+static int ui_theme_id_is_safe_for_json(const char* theme_id)
+{
+    const unsigned char* cursor = (const unsigned char*)theme_id;
+
+    if (!theme_id || theme_id[0] == '\0') {
+        return 0;
+    }
+
+    while (*cursor != '\0') {
+        if (!(isalnum(*cursor) || *cursor == '-' || *cursor == '_' || *cursor == '.')) {
+            return 0;
+        }
+        cursor++;
+    }
+
+    return 1;
+}
+
+static const char* ui_theme_filename_from_path(const char* path)
+{
+    const char* last_slash = NULL;
+    const char* last_backslash = NULL;
+
+    if (!path) {
+        return NULL;
+    }
+
+    last_slash = strrchr(path, '/');
+    last_backslash = strrchr(path, '\\');
+    if (!last_slash && !last_backslash) {
+        return path;
+    }
+    if (!last_slash) {
+        return last_backslash + 1;
+    }
+    if (!last_backslash) {
+        return last_slash + 1;
+    }
+    return (last_slash > last_backslash) ? (last_slash + 1) : (last_backslash + 1);
+}
+
+static int ui_theme_id_from_path(const char* path, char* out_id, size_t out_id_size)
+{
+    const char* filename = NULL;
+    size_t length = 0u;
+    size_t write_length = 0u;
+
+    if (!path || !out_id || out_id_size == 0u) {
+        return 0;
+    }
+
+    filename = ui_theme_filename_from_path(path);
+    if (!filename || filename[0] == '\0') {
+        return 0;
+    }
+
+    length = strlen(filename);
+    if (length > 5u && ui_theme_path_has_json_extension(filename)) {
+        length -= 5u;
+    }
+    if (length == 0u) {
+        return 0;
+    }
+
+    write_length = (length < (out_id_size - 1u)) ? length : (out_id_size - 1u);
+    memcpy(out_id, filename, write_length);
+    out_id[write_length] = '\0';
+    return write_length > 0u;
+}
+
+static void ui_theme_apply_color_overrides(const char* text, UiThemeTokens* tokens)
+{
+    typedef struct UiThemeColorField {
+        const char* key;
+        size_t offset;
+    } UiThemeColorField;
+
+    static const UiThemeColorField fields[] = {
+        {"primary", offsetof(UiThemeTokens, primary)},
+        {"primary_hover", offsetof(UiThemeTokens, primary_hover)},
+        {"primary_active", offsetof(UiThemeTokens, primary_active)},
+        {"background", offsetof(UiThemeTokens, background)},
+        {"panel", offsetof(UiThemeTokens, panel)},
+        {"panel_hover", offsetof(UiThemeTokens, panel_hover)},
+        {"canvas_background", offsetof(UiThemeTokens, canvas_background)},
+        {"text", offsetof(UiThemeTokens, text)},
+        {"text_secondary", offsetof(UiThemeTokens, text_secondary)},
+        {"text_disabled", offsetof(UiThemeTokens, text_disabled)},
+        {"border", offsetof(UiThemeTokens, border)},
+        {"border_hover", offsetof(UiThemeTokens, border_hover)},
+        {"success", offsetof(UiThemeTokens, success)},
+        {"warning", offsetof(UiThemeTokens, warning)},
+        {"error", offsetof(UiThemeTokens, error)},
+    };
+
+    if (!text || !tokens) {
+        return;
+    }
+
+    for (size_t i = 0; i < (sizeof(fields) / sizeof(fields[0])); ++i) {
+        char color_text[16];
+        struct nk_color parsed;
+
+        if (!ui_extract_json_string_value(text, fields[i].key, color_text, sizeof(color_text))) {
+            continue;
+        }
+        if (!ui_parse_hex_color(color_text, &parsed)) {
+            continue;
+        }
+
+        *(struct nk_color*)((char*)tokens + fields[i].offset) = parsed;
+    }
+}
+
+static void ui_theme_apply_float_overrides(const char* text, UiThemeTokens* tokens)
+{
+    typedef struct UiThemeFloatField {
+        const char* key;
+        size_t offset;
+    } UiThemeFloatField;
+
+    static const UiThemeFloatField fields[] = {
+        {"row_height", offsetof(UiThemeTokens, row_height)},
+        {"panel_width", offsetof(UiThemeTokens, panel_width)},
+        {"menu_height", offsetof(UiThemeTokens, menu_height)},
+        {"status_height", offsetof(UiThemeTokens, status_height)},
+        {"tool_rail_width", offsetof(UiThemeTokens, tool_rail_width)},
+        {"padding", offsetof(UiThemeTokens, padding)},
+        {"margin", offsetof(UiThemeTokens, margin)},
+        {"gap", offsetof(UiThemeTokens, gap)},
+        {"border_radius", offsetof(UiThemeTokens, border_radius)},
+        {"transition_duration", offsetof(UiThemeTokens, transition_duration)},
+    };
+
+    if (!text || !tokens) {
+        return;
+    }
+
+    for (size_t i = 0; i < (sizeof(fields) / sizeof(fields[0])); ++i) {
+        float value = 0.0f;
+        if (!ui_extract_json_number_value(text, fields[i].key, &value)) {
+            continue;
+        }
+        *(float*)((char*)tokens + fields[i].offset) = value;
+    }
+}
+
+static void ui_theme_apply_bool_overrides(const char* text, UiThemeTokens* tokens)
+{
+    int bool_value = 0;
+
+    if (!text || !tokens) {
+        return;
+    }
+
+    if (ui_extract_json_bool_value(text, "enable_transitions", &bool_value)) {
+        tokens->enable_transitions = bool_value ? nk_true : nk_false;
+    }
+}
+
+static int ui_theme_store_custom_entry(const char* theme_id,
+                                       const char* label,
+                                       const UiThemeTokens* tokens)
+{
+    int existing_index = -1;
+    int target_index = -1;
+
+    if (!theme_id || !tokens) {
+        return 0;
+    }
+    if (!ui_theme_id_is_safe_for_json(theme_id)) {
+        return 0;
+    }
+    if (ui_theme_index_of_id(theme_id) >= 0 && ui_theme_custom_index_of_id(theme_id) < 0) {
+        /* Built-in IDs are reserved and cannot be overridden by file themes. */
+        return 0;
+    }
+
+    existing_index = ui_theme_custom_index_of_id(theme_id);
+    if (existing_index >= 0) {
+        target_index = existing_index;
+    } else {
+        if (g_custom_theme_count >= UI_THEME_MAX_CUSTOM) {
+            return 0;
+        }
+        target_index = g_custom_theme_count++;
+    }
+
+    snprintf(g_custom_theme_entries[target_index].id,
+             sizeof(g_custom_theme_entries[target_index].id),
+             "%s",
+             theme_id);
+    snprintf(g_custom_theme_entries[target_index].label,
+             sizeof(g_custom_theme_entries[target_index].label),
+             "%s",
+             (label && label[0] != '\0') ? label : theme_id);
+
+    g_custom_theme_entries[target_index].descriptor.id = g_custom_theme_entries[target_index].id;
+    g_custom_theme_entries[target_index].descriptor.label = g_custom_theme_entries[target_index].label;
+    g_custom_theme_entries[target_index].tokens = *tokens;
+    return 1;
+}
+
+static int ui_theme_load_external_file(const char* path)
+{
+    char* text = NULL;
+    char theme_id[UI_THEME_MAX_ID_LEN];
+    char theme_label[UI_THEME_MAX_LABEL_LEN];
+    char base_theme_id[UI_THEME_MAX_ID_LEN];
+    UiThemeTokens tokens;
+    int base_index = -1;
+    int loaded = 0;
+
+    if (!path) {
+        return 0;
+    }
+
+    text = ui_read_text_file(path);
+    if (!text) {
+        return 0;
+    }
+
+    theme_id[0] = '\0';
+    theme_label[0] = '\0';
+    base_theme_id[0] = '\0';
+
+    if (!ui_extract_json_string_value(text, "id", theme_id, sizeof(theme_id))) {
+        ui_theme_id_from_path(path, theme_id, sizeof(theme_id));
+    }
+    if (!ui_theme_id_is_safe_for_json(theme_id)) {
+        free(text);
+        return 0;
+    }
+
+    ui_extract_json_string_value(text, "label", theme_label, sizeof(theme_label));
+    if (!ui_extract_json_string_value(text, "base_theme", base_theme_id, sizeof(base_theme_id))) {
+        if (!ui_extract_json_string_value(text, "base", base_theme_id, sizeof(base_theme_id))) {
+            ui_extract_json_string_value(text, "extends", base_theme_id, sizeof(base_theme_id));
+        }
+    }
+
+    base_index = ui_theme_index_of_id(base_theme_id);
+    if (base_index >= 0) {
+        const UiThemeDescriptor* base_descriptor = ui_theme_descriptor_at(base_index);
+        tokens = ui_theme_tokens_for_id(base_descriptor ? base_descriptor->id : ui_theme_default_id());
+    } else {
+        tokens = ui_theme_default_tokens();
+    }
+
+    ui_theme_apply_color_overrides(text, &tokens);
+    ui_theme_apply_float_overrides(text, &tokens);
+    ui_theme_apply_bool_overrides(text, &tokens);
+    loaded = ui_theme_store_custom_entry(theme_id, theme_label, &tokens);
+
+    free(text);
+    return loaded;
+}
+
+int ui_theme_reload_external(const char* directory_path)
+{
+    int loaded_count = 0;
+
+    g_custom_theme_count = 0;
+    memset(g_custom_theme_entries, 0, sizeof(g_custom_theme_entries));
+
+    if (!directory_path || directory_path[0] == '\0') {
+        return 0;
+    }
+
+#ifdef _WIN32
+    {
+        WIN32_FIND_DATAA find_data;
+        HANDLE find_handle = INVALID_HANDLE_VALUE;
+        char search_pattern[UI_THEME_MAX_PATH_LEN];
+
+        snprintf(search_pattern, sizeof(search_pattern), "%s\\*.json", directory_path);
+        find_handle = FindFirstFileA(search_pattern, &find_data);
+        if (find_handle == INVALID_HANDLE_VALUE) {
+            return 0;
+        }
+
+        do {
+            char file_path[UI_THEME_MAX_PATH_LEN];
+            if ((find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+                continue;
+            }
+
+            snprintf(file_path, sizeof(file_path), "%s\\%s", directory_path, find_data.cFileName);
+            loaded_count += ui_theme_load_external_file(file_path);
+        } while (FindNextFileA(find_handle, &find_data));
+
+        FindClose(find_handle);
+    }
+#else
+    {
+        DIR* directory = NULL;
+        struct dirent* entry = NULL;
+
+        directory = opendir(directory_path);
+        if (!directory) {
+            return 0;
+        }
+
+        while ((entry = readdir(directory)) != NULL) {
+            char file_path[UI_THEME_MAX_PATH_LEN];
+
+            if (entry->d_name[0] == '.') {
+                continue;
+            }
+            if (!ui_theme_path_has_json_extension(entry->d_name)) {
+                continue;
+            }
+
+            snprintf(file_path, sizeof(file_path), "%s/%s", directory_path, entry->d_name);
+            loaded_count += ui_theme_load_external_file(file_path);
+        }
+
+        closedir(directory);
+    }
+#endif
+
+    return loaded_count;
+}
+
+unsigned long long ui_theme_external_signature(const char* directory_path)
+{
+    unsigned long long aggregate_hash = UI_THEME_HASH_OFFSET_BASIS;
+    unsigned long long file_count = 0ull;
+
+    if (!directory_path || directory_path[0] == '\0') {
+        return aggregate_hash;
+    }
+
+#ifdef _WIN32
+    {
+        WIN32_FIND_DATAA find_data;
+        HANDLE find_handle = INVALID_HANDLE_VALUE;
+        char search_pattern[UI_THEME_MAX_PATH_LEN];
+
+        snprintf(search_pattern, sizeof(search_pattern), "%s\\*.json", directory_path);
+        find_handle = FindFirstFileA(search_pattern, &find_data);
+        if (find_handle == INVALID_HANDLE_VALUE) {
+            return aggregate_hash;
+        }
+
+        do {
+            unsigned long long file_hash = UI_THEME_HASH_OFFSET_BASIS;
+            unsigned long long file_size = 0ull;
+            unsigned long long file_time = 0ull;
+
+            if ((find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+                continue;
+            }
+
+            file_size = ((unsigned long long)find_data.nFileSizeHigh << 32) |
+                        (unsigned long long)find_data.nFileSizeLow;
+            file_time = ((unsigned long long)find_data.ftLastWriteTime.dwHighDateTime << 32) |
+                        (unsigned long long)find_data.ftLastWriteTime.dwLowDateTime;
+
+            file_hash = ui_theme_hash_cstring(file_hash, find_data.cFileName);
+            file_hash = ui_theme_hash_u64(file_hash, file_size);
+            file_hash = ui_theme_hash_u64(file_hash, file_time);
+
+            aggregate_hash ^= file_hash;
+            file_count++;
+        } while (FindNextFileA(find_handle, &find_data));
+
+        FindClose(find_handle);
+    }
+#else
+    {
+        DIR* directory = NULL;
+        struct dirent* entry = NULL;
+
+        directory = opendir(directory_path);
+        if (!directory) {
+            return aggregate_hash;
+        }
+
+        while ((entry = readdir(directory)) != NULL) {
+            char file_path[UI_THEME_MAX_PATH_LEN];
+            struct stat info;
+            unsigned long long file_hash = UI_THEME_HASH_OFFSET_BASIS;
+            unsigned long long file_size = 0ull;
+            unsigned long long file_time = 0ull;
+
+            if (entry->d_name[0] == '.') {
+                continue;
+            }
+            if (!ui_theme_path_has_json_extension(entry->d_name)) {
+                continue;
+            }
+
+            snprintf(file_path, sizeof(file_path), "%s/%s", directory_path, entry->d_name);
+            if (stat(file_path, &info) != 0) {
+                continue;
+            }
+
+            file_size = (unsigned long long)info.st_size;
+            file_time = (unsigned long long)info.st_mtime;
+
+            file_hash = ui_theme_hash_cstring(file_hash, entry->d_name);
+            file_hash = ui_theme_hash_u64(file_hash, file_size);
+            file_hash = ui_theme_hash_u64(file_hash, file_time);
+
+            aggregate_hash ^= file_hash;
+            file_count++;
+        }
+
+        closedir(directory);
+    }
+#endif
+
+    aggregate_hash = ui_theme_hash_u64(aggregate_hash, file_count);
+    return aggregate_hash;
+}
+
+int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_theme_id_size)
+{
+    char* text = NULL;
+    int loaded = 0;
+
+    if (!path || !out_theme_id || out_theme_id_size == 0u) {
+        return 0;
+    }
+
+    out_theme_id[0] = '\0';
+    text = ui_read_text_file(path);
+    if (!text) {
+        return 0;
+    }
+
+    loaded = ui_extract_json_string_value(text,
+                                          UI_THEME_CONFIG_KEY,
+                                          out_theme_id,
+                                          out_theme_id_size);
+    if (!loaded) {
+        loaded = ui_extract_json_string_value(text,
+                                              UI_THEME_COMPAT_KEY,
+                                              out_theme_id,
+                                              out_theme_id_size);
+    }
+
+    free(text);
+    return loaded && out_theme_id[0] != '\0';
+}
+
+static char* ui_duplicate_path_with_suffix(const char* path, const char* suffix)
+{
+    size_t path_length = 0u;
+    size_t suffix_length = 0u;
+    char* result = NULL;
+
+    if (!path || !suffix) {
+        return NULL;
+    }
+
+    path_length = strlen(path);
+    suffix_length = strlen(suffix);
+    result = (char*)malloc(path_length + suffix_length + 1u);
+    if (!result) {
+        return NULL;
+    }
+
+    memcpy(result, path, path_length);
+    memcpy(result + path_length, suffix, suffix_length);
+    result[path_length + suffix_length] = '\0';
+    return result;
+}
+
+static int ui_replace_file_with_temp(const char* temp_path, const char* target_path)
+{
+    if (!temp_path || !target_path) {
+        return 0;
+    }
+
+#ifdef _WIN32
+    if (MoveFileExA(temp_path,
+                    target_path,
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        return 1;
+    }
+    remove(temp_path);
+    return 0;
+#else
+    if (rename(temp_path, target_path) == 0) {
+        return 1;
+    }
+    remove(temp_path);
+    return 0;
+#endif
+}
+
+int ui_theme_save_selected_id(const char* path, const char* theme_id)
+{
+    FILE* file = NULL;
+    char* temp_path = NULL;
+    int close_result = 0;
+
+    if (!path || !theme_id) {
+        return 0;
+    }
+    if (ui_theme_index_of_id(theme_id) < 0) {
+        return 0;
+    }
+    if (!ui_theme_id_is_safe_for_json(theme_id)) {
+        return 0;
+    }
+
+    temp_path = ui_duplicate_path_with_suffix(path, ".tmp");
+    if (!temp_path) {
+        return 0;
+    }
+
+    file = fopen(temp_path, "wb");
+    if (!file) {
+        free(temp_path);
+        return 0;
+    }
+
+    fprintf(file, "{\n");
+    fprintf(file, "  \"%s\": \"%s\"\n", UI_THEME_CONFIG_KEY, theme_id);
+    fprintf(file, "}\n");
+    if (ferror(file)) {
+        fclose(file);
+        remove(temp_path);
+        free(temp_path);
+        return 0;
+    }
+
+    close_result = fclose(file);
+    if (close_result != 0) {
+        remove(temp_path);
+        free(temp_path);
+        return 0;
+    }
+
+    if (!ui_replace_file_with_temp(temp_path, path)) {
+        free(temp_path);
+        return 0;
+    }
+
+    free(temp_path);
+    return 1;
 }
 
 void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens)

--- a/src/ui/ui_theme.c
+++ b/src/ui/ui_theme.c
@@ -23,39 +23,40 @@ UiThemeTokens ui_theme_default_tokens(void)
 {
     UiThemeTokens tokens;
 
-    tokens.primary = nk_rgba(46, 117, 224, 255);
-    tokens.primary_hover = nk_rgba(61, 130, 233, 255);
-    tokens.primary_active = nk_rgba(35, 101, 195, 255);
+    tokens.primary = nk_rgba(47, 109, 188, 255);
+    tokens.primary_hover = nk_rgba(62, 123, 205, 255);
+    tokens.primary_active = nk_rgba(37, 89, 160, 255);
 
-    tokens.background = nk_rgba(236, 240, 246, 255);
-    tokens.panel = nk_rgba(250, 252, 255, 255);
-    tokens.panel_hover = nk_rgba(243, 247, 253, 255);
+    tokens.background = nk_rgba(226, 233, 241, 255);
+    tokens.panel = nk_rgba(244, 248, 253, 255);
+    tokens.panel_hover = nk_rgba(233, 240, 248, 255);
+    tokens.canvas_background = nk_rgba(218, 226, 236, 255);
 
-    tokens.text = nk_rgba(34, 40, 49, 255);
-    tokens.text_secondary = nk_rgba(95, 104, 117, 255);
-    tokens.text_disabled = nk_rgba(150, 159, 171, 255);
+    tokens.text = nk_rgba(24, 35, 49, 255);
+    tokens.text_secondary = nk_rgba(84, 96, 111, 255);
+    tokens.text_disabled = nk_rgba(140, 151, 166, 255);
 
-    tokens.border = nk_rgba(188, 198, 212, 255);
-    tokens.border_hover = nk_rgba(164, 176, 194, 255);
+    tokens.border = nk_rgba(181, 194, 212, 255);
+    tokens.border_hover = nk_rgba(149, 166, 189, 255);
 
-    tokens.success = nk_rgba(43, 154, 103, 255);
-    tokens.warning = nk_rgba(204, 136, 36, 255);
-    tokens.error = nk_rgba(196, 70, 70, 255);
+    tokens.success = nk_rgba(45, 143, 105, 255);
+    tokens.warning = nk_rgba(194, 129, 42, 255);
+    tokens.error = nk_rgba(182, 74, 74, 255);
 
-    tokens.row_height = 28.0f;
-    tokens.panel_width = 280.0f;
-    tokens.menu_height = 30.0f;
-    tokens.status_height = 36.0f;
-    tokens.tool_rail_width = 80.0f;
+    tokens.row_height = 30.0f;
+    tokens.panel_width = 292.0f;
+    tokens.menu_height = 34.0f;
+    tokens.status_height = 32.0f;
+    tokens.tool_rail_width = 96.0f;
 
-    tokens.padding = 4.0f;
-    tokens.margin = 12.0f;
-    tokens.gap = 8.0f;
+    tokens.padding = 5.0f;
+    tokens.margin = 0.0f;
+    tokens.gap = 0.0f;
 
-    tokens.border_radius = 4.0f;
+    tokens.border_radius = 0.0f;
 
     tokens.enable_transitions = nk_true;
-    tokens.transition_duration = 0.10f;
+    tokens.transition_duration = 0.12f;
     return tokens;
 }
 
@@ -75,8 +76,8 @@ void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens)
     hover_panel = ui_theme_mix_channel(local_tokens.panel_hover, local_tokens.background, 0.35f);
 
     table[NK_COLOR_TEXT] = local_tokens.text;
-    table[NK_COLOR_WINDOW] = local_tokens.background;
-    table[NK_COLOR_HEADER] = local_tokens.panel;
+    table[NK_COLOR_WINDOW] = local_tokens.panel;
+    table[NK_COLOR_HEADER] = ui_theme_mix_channel(local_tokens.panel, local_tokens.background, 0.60f);
     table[NK_COLOR_BORDER] = local_tokens.border;
     table[NK_COLOR_BUTTON] = subtle_panel;
     table[NK_COLOR_BUTTON_HOVER] = local_tokens.panel_hover;
@@ -110,16 +111,16 @@ void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens)
     nk_style_default(ctx);
     nk_style_from_table(ctx, table);
 
-    ctx->style.window.background = local_tokens.background;
-    ctx->style.window.fixed_background = nk_style_item_color(local_tokens.background);
+    ctx->style.window.background = local_tokens.panel;
+    ctx->style.window.fixed_background = nk_style_item_color(local_tokens.panel);
     ctx->style.window.border_color = local_tokens.border;
     ctx->style.window.rounding = local_tokens.border_radius;
     ctx->style.window.border = 1.0f;
-    ctx->style.window.spacing = nk_vec2(local_tokens.gap * 0.5f, local_tokens.gap * 0.5f);
-    ctx->style.window.padding = nk_vec2(local_tokens.padding * 2.0f, local_tokens.padding * 1.5f);
-    ctx->style.window.group_padding = nk_vec2(local_tokens.padding * 2.0f, local_tokens.padding * 1.5f);
-    ctx->style.window.tooltip_padding = nk_vec2(local_tokens.padding * 2.0f, local_tokens.padding * 1.5f);
-    ctx->style.window.menu_padding = nk_vec2(local_tokens.padding * 1.5f, local_tokens.padding * 1.5f);
+    ctx->style.window.spacing = nk_vec2(local_tokens.padding * 0.8f, local_tokens.padding * 0.8f);
+    ctx->style.window.padding = nk_vec2(local_tokens.padding * 1.6f, local_tokens.padding * 1.3f);
+    ctx->style.window.group_padding = nk_vec2(local_tokens.padding * 1.6f, local_tokens.padding * 1.3f);
+    ctx->style.window.tooltip_padding = nk_vec2(local_tokens.padding * 1.8f, local_tokens.padding * 1.4f);
+    ctx->style.window.menu_padding = nk_vec2(local_tokens.padding * 1.3f, local_tokens.padding * 1.1f);
     ctx->style.window.tooltip_border = 1.0f;
     ctx->style.window.tooltip_border_color = local_tokens.border_hover;
 

--- a/src/ui/ui_theme.c
+++ b/src/ui/ui_theme.c
@@ -1,3 +1,15 @@
+/**
+ * @file ui_theme.c
+ * @brief Theme token definitions, external theme loading, and Nuklear style apply.
+ *
+ * Role in project:
+ * - Maintains built-in theme presets and runtime custom theme registry.
+ * - Parses simple JSON theme files and maps tokens into UI style structures.
+ *
+ * Module relationships:
+ * - Consumed by `ui_system`/`ui_menubar`.
+ * - Uses file-system helpers and lightweight parsing utilities.
+ */
 #include <nuklear/nuklear.h>
 #include <ui/ui_theme.h>
 

--- a/themes/README.md
+++ b/themes/README.md
@@ -1,0 +1,51 @@
+Theme Files (`themes/*.json`)
+======================================
+
+GLDraw loads custom themes from the `themes/` directory at startup.
+Each file with `.json` extension is parsed as one theme entry.
+Theme files are also hot-reloaded while GLDraw is running.
+You can force a refresh from `Theme -> Reload Themes`.
+
+Required fields:
+
+- `id` (string): unique identifier, allowed chars `[A-Za-z0-9._-]`
+
+Optional fields:
+
+- `label` (string): display name in the `Theme` menu
+- `base_theme` (string): parent theme id (for example `gldraw-dark-plus`)
+- `base` or `extends` can be used as aliases for `base_theme`
+- `base_theme` should point to a built-in theme for predictable load order
+
+Color fields (`#RRGGBB` or `#RRGGBBAA`):
+
+- `primary`, `primary_hover`, `primary_active`
+- `background`, `panel`, `panel_hover`, `canvas_background`
+- `text`, `text_secondary`, `text_disabled`
+- `border`, `border_hover`
+- `success`, `warning`, `error`
+
+Float fields:
+
+- `row_height`, `panel_width`, `menu_height`, `status_height`, `tool_rail_width`
+- `padding`, `margin`, `gap`
+- `border_radius`
+- `transition_duration`
+
+Boolean fields:
+
+- `enable_transitions`
+
+Example:
+
+```json
+{
+  "id": "my-team-theme",
+  "label": "My Team Theme",
+  "base_theme": "gldraw-dark-plus",
+  "primary": "#57A7FF",
+  "panel": "#18212B",
+  "canvas_background": "#0E141B",
+  "enable_transitions": true
+}
+```

--- a/themes/oceanic.json
+++ b/themes/oceanic.json
@@ -1,0 +1,30 @@
+{
+  "id": "oceanic-night",
+  "label": "Oceanic Night",
+  "base_theme": "gldraw-dark-plus",
+
+  "primary": "#4FC3F7",
+  "primary_hover": "#81D4FA",
+  "primary_active": "#29B6F6",
+
+  "background": "#101820",
+  "panel": "#16222D",
+  "panel_hover": "#1D2C39",
+  "canvas_background": "#0C131A",
+
+  "text": "#E5EEF7",
+  "text_secondary": "#AFC4D8",
+  "text_disabled": "#6E859A",
+
+  "border": "#294258",
+  "border_hover": "#41627C",
+
+  "row_height": 30,
+  "menu_height": 34,
+  "status_height": 32,
+  "tool_rail_width": 100,
+  "border_radius": 2,
+
+  "enable_transitions": true,
+  "transition_duration": 0.14
+}

--- a/themes/paper_ink.json
+++ b/themes/paper_ink.json
@@ -1,0 +1,29 @@
+{
+  "id": "paper-ink",
+  "label": "Paper Ink",
+  "base_theme": "gldraw-light",
+
+  "primary": "#0E5A8A",
+  "primary_hover": "#1A6DA5",
+  "primary_active": "#094566",
+
+  "background": "#F4F0E6",
+  "panel": "#FCFAF2",
+  "panel_hover": "#F3EEE0",
+  "canvas_background": "#EFE8D8",
+
+  "text": "#2D2A24",
+  "text_secondary": "#61594D",
+  "text_disabled": "#9A9184",
+
+  "border": "#C7BCA8",
+  "border_hover": "#AFA28C",
+
+  "padding": 6,
+  "panel_width": 300,
+  "tool_rail_width": 104,
+  "border_radius": 0,
+
+  "enable_transitions": true,
+  "transition_duration": 0.1
+}


### PR DESCRIPTION
## Summary
- standardize code comments across all user-written source files
- add missing Doxygen coverage for core structs and functions while tightening ambiguous wording
- normalize terminology, TODO references, and formatting inconsistencies in the documentation comments

## Testing
- cmake --build build --target GLDraw
- Verify Doxygen parses cleanly when configured
