### PR TITLE
fix: move lightweight history transaction declarations to header

### DIFF
--- a/include/document/history.h
+++ b/include/document/history.h
@@ -63,6 +63,10 @@ int document_history_init(DocumentHistory* history);
 void document_history_shutdown(DocumentHistory* history);
 /** Push one transaction and clear redo stack. Complexity: `O(n + capacity)` worst-case. */
 int document_history_push(DocumentHistory* history, DocumentSnapshot* before, const Document* after_document);
+/** Push lightweight scalar edit transaction without full document snapshots. Returns 1 on success, 0 on failure. */
+int document_history_push_scalar_edit(DocumentHistory* history, const Document* document, ObjectId object_id, const char* key, float before_value, float after_value, unsigned int revision_before, unsigned int revision_after);
+/** Push lightweight translate transaction for a fixed object-id set. Returns 1 on success, 0 on failure. */
+int document_history_push_translate_edit(DocumentHistory* history, const Document* document, const ObjectId* object_ids, int object_count, Vec2 delta, unsigned int revision_before, unsigned int revision_after);
 /** Apply latest undo entry. Returns 0 when stack empty/failure. Complexity: `O(n + capacity)` worst-case. */
 int document_history_undo(DocumentHistory* history, Document* document);
 /** Apply latest redo entry. Returns 0 when stack empty/failure. Complexity: `O(n + capacity)` worst-case. */

--- a/src/tools/tool_controller.c
+++ b/src/tools/tool_controller.c
@@ -54,14 +54,6 @@ static void snapshot_reset(DocumentSnapshot* snapshot)
     document_snapshot_init(snapshot);
 }
 
-int document_history_push_translate_edit(DocumentHistory* history,
-                                         const Document* document,
-                                         const ObjectId* object_ids,
-                                         int object_count,
-                                         Vec2 delta,
-                                         unsigned int revision_before,
-                                         unsigned int revision_after);
-
 /** Destroy active overlay object preview if present. */
 static void destroy_overlay(Tool* tool)
 {

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -50,15 +50,6 @@
 #define UI_THEME_DESCRIPTOR_CACHE_MAX 64
 #define UI_THEME_WATCH_INTERVAL_SECONDS 0.35
 
-int document_history_push_scalar_edit(DocumentHistory* history,
-                                      const Document* document,
-                                      ObjectId object_id,
-                                      const char* key,
-                                      float before_value,
-                                      float after_value,
-                                      unsigned int revision_before,
-                                      unsigned int revision_after);
-
 struct UiSystem {
     struct nk_glfw glfw;
     struct nk_context* ctx;


### PR DESCRIPTION
## Summary
- move the lightweight history transaction declarations into the public history header
- make the scalar-edit and translate-edit helpers reusable across tool and UI modules
- keep the history transaction surface consistent for future call sites

## Testing
- Build passes
- Verify history transactions work correctly
