### PR TITLE
docs: add Doxygen comments

### DIFF
--- a/include/app/application.h
+++ b/include/app/application.h
@@ -1,29 +1,17 @@
 /**
  * @file application.h
- * @brief Process-level application entry point.
- *
- * Role in project:
- * - Exposes the single runtime entry used by `main`.
- * - Owns startup, main loop, and shutdown orchestration.
- *
- * Module relationships:
- * - Called by `src/main.c`.
- * - Coordinates workspace, window, render, tools, and UI systems.
+ * @brief 应用层入口接口。
  */
 #ifndef GLDRAW_APP_APPLICATION_H
 #define GLDRAW_APP_APPLICATION_H
 
 /**
- * @brief Run the GLDraw application loop.
- * @return `0` on normal exit, `-1` on unrecoverable init/runtime failure.
+ * @brief 启动并运行 GLDraw 主循环。
  *
- * Edge cases:
- * - Returns early if critical resources fail to initialize.
- * - Performs internal cleanup on failure paths.
+ * 该函数负责初始化窗口、渲染系统、UI 系统与工作区，
+ * 在退出时完成资源释放与收尾。
  *
- * Time complexity:
- * - Init/teardown are effectively `O(1)`.
- * - Per-frame work depends on scene size and active UI/tool state.
+ * @return 正常退出返回 `0`；初始化失败或运行期不可恢复错误返回 `-1`。
  */
 int app_run(void);
 

--- a/include/app/application.h
+++ b/include/app/application.h
@@ -1,17 +1,17 @@
 /**
  * @file application.h
- * @brief 应用层入口接口。
+ * @brief Application layer entry point interface.
  */
 #ifndef GLDRAW_APP_APPLICATION_H
 #define GLDRAW_APP_APPLICATION_H
 
 /**
- * @brief 启动并运行 GLDraw 主循环。
+ * @brief Start and run the GLDraw main loop.
  *
- * 该函数负责初始化窗口、渲染系统、UI 系统与工作区，
- * 在退出时完成资源释放与收尾。
+ * This function initializes the window, rendering system, UI system, and workspace,
+ * and performs cleanup and finalization on exit.
  *
- * @return 正常退出返回 `0`；初始化失败或运行期不可恢复错误返回 `-1`。
+ * @return `0` on normal exit; `-1` on initialization failure or unrecoverable runtime error.
  */
 int app_run(void);
 

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -1,6 +1,6 @@
 /**
  * @file workspace.h
- * @brief 编辑器运行时共享工作区定义。
+ * @brief Editor runtime shared workspace definition.
  */
 #ifndef GLDRAW_APP_WORKSPACE_H
 #define GLDRAW_APP_WORKSPACE_H
@@ -14,24 +14,24 @@ struct Workspace;
 
 /**
  * @typedef WorkspaceCommandFn
- * @brief 工作区命令回调签名（如保存/加载）。
- * @param workspace 目标工作区。
- * @param user_data 调用方透传上下文。
- * @return 成功返回非零，失败返回 0。
+ * @brief Workspace command callback signature (e.g., save/load).
+ * @param workspace Target workspace.
+ * @param user_data Caller-supplied context passed through.
+ * @return Non-zero on success, zero on failure.
  */
 typedef int (*WorkspaceCommandFn)(struct Workspace* workspace, void* user_data);
 
 /**
  * @struct WorkspaceLayout
- * @brief UI 计算出的布局快照。
+ * @brief Layout snapshot computed by the UI.
  *
- * @member window_bounds 窗口边界。
- * @member canvas_content_bounds 画布可用内容区。
- * @member appbar_bounds 顶部工具条区域。
- * @member rail_bounds 左侧工具轨区域。
- * @member panel_bounds 右侧面板区域。
- * @member status_bounds 底部状态栏区域。
- * @member layout_revision 布局版本号（用于跨系统同步）。
+ * @member window_bounds Window boundary.
+ * @member canvas_content_bounds Available canvas content area.
+ * @member appbar_bounds Top toolbar area.
+ * @member rail_bounds Left tool rail area.
+ * @member panel_bounds Right panel area.
+ * @member status_bounds Bottom status bar area.
+ * @member layout_revision Layout version number (used for cross-system sync).
  */
 typedef struct WorkspaceLayout {
     RectF window_bounds;
@@ -45,20 +45,20 @@ typedef struct WorkspaceLayout {
 
 /**
  * @struct Workspace
- * @brief 运行时核心状态容器。
+ * @brief Runtime core state container.
  *
- * @member document 当前文档对象与选择状态。
- * @member history 撤销/重做历史。
- * @member canvas 画布视图状态。
- * @member tools 工具控制器。
- * @member layout UI 布局信息。
- * @member current_document_path 当前文档路径（空串表示未命名文档）。
- * @member status_message 状态栏消息。
- * @member saved_revision 最近一次保存对应的文档修订号。
- * @member document_dirty 文档是否脏（非零表示有未保存改动）。
- * @member save_document 保存回调。
- * @member load_document 加载回调。
- * @member command_user_data 回调上下文。
+ * @member document Current document object and selection state.
+ * @member history Undo/redo history.
+ * @member canvas Canvas view state.
+ * @member tools Tool controller.
+ * @member layout UI layout information.
+ * @member current_document_path Current document path (empty string means unnamed).
+ * @member status_message Status bar message.
+ * @member saved_revision Document revision corresponding to the last save.
+ * @member document_dirty Whether the document is dirty (non-zero means unsaved changes).
+ * @member save_document Save callback.
+ * @member load_document Load callback.
+ * @member command_user_data Callback context.
  */
 typedef struct Workspace {
     Document document;
@@ -76,9 +76,9 @@ typedef struct Workspace {
 } Workspace;
 
 /**
- * @brief 将当前文档修订号标记为“已保存”。
- * @param workspace 目标工作区，为 `NULL` 时无操作。
- * @return 无。
+ * @brief Mark the current document revision as saved.
+ * @param workspace Target workspace; no-op if `NULL`.
+ * @return No return value.
  */
 static inline void workspace_mark_saved(Workspace* workspace)
 {
@@ -91,9 +91,9 @@ static inline void workspace_mark_saved(Workspace* workspace)
 }
 
 /**
- * @brief 根据 `saved_revision` 与当前修订号同步脏标记。
- * @param workspace 目标工作区，为 `NULL` 时无操作。
- * @return 无。
+ * @brief Sync the dirty flag based on `saved_revision` and the current revision.
+ * @param workspace Target workspace; no-op if `NULL`.
+ * @return No return value.
  */
 static inline void workspace_sync_document_dirty(Workspace* workspace)
 {

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -1,14 +1,6 @@
 /**
  * @file workspace.h
- * @brief Shared editor state hub used across runtime systems.
- *
- * Role in project:
- * - Aggregates document, history, canvas, tools, and UI layout state.
- * - Provides function hooks for save/load commands.
- *
- * Module relationships:
- * - Owned by `application.c`.
- * - Referenced by tools and UI for coordinated document operations.
+ * @brief 编辑器运行时共享工作区定义。
  */
 #ifndef GLDRAW_APP_WORKSPACE_H
 #define GLDRAW_APP_WORKSPACE_H
@@ -19,10 +11,28 @@
 #include <tools/tool_controller.h>
 
 struct Workspace;
-/** Callback signature for workspace-level commands (save/load). */
+
+/**
+ * @typedef WorkspaceCommandFn
+ * @brief 工作区命令回调签名（如保存/加载）。
+ * @param workspace 目标工作区。
+ * @param user_data 调用方透传上下文。
+ * @return 成功返回非零，失败返回 0。
+ */
 typedef int (*WorkspaceCommandFn)(struct Workspace* workspace, void* user_data);
 
-/** UI-computed layout snapshot shared with input/canvas subsystems. */
+/**
+ * @struct WorkspaceLayout
+ * @brief UI 计算出的布局快照。
+ *
+ * @member window_bounds 窗口边界。
+ * @member canvas_content_bounds 画布可用内容区。
+ * @member appbar_bounds 顶部工具条区域。
+ * @member rail_bounds 左侧工具轨区域。
+ * @member panel_bounds 右侧面板区域。
+ * @member status_bounds 底部状态栏区域。
+ * @member layout_revision 布局版本号（用于跨系统同步）。
+ */
 typedef struct WorkspaceLayout {
     RectF window_bounds;
     RectF canvas_content_bounds;
@@ -34,39 +44,41 @@ typedef struct WorkspaceLayout {
 } WorkspaceLayout;
 
 /**
- * @brief Central runtime state passed between systems.
+ * @struct Workspace
+ * @brief 运行时核心状态容器。
  *
- * Memory ownership notes:
- * - `document`, `history`, `canvas`, and `tools` are embedded values (no extra indirection).
- * - `save_document`/`load_document` are callbacks owned by the application layer.
- *
- * Concurrency note:
- * - This struct is not thread-safe; all access must be serialized by the caller.
+ * @member document 当前文档对象与选择状态。
+ * @member history 撤销/重做历史。
+ * @member canvas 画布视图状态。
+ * @member tools 工具控制器。
+ * @member layout UI 布局信息。
+ * @member current_document_path 当前文档路径（空串表示未命名文档）。
+ * @member status_message 状态栏消息。
+ * @member saved_revision 最近一次保存对应的文档修订号。
+ * @member document_dirty 文档是否脏（非零表示有未保存改动）。
+ * @member save_document 保存回调。
+ * @member load_document 加载回调。
+ * @member command_user_data 回调上下文。
  */
 typedef struct Workspace {
-    Document document;              /**< In-memory document with objects and selection */
-    DocumentHistory history;        /**< Undo/redo stacks */
-    CanvasView canvas;              /**< Viewport, zoom, pan, and coordinate transforms */
-    ToolController tools;           /**< Active tool and its runtime state */
-    WorkspaceLayout layout;        /**< UI-computed layout rectangles (set by UI system) */
-    char current_document_path[260]; /**< Active file path (empty for new documents) */
-    char status_message[256];       /**< Current status bar message */
-    unsigned int saved_revision;     /**< Document revision last marked as saved */
-    int document_dirty;             /**< Non-zero when current revision differs from saved_revision */
-    WorkspaceCommandFn save_document; /**< Workspace-level save callback */
-    WorkspaceCommandFn load_document; /**< Workspace-level load callback */
-    void* command_user_data;        /**< Caller-supplied context for command callbacks */
+    Document document;
+    DocumentHistory history;
+    CanvasView canvas;
+    ToolController tools;
+    WorkspaceLayout layout;
+    char current_document_path[260];
+    char status_message[256];
+    unsigned int saved_revision;
+    int document_dirty;
+    WorkspaceCommandFn save_document;
+    WorkspaceCommandFn load_document;
+    void* command_user_data;
 } Workspace;
 
 /**
- * @brief Mark the current document revision as persisted.
- * @param workspace [in,out] Target workspace; ignored when `NULL`.
- * @return None.
- *
- * Edge cases:
- * - Safe no-op for `NULL`.
- *
- * Time complexity: `O(1)`.
+ * @brief 将当前文档修订号标记为“已保存”。
+ * @param workspace 目标工作区，为 `NULL` 时无操作。
+ * @return 无。
  */
 static inline void workspace_mark_saved(Workspace* workspace)
 {
@@ -79,14 +91,9 @@ static inline void workspace_mark_saved(Workspace* workspace)
 }
 
 /**
- * @brief Recompute dirty flag from saved revision and current revision.
- * @param workspace [in,out] Target workspace; ignored when `NULL`.
- * @return None.
- *
- * Edge cases:
- * - Safe no-op for `NULL`.
- *
- * Time complexity: `O(1)`.
+ * @brief 根据 `saved_revision` 与当前修订号同步脏标记。
+ * @param workspace 目标工作区，为 `NULL` 时无操作。
+ * @return 无。
  */
 static inline void workspace_sync_document_dirty(Workspace* workspace)
 {

--- a/include/base/log.h
+++ b/include/base/log.h
@@ -1,13 +1,8 @@
 /**
  * @file log.h
- * @brief Lightweight stderr logging helpers.
+ * @brief 轻量级日志输出宏与实现。
  *
- * Role in project:
- * - Provides file/line scoped debug/info/warn/error logging macros.
- * - Keeps logging dependency-free for low-level modules.
- *
- * Module relationships:
- * - Used by app, canvas, document, render, tools, and UI subsystems.
+ * 日志统一输出到 `stderr`，并带有级别、文件与行号信息。
  */
 #ifndef GLDRAW_BASE_LOG_H
 #define GLDRAW_BASE_LOG_H
@@ -16,16 +11,14 @@
 #include <stdio.h>
 
 /**
- * @brief Internal varargs logger writing one line to `stderr`.
- * @param level [in] Log level tag string.
- * @param file [in] Source file path from caller.
- * @param line [in] Source line number from caller.
- * @param fmt [in] `printf`-style format string.
- * @param ... [in] Format arguments.
- *
- * Note:
- * - Return values of `fprintf`/`vfprintf` are intentionally ignored.
- * - Caller must ensure `fmt` and varargs match.
+ * @brief 内部日志实现函数（单行输出到 `stderr`）。
+ * @param level 日志级别字符串。
+ * @param file 调用位置文件名。
+ * @param line 调用位置行号。
+ * @param fmt `printf` 风格格式串。
+ * @param ... 与 `fmt` 匹配的可变参数。
+ * @return 无。
+ * @note 调用方必须保证格式串与参数类型一致。
  */
 static inline void log_write_impl(const char* level,
                                   const char* file,
@@ -41,14 +34,26 @@ static inline void log_write_impl(const char* level,
     va_end(args);
 }
 
+/** @def LOG_DEBUG
+ * @brief Debug 日志宏（仅在非 `NDEBUG` 构建启用）。
+ */
 #ifndef NDEBUG
 #define LOG_DEBUG(fmt, ...) log_write_impl("DEBUG", __FILE__, __LINE__, fmt, __VA_ARGS__)
 #else
 #define LOG_DEBUG(fmt, ...) ((void)0)
 #endif
 
+/** @def LOG_INFO
+ * @brief Info 日志宏。
+ */
 #define LOG_INFO(fmt, ...) log_write_impl("INFO", __FILE__, __LINE__, fmt, __VA_ARGS__)
+/** @def LOG_WARN
+ * @brief Warn 日志宏。
+ */
 #define LOG_WARN(fmt, ...) log_write_impl("WARN", __FILE__, __LINE__, fmt, __VA_ARGS__)
+/** @def LOG_ERROR
+ * @brief Error 日志宏。
+ */
 #define LOG_ERROR(fmt, ...) log_write_impl("ERROR", __FILE__, __LINE__, fmt, __VA_ARGS__)
 
 #endif /* GLDRAW_BASE_LOG_H */

--- a/include/base/log.h
+++ b/include/base/log.h
@@ -1,8 +1,8 @@
 /**
  * @file log.h
- * @brief 轻量级日志输出宏与实现。
+ * @brief Lightweight log output macros and implementation.
  *
- * 日志统一输出到 `stderr`，并带有级别、文件与行号信息。
+ * All logs are output to `stderr` with level, file, and line number information.
  */
 #ifndef GLDRAW_BASE_LOG_H
 #define GLDRAW_BASE_LOG_H
@@ -11,14 +11,14 @@
 #include <stdio.h>
 
 /**
- * @brief 内部日志实现函数（单行输出到 `stderr`）。
- * @param level 日志级别字符串。
- * @param file 调用位置文件名。
- * @param line 调用位置行号。
- * @param fmt `printf` 风格格式串。
- * @param ... 与 `fmt` 匹配的可变参数。
- * @return 无。
- * @note 调用方必须保证格式串与参数类型一致。
+ * @brief Internal log implementation function (single line to `stderr`).
+ * @param level Log level string.
+ * @param file Caller's file name.
+ * @param line Caller's line number.
+ * @param fmt `printf`-style format string.
+ * @param ... Variable arguments matching `fmt`.
+ * @return No return value.
+ * @note Callers must ensure the format string matches the argument types.
  */
 static inline void log_write_impl(const char* level,
                                   const char* file,
@@ -35,7 +35,7 @@ static inline void log_write_impl(const char* level,
 }
 
 /** @def LOG_DEBUG
- * @brief Debug 日志宏（仅在非 `NDEBUG` 构建启用）。
+ * @brief Debug log macro (enabled only in non-`NDEBUG` builds).
  */
 #ifndef NDEBUG
 #define LOG_DEBUG(fmt, ...) log_write_impl("DEBUG", __FILE__, __LINE__, fmt, __VA_ARGS__)
@@ -44,15 +44,15 @@ static inline void log_write_impl(const char* level,
 #endif
 
 /** @def LOG_INFO
- * @brief Info 日志宏。
+ * @brief Info log macro.
  */
 #define LOG_INFO(fmt, ...) log_write_impl("INFO", __FILE__, __LINE__, fmt, __VA_ARGS__)
 /** @def LOG_WARN
- * @brief Warn 日志宏。
+ * @brief Warning log macro.
  */
 #define LOG_WARN(fmt, ...) log_write_impl("WARN", __FILE__, __LINE__, fmt, __VA_ARGS__)
 /** @def LOG_ERROR
- * @brief Error 日志宏。
+ * @brief Error log macro.
  */
 #define LOG_ERROR(fmt, ...) log_write_impl("ERROR", __FILE__, __LINE__, fmt, __VA_ARGS__)
 

--- a/include/base/math2d.h
+++ b/include/base/math2d.h
@@ -1,13 +1,9 @@
 /**
  * @file math2d.h
- * @brief Inline 2D math helpers shared by canvas/tools/render code.
+ * @brief 2D 数学内联工具函数。
  *
- * Role in project:
- * - Centralizes tiny vector/rectangle operations.
- * - Avoids repeated ad-hoc math across modules.
- *
- * Module relationships:
- * - Consumed by canvas transforms, tool delta handling, and rendering math.
+ * 本文件提供向量运算、标量夹取和矩形判定等常用基础能力。
+ * 所有函数均为 `static inline`，用于减少跨模块重复代码。
  */
 #ifndef GLDRAW_BASE_MATH2D_H
 #define GLDRAW_BASE_MATH2D_H
@@ -15,7 +11,12 @@
 #include <math.h>
 #include <base/types.h>
 
-/** Build a vector from two scalars. Complexity: `O(1)`. */
+/**
+ * @brief 构造二维向量。
+ * @param x X 分量。
+ * @param y Y 分量。
+ * @return 构造后的 `Vec2`。
+ */
 static inline Vec2 vec2_make(float x, float y)
 {
     Vec2 value;
@@ -24,46 +25,77 @@ static inline Vec2 vec2_make(float x, float y)
     return value;
 }
 
-/** Add two vectors component-wise. Complexity: `O(1)`. */
+/**
+ * @brief 逐分量相加两个向量。
+ * @param a 第一个向量。
+ * @param b 第二个向量。
+ * @return `a + b`。
+ */
 static inline Vec2 vec2_add(Vec2 a, Vec2 b)
 {
     return vec2_make(a.x + b.x, a.y + b.y);
 }
 
-/** Subtract two vectors component-wise. Complexity: `O(1)`. */
+/**
+ * @brief 逐分量相减两个向量。
+ * @param a 被减向量。
+ * @param b 减数向量。
+ * @return `a - b`。
+ */
 static inline Vec2 vec2_sub(Vec2 a, Vec2 b)
 {
     return vec2_make(a.x - b.x, a.y - b.y);
 }
 
-/** Multiply a vector by a scalar. Complexity: `O(1)`. */
+/**
+ * @brief 向量按标量缩放。
+ * @param value 输入向量。
+ * @param scalar 缩放系数。
+ * @return `value * scalar`。
+ */
 static inline Vec2 vec2_scale(Vec2 value, float scalar)
 {
     return vec2_make(value.x * scalar, value.y * scalar);
 }
 
-/** Dot product of two vectors. Complexity: `O(1)`. */
+/**
+ * @brief 计算两个向量的点积。
+ * @param a 第一个向量。
+ * @param b 第二个向量。
+ * @return 点积值 `a.x * b.x + a.y * b.y`。
+ */
 static inline float vec2_dot(Vec2 a, Vec2 b)
 {
     return a.x * b.x + a.y * b.y;
 }
 
-/** Squared length of a vector (avoids `sqrt`). Complexity: `O(1)`. */
+/**
+ * @brief 计算向量长度平方。
+ * @param value 输入向量。
+ * @return 长度平方值（避免 `sqrt` 开销）。
+ */
 static inline float vec2_length_sq(Vec2 value)
 {
     return vec2_dot(value, value);
 }
 
-/** Euclidean vector length. Complexity: `O(1)`. */
+/**
+ * @brief 计算向量欧氏长度。
+ * @param value 输入向量。
+ * @return 向量长度。
+ */
 static inline float vec2_length(Vec2 value)
 {
     return sqrtf(vec2_length_sq(value));
 }
 
 /**
- * Clamp a scalar into `[min_value, max_value]`.
- * Edge case: behavior assumes `min_value <= max_value`.
- * Complexity: `O(1)`.
+ * @brief 将标量约束到闭区间 `[min_value, max_value]`。
+ * @param value 输入值。
+ * @param min_value 下界。
+ * @param max_value 上界。
+ * @return 夹取后的值。
+ * @note 调用方应保证 `min_value <= max_value`。
  */
 static inline float clampf(float value, float min_value, float max_value)
 {
@@ -76,34 +108,51 @@ static inline float clampf(float value, float min_value, float max_value)
     return value;
 }
 
-/** Rectangle left edge (`x`). Complexity: `O(1)`. */
+/**
+ * @brief 获取矩形左边界。
+ * @param rect 输入矩形。
+ * @return 左边界 `x`。
+ */
 static inline float rectf_left(const RectF* rect)
 {
     return rect->x;
 }
 
-/** Rectangle right edge (`x + w`). Complexity: `O(1)`. */
+/**
+ * @brief 获取矩形右边界。
+ * @param rect 输入矩形。
+ * @return 右边界 `x + w`。
+ */
 static inline float rectf_right(const RectF* rect)
 {
     return rect->x + rect->w;
 }
 
-/** Rectangle bottom edge (`y`). Complexity: `O(1)`. */
+/**
+ * @brief 获取矩形下边界。
+ * @param rect 输入矩形。
+ * @return 下边界 `y`。
+ */
 static inline float rectf_bottom(const RectF* rect)
 {
     return rect->y;
 }
 
-/** Rectangle top edge (`y + h`). Complexity: `O(1)`. */
+/**
+ * @brief 获取矩形上边界。
+ * @param rect 输入矩形。
+ * @return 上边界 `y + h`。
+ */
 static inline float rectf_top(const RectF* rect)
 {
     return rect->y + rect->h;
 }
 
 /**
- * Inclusive point-in-rectangle test.
- * Risk: caller must pass a non-null `rect`.
- * Complexity: `O(1)`.
+ * @brief 判断点是否位于矩形内部（含边界）。
+ * @param rect 输入矩形。
+ * @param point 待检测点。
+ * @return 点在矩形内返回非零，否则返回 0。
  */
 static inline int rectf_contains_point(const RectF* rect, Vec2 point)
 {

--- a/include/base/math2d.h
+++ b/include/base/math2d.h
@@ -1,9 +1,9 @@
 /**
  * @file math2d.h
- * @brief 2D 数学内联工具函数。
+ * @brief 2D math inline utility functions.
  *
- * 本文件提供向量运算、标量夹取和矩形判定等常用基础能力。
- * 所有函数均为 `static inline`，用于减少跨模块重复代码。
+ * Provides common basics: vector operations, scalar clamping, and rectangle tests.
+ * All functions are `static inline` to reduce cross-module duplicate code.
  */
 #ifndef GLDRAW_BASE_MATH2D_H
 #define GLDRAW_BASE_MATH2D_H
@@ -12,10 +12,10 @@
 #include <base/types.h>
 
 /**
- * @brief 构造二维向量。
- * @param x X 分量。
- * @param y Y 分量。
- * @return 构造后的 `Vec2`。
+ * @brief Construct a 2D vector.
+ * @param x X component.
+ * @param y Y component.
+ * @return The constructed `Vec2`.
  */
 static inline Vec2 vec2_make(float x, float y)
 {
@@ -26,10 +26,10 @@ static inline Vec2 vec2_make(float x, float y)
 }
 
 /**
- * @brief 逐分量相加两个向量。
- * @param a 第一个向量。
- * @param b 第二个向量。
- * @return `a + b`。
+ * @brief Component-wise addition of two vectors.
+ * @param a First vector.
+ * @param b Second vector.
+ * @return `a + b`.
  */
 static inline Vec2 vec2_add(Vec2 a, Vec2 b)
 {
@@ -37,10 +37,10 @@ static inline Vec2 vec2_add(Vec2 a, Vec2 b)
 }
 
 /**
- * @brief 逐分量相减两个向量。
- * @param a 被减向量。
- * @param b 减数向量。
- * @return `a - b`。
+ * @brief Component-wise subtraction of two vectors.
+ * @param a Vector being subtracted.
+ * @param b Vector to subtract.
+ * @return `a - b`.
  */
 static inline Vec2 vec2_sub(Vec2 a, Vec2 b)
 {
@@ -48,10 +48,10 @@ static inline Vec2 vec2_sub(Vec2 a, Vec2 b)
 }
 
 /**
- * @brief 向量按标量缩放。
- * @param value 输入向量。
- * @param scalar 缩放系数。
- * @return `value * scalar`。
+ * @brief Scale a vector by a scalar.
+ * @param value Input vector.
+ * @param scalar Scale factor.
+ * @return `value * scalar`.
  */
 static inline Vec2 vec2_scale(Vec2 value, float scalar)
 {
@@ -59,10 +59,10 @@ static inline Vec2 vec2_scale(Vec2 value, float scalar)
 }
 
 /**
- * @brief 计算两个向量的点积。
- * @param a 第一个向量。
- * @param b 第二个向量。
- * @return 点积值 `a.x * b.x + a.y * b.y`。
+ * @brief Compute the dot product of two vectors.
+ * @param a First vector.
+ * @param b Second vector.
+ * @return Dot product `a.x * b.x + a.y * b.y`.
  */
 static inline float vec2_dot(Vec2 a, Vec2 b)
 {
@@ -70,9 +70,9 @@ static inline float vec2_dot(Vec2 a, Vec2 b)
 }
 
 /**
- * @brief 计算向量长度平方。
- * @param value 输入向量。
- * @return 长度平方值（避免 `sqrt` 开销）。
+ * @brief Compute the squared length of a vector.
+ * @param value Input vector.
+ * @return Squared length (avoids `sqrt` overhead).
  */
 static inline float vec2_length_sq(Vec2 value)
 {
@@ -80,9 +80,9 @@ static inline float vec2_length_sq(Vec2 value)
 }
 
 /**
- * @brief 计算向量欧氏长度。
- * @param value 输入向量。
- * @return 向量长度。
+ * @brief Compute the Euclidean length of a vector.
+ * @param value Input vector.
+ * @return Vector length.
  */
 static inline float vec2_length(Vec2 value)
 {
@@ -90,12 +90,12 @@ static inline float vec2_length(Vec2 value)
 }
 
 /**
- * @brief 将标量约束到闭区间 `[min_value, max_value]`。
- * @param value 输入值。
- * @param min_value 下界。
- * @param max_value 上界。
- * @return 夹取后的值。
- * @note 调用方应保证 `min_value <= max_value`。
+ * @brief Clamp a scalar to the closed interval `[min_value, max_value]`.
+ * @param value Input value.
+ * @param min_value Lower bound.
+ * @param max_value Upper bound.
+ * @return Clamped value.
+ * @note Callers must ensure `min_value <= max_value`.
  */
 static inline float clampf(float value, float min_value, float max_value)
 {
@@ -109,9 +109,9 @@ static inline float clampf(float value, float min_value, float max_value)
 }
 
 /**
- * @brief 获取矩形左边界。
- * @param rect 输入矩形。
- * @return 左边界 `x`。
+ * @brief Get the left edge of a rectangle.
+ * @param rect Input rectangle.
+ * @return Left edge `x`.
  */
 static inline float rectf_left(const RectF* rect)
 {
@@ -119,9 +119,9 @@ static inline float rectf_left(const RectF* rect)
 }
 
 /**
- * @brief 获取矩形右边界。
- * @param rect 输入矩形。
- * @return 右边界 `x + w`。
+ * @brief Get the right edge of a rectangle.
+ * @param rect Input rectangle.
+ * @return Right edge `x + w`.
  */
 static inline float rectf_right(const RectF* rect)
 {
@@ -129,9 +129,9 @@ static inline float rectf_right(const RectF* rect)
 }
 
 /**
- * @brief 获取矩形下边界。
- * @param rect 输入矩形。
- * @return 下边界 `y`。
+ * @brief Get the bottom edge of a rectangle.
+ * @param rect Input rectangle.
+ * @return Bottom edge `y`.
  */
 static inline float rectf_bottom(const RectF* rect)
 {
@@ -139,9 +139,9 @@ static inline float rectf_bottom(const RectF* rect)
 }
 
 /**
- * @brief 获取矩形上边界。
- * @param rect 输入矩形。
- * @return 上边界 `y + h`。
+ * @brief Get the top edge of a rectangle.
+ * @param rect Input rectangle.
+ * @return Top edge `y + h`.
  */
 static inline float rectf_top(const RectF* rect)
 {
@@ -149,10 +149,10 @@ static inline float rectf_top(const RectF* rect)
 }
 
 /**
- * @brief 判断点是否位于矩形内部（含边界）。
- * @param rect 输入矩形。
- * @param point 待检测点。
- * @return 点在矩形内返回非零，否则返回 0。
+ * @brief Check whether a point is inside the rectangle (including the boundary).
+ * @param rect Input rectangle.
+ * @param point Point to test.
+ * @return Non-zero if the point is inside, zero otherwise.
  */
 static inline int rectf_contains_point(const RectF* rect, Vec2 point)
 {

--- a/include/base/types.h
+++ b/include/base/types.h
@@ -1,27 +1,40 @@
 /**
  * @file types.h
- * @brief Small shared value types used by all core modules.
+ * @brief 项目共享的基础值类型定义。
  *
- * Role in project:
- * - Provides stable primitive structs for geometry and color.
- * - Reduces cross-module coupling on third-party math/color APIs.
- *
- * Module relationships:
- * - Included by document, canvas, tools, render, and UI headers.
+ * 该文件只声明轻量级 POD 类型，不包含任何行为逻辑，
+ * 供 document/canvas/tools/render/ui 等模块复用。
  */
 #ifndef GLDRAW_BASE_TYPES_H
 #define GLDRAW_BASE_TYPES_H
 
-/** Stable object identity in a document. */
+/**
+ * @typedef ObjectId
+ * @brief 文档内对象的稳定标识符类型。
+ */
 typedef unsigned int ObjectId;
 
-/** 2D vector in world/screen space. */
+/**
+ * @struct Vec2
+ * @brief 二维向量（可用于世界坐标或屏幕坐标）。
+ *
+ * @member x X 分量。
+ * @member y Y 分量。
+ */
 typedef struct {
     float x;
     float y;
 } Vec2;
 
-/** RGBA color in normalized float range `[0, 1]`. */
+/**
+ * @struct Color
+ * @brief RGBA 颜色（分量范围通常为 `[0, 1]`）。
+ *
+ * @member r 红色分量。
+ * @member g 绿色分量。
+ * @member b 蓝色分量。
+ * @member a 透明度分量。
+ */
 typedef struct {
     float r;
     float g;
@@ -29,7 +42,15 @@ typedef struct {
     float a;
 } Color;
 
-/** Floating-point rectangle (`x`, `y`, `width`, `height`). */
+/**
+ * @struct RectF
+ * @brief 浮点矩形（x/y/w/h）。
+ *
+ * @member x 左下角（或左上角，取决于调用方坐标系）X 坐标。
+ * @member y 左下角（或左上角，取决于调用方坐标系）Y 坐标。
+ * @member w 宽度。
+ * @member h 高度。
+ */
 typedef struct {
     float x;
     float y;

--- a/include/base/types.h
+++ b/include/base/types.h
@@ -1,25 +1,25 @@
 /**
  * @file types.h
- * @brief 项目共享的基础值类型定义。
+ * @brief Project-shared basic value type definitions.
  *
- * 该文件只声明轻量级 POD 类型，不包含任何行为逻辑，
- * 供 document/canvas/tools/render/ui 等模块复用。
+ * This file declares lightweight POD types only, with no behavior logic.
+ * Shared by document/canvas/tools/render/ui and other modules.
  */
 #ifndef GLDRAW_BASE_TYPES_H
 #define GLDRAW_BASE_TYPES_H
 
 /**
  * @typedef ObjectId
- * @brief 文档内对象的稳定标识符类型。
+ * @brief Stable object identifier type within a document.
  */
 typedef unsigned int ObjectId;
 
 /**
  * @struct Vec2
- * @brief 二维向量（可用于世界坐标或屏幕坐标）。
+ * @brief 2D vector (usable for world or screen coordinates).
  *
- * @member x X 分量。
- * @member y Y 分量。
+ * @member x X component.
+ * @member y Y component.
  */
 typedef struct {
     float x;
@@ -28,12 +28,12 @@ typedef struct {
 
 /**
  * @struct Color
- * @brief RGBA 颜色（分量范围通常为 `[0, 1]`）。
+ * @brief RGBA color (component range is typically `[0, 1]`).
  *
- * @member r 红色分量。
- * @member g 绿色分量。
- * @member b 蓝色分量。
- * @member a 透明度分量。
+ * @member r Red component.
+ * @member g Green component.
+ * @member b Blue component.
+ * @member a Alpha component.
  */
 typedef struct {
     float r;
@@ -44,12 +44,12 @@ typedef struct {
 
 /**
  * @struct RectF
- * @brief 浮点矩形（x/y/w/h）。
+ * @brief Floating-point rectangle (x/y/w/h).
  *
- * @member x 左下角（或左上角，取决于调用方坐标系）X 坐标。
- * @member y 左下角（或左上角，取决于调用方坐标系）Y 坐标。
- * @member w 宽度。
- * @member h 高度。
+ * @member x X coordinate of the bottom-left corner (or top-left, depending on caller's coordinate system).
+ * @member y Y coordinate of the bottom-left corner (or top-left, depending on caller's coordinate system).
+ * @member w Width.
+ * @member h Height.
  */
 typedef struct {
     float x;

--- a/include/canvas/canvas_view.h
+++ b/include/canvas/canvas_view.h
@@ -1,14 +1,6 @@
 /**
  * @file canvas_view.h
- * @brief Canvas camera and coordinate conversion API.
- *
- * Role in project:
- * - Stores viewport, center, zoom, and presentation flags.
- * - Converts between world space and screen space for tools/rendering.
- *
- * Module relationships:
- * - Reads `Document` for picking.
- * - Used by tools, renderer, and application event handling.
+ * @brief 画布视口状态与坐标变换接口。
  */
 #ifndef GLDRAW_CANVAS_CANVAS_VIEW_H
 #define GLDRAW_CANVAS_CANVAS_VIEW_H
@@ -16,7 +8,14 @@
 #include <base/types.h>
 #include <document/document.h>
 
-/** Canonical camera state for viewport transforms. */
+/**
+ * @struct CanvasViewportState
+ * @brief 画布相机的规范状态。
+ *
+ * @member viewport 屏幕空间视口矩形。
+ * @member center 世界坐标系下视口中心。
+ * @member zoom 缩放因子。
+ */
 typedef struct CanvasViewportState {
     RectF viewport;
     Vec2 center;
@@ -24,58 +23,154 @@ typedef struct CanvasViewportState {
 } CanvasViewportState;
 
 /**
- * @brief Runtime canvas view state.
+ * @struct CanvasView
+ * @brief 画布运行时状态。
  *
- * Stores viewport, center, zoom, and presentation flags.
+ * @member document 参与拾取与渲染的数据文档（不拥有）。
+ * @member viewport_state 视口/中心/缩放状态。
+ * @member show_grid 是否显示网格。
+ * @member background 画布背景色。
  */
 typedef struct CanvasView {
-    Document* document;             /**< Document used for picking */
-    CanvasViewportState viewport_state; /**< Canonical camera state */
-    int show_grid;                 /**< Non-zero to draw grid */
-    Color background;              /**< Canvas background color */
+    Document* document;
+    CanvasViewportState viewport_state;
+    int show_grid;
+    Color background;
 } CanvasView;
 
-/** Initialize canvas state and bind a document. Complexity: `O(1)`. */
-void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport);
-/** Rebind document used for picking. Complexity: `O(1)`. */
-void canvas_view_set_document(CanvasView* canvas, Document* document);
-/** Update screen viewport rectangle. Complexity: `O(1)`. */
-void canvas_view_set_viewport(CanvasView* canvas, RectF viewport);
-/** Set world-space center. Complexity: `O(1)`. */
-void canvas_view_set_center(CanvasView* canvas, Vec2 center);
-/** Set zoom (clamped to valid range). Complexity: `O(1)`. */
-void canvas_view_set_zoom(CanvasView* canvas, float zoom);
-/** Set center and zoom atomically. Complexity: `O(1)`. */
-void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom);
-/** Get current viewport rectangle. Complexity: `O(1)`. */
-RectF canvas_view_viewport(const CanvasView* canvas);
-/** Get current world-space center. Complexity: `O(1)`. */
-Vec2 canvas_view_center(const CanvasView* canvas);
-/** Get current zoom factor. Complexity: `O(1)`. */
-float canvas_view_zoom(const CanvasView* canvas);
-/** Convert world coordinates to screen coordinates. Complexity: `O(1)`. */
-Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world);
-/** Convert screen coordinates to world coordinates. Complexity: `O(1)`. */
-Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen);
-/** Pan camera by a screen-space delta. Complexity: `O(1)`. */
-void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen);
-/** Zoom around a fixed screen anchor to keep cursor focus stable. Complexity: `O(1)`. */
-void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 screen_anchor);
-/** Convert pixel tolerance to world-space tolerance at current zoom. Complexity: `O(1)`. */
-float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pixels);
-/** Get currently visible world-space rectangle. Complexity: `O(1)`. */
-RectF canvas_view_visible_world_rect(const CanvasView* canvas);
 /**
- * @brief Pick top-most object under a screen point.
- * @param canvas [in] Canvas view instance.
- * @param screen_point [in] Screen-space pixel coordinate.
- * @param tolerance_pixels [in] Pick tolerance in screen pixels.
- * @return Pointer to the top-most hit object, or `NULL` if no hit or invalid input.
+ * @brief 初始化画布状态并绑定文档。
+ * @param canvas 画布实例输出地址。
+ * @param document 初始绑定文档（可为 `NULL`）。
+ * @param viewport 初始屏幕视口。
+ * @return 无。
+ */
+void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport);
+
+/**
+ * @brief 重新绑定文档。
+ * @param canvas 画布实例。
+ * @param document 新文档指针。
+ * @return 无。
+ */
+void canvas_view_set_document(CanvasView* canvas, Document* document);
+
+/**
+ * @brief 设置画布屏幕视口。
+ * @param canvas 画布实例。
+ * @param viewport 视口矩形。
+ * @return 无。
+ */
+void canvas_view_set_viewport(CanvasView* canvas, RectF viewport);
+
+/**
+ * @brief 设置画布中心点（世界坐标）。
+ * @param canvas 画布实例。
+ * @param center 新中心点。
+ * @return 无。
+ */
+void canvas_view_set_center(CanvasView* canvas, Vec2 center);
+
+/**
+ * @brief 设置缩放因子。
+ * @param canvas 画布实例。
+ * @param zoom 新缩放值（实现中会进行有效范围夹取）。
+ * @return 无。
+ */
+void canvas_view_set_zoom(CanvasView* canvas, float zoom);
+
+/**
+ * @brief 原子设置中心与缩放。
+ * @param canvas 画布实例。
+ * @param center 新中心点。
+ * @param zoom 新缩放值。
+ * @return 无。
+ */
+void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom);
+
+/**
+ * @brief 获取当前屏幕视口。
+ * @param canvas 画布实例。
+ * @return 当前视口矩形。
+ */
+RectF canvas_view_viewport(const CanvasView* canvas);
+
+/**
+ * @brief 获取当前世界坐标中心。
+ * @param canvas 画布实例。
+ * @return 当前中心点。
+ */
+Vec2 canvas_view_center(const CanvasView* canvas);
+
+/**
+ * @brief 获取当前缩放值。
+ * @param canvas 画布实例。
+ * @return 当前缩放因子。
+ */
+float canvas_view_zoom(const CanvasView* canvas);
+
+/**
+ * @brief 将世界坐标转换为屏幕坐标。
+ * @param canvas 画布实例。
+ * @param world 世界坐标点。
+ * @return 对应的屏幕坐标点。
+ */
+Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world);
+
+/**
+ * @brief 将屏幕坐标转换为世界坐标。
+ * @param canvas 画布实例。
+ * @param screen 屏幕坐标点。
+ * @return 对应的世界坐标点。
+ */
+Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen);
+
+/**
+ * @brief 按屏幕位移平移画布。
+ * @param canvas 画布实例。
+ * @param delta_screen 屏幕空间位移增量。
+ * @return 无。
+ */
+void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen);
+
+/**
+ * @brief 以指定屏幕锚点执行缩放。
  *
- * Why reverse loop:
- * - Newer objects are drawn later and visually on top, so picking scans from end.
+ * 算法要点：先计算缩放前锚点对应世界坐标，再缩放并计算缩放后坐标，
+ * 最后用两者差值修正中心点，实现“光标处缩放不漂移”。
  *
- * Complexity: `O(n)` where `n` is document object count (reverse linear scan).
+ * @param canvas 画布实例。
+ * @param factor 缩放倍率（大于 1 放大，小于 1 缩小）。
+ * @param screen_anchor 屏幕锚点。
+ * @return 无。
+ */
+void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 screen_anchor);
+
+/**
+ * @brief 将像素容差换算为世界坐标容差。
+ * @param canvas 画布实例。
+ * @param pixels 像素单位容差。
+ * @return 世界坐标单位容差。
+ */
+float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pixels);
+
+/**
+ * @brief 获取当前可见世界矩形。
+ * @param canvas 画布实例。
+ * @return 视口在世界坐标系下覆盖的矩形。
+ */
+RectF canvas_view_visible_world_rect(const CanvasView* canvas);
+
+/**
+ * @brief 在屏幕点执行对象拾取。
+ *
+ * 算法要点：从对象数组末尾逆序遍历（后绘制对象优先命中），
+ * 并将像素容差换算到世界坐标后调用对象命中测试。
+ *
+ * @param canvas 画布实例。
+ * @param screen_point 屏幕空间待拾取点。
+ * @param tolerance_pixels 像素容差。
+ * @return 命中对象指针；未命中或参数非法时返回 `NULL`。
  */
 GraphicObject* canvas_view_pick_object(const CanvasView* canvas, Vec2 screen_point, float tolerance_pixels);
 

--- a/include/canvas/canvas_view.h
+++ b/include/canvas/canvas_view.h
@@ -1,6 +1,6 @@
 /**
  * @file canvas_view.h
- * @brief 画布视口状态与坐标变换接口。
+ * @brief Canvas viewport state and coordinate transform interface.
  */
 #ifndef GLDRAW_CANVAS_CANVAS_VIEW_H
 #define GLDRAW_CANVAS_CANVAS_VIEW_H
@@ -10,11 +10,11 @@
 
 /**
  * @struct CanvasViewportState
- * @brief 画布相机的规范状态。
+ * @brief Canonical state of the canvas camera.
  *
- * @member viewport 屏幕空间视口矩形。
- * @member center 世界坐标系下视口中心。
- * @member zoom 缩放因子。
+ * @member viewport Screen-space viewport rectangle.
+ * @member center Viewport center in world coordinates.
+ * @member zoom Zoom factor.
  */
 typedef struct CanvasViewportState {
     RectF viewport;
@@ -24,12 +24,12 @@ typedef struct CanvasViewportState {
 
 /**
  * @struct CanvasView
- * @brief 画布运行时状态。
+ * @brief Canvas runtime state.
  *
- * @member document 参与拾取与渲染的数据文档（不拥有）。
- * @member viewport_state 视口/中心/缩放状态。
- * @member show_grid 是否显示网格。
- * @member background 画布背景色。
+ * @member document Data document participating in picking and rendering (non-owning).
+ * @member viewport_state Viewport/center/zoom state.
+ * @member show_grid Whether to show the grid.
+ * @member background Canvas background color.
  */
 typedef struct CanvasView {
     Document* document;
@@ -39,138 +39,139 @@ typedef struct CanvasView {
 } CanvasView;
 
 /**
- * @brief 初始化画布状态并绑定文档。
- * @param canvas 画布实例输出地址。
- * @param document 初始绑定文档（可为 `NULL`）。
- * @param viewport 初始屏幕视口。
- * @return 无。
+ * @brief Initialize the canvas state and bind a document.
+ * @param canvas Canvas instance output address.
+ * @param document Initially bound document (may be `NULL`).
+ * @param viewport Initial screen viewport.
+ * @return No return value.
  */
 void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport);
 
 /**
- * @brief 重新绑定文档。
- * @param canvas 画布实例。
- * @param document 新文档指针。
- * @return 无。
+ * @brief Re-bind a document.
+ * @param canvas Canvas instance.
+ * @param document New document pointer.
+ * @return No return value.
  */
 void canvas_view_set_document(CanvasView* canvas, Document* document);
 
 /**
- * @brief 设置画布屏幕视口。
- * @param canvas 画布实例。
- * @param viewport 视口矩形。
- * @return 无。
+ * @brief Set the canvas screen viewport.
+ * @param canvas Canvas instance.
+ * @param viewport Viewport rectangle.
+ * @return No return value.
  */
 void canvas_view_set_viewport(CanvasView* canvas, RectF viewport);
 
 /**
- * @brief 设置画布中心点（世界坐标）。
- * @param canvas 画布实例。
- * @param center 新中心点。
- * @return 无。
+ * @brief Set the canvas center point (in world coordinates).
+ * @param canvas Canvas instance.
+ * @param center New center point.
+ * @return No return value.
  */
 void canvas_view_set_center(CanvasView* canvas, Vec2 center);
 
 /**
- * @brief 设置缩放因子。
- * @param canvas 画布实例。
- * @param zoom 新缩放值（实现中会进行有效范围夹取）。
- * @return 无。
+ * @brief Set the zoom factor.
+ * @param canvas Canvas instance.
+ * @param zoom New zoom value (clamped to a valid range in the implementation).
+ * @return No return value.
  */
 void canvas_view_set_zoom(CanvasView* canvas, float zoom);
 
 /**
- * @brief 原子设置中心与缩放。
- * @param canvas 画布实例。
- * @param center 新中心点。
- * @param zoom 新缩放值。
- * @return 无。
+ * @brief Atomically set center and zoom.
+ * @param canvas Canvas instance.
+ * @param center New center point.
+ * @param zoom New zoom value.
+ * @return No return value.
  */
 void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom);
 
 /**
- * @brief 获取当前屏幕视口。
- * @param canvas 画布实例。
- * @return 当前视口矩形。
+ * @brief Get the current screen viewport.
+ * @param canvas Canvas instance.
+ * @return Current viewport rectangle.
  */
 RectF canvas_view_viewport(const CanvasView* canvas);
 
 /**
- * @brief 获取当前世界坐标中心。
- * @param canvas 画布实例。
- * @return 当前中心点。
+ * @brief Get the current world-coordinate center.
+ * @param canvas Canvas instance.
+ * @return Current center point.
  */
 Vec2 canvas_view_center(const CanvasView* canvas);
 
 /**
- * @brief 获取当前缩放值。
- * @param canvas 画布实例。
- * @return 当前缩放因子。
+ * @brief Get the current zoom value.
+ * @param canvas Canvas instance.
+ * @return Current zoom factor.
  */
 float canvas_view_zoom(const CanvasView* canvas);
 
 /**
- * @brief 将世界坐标转换为屏幕坐标。
- * @param canvas 画布实例。
- * @param world 世界坐标点。
- * @return 对应的屏幕坐标点。
+ * @brief Convert world coordinates to screen coordinates.
+ * @param canvas Canvas instance.
+ * @param world World coordinate point.
+ * @return Corresponding screen coordinate point.
  */
 Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world);
 
 /**
- * @brief 将屏幕坐标转换为世界坐标。
- * @param canvas 画布实例。
- * @param screen 屏幕坐标点。
- * @return 对应的世界坐标点。
+ * @brief Convert screen coordinates to world coordinates.
+ * @param canvas Canvas instance.
+ * @param screen Screen coordinate point.
+ * @return Corresponding world coordinate point.
  */
 Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen);
 
 /**
- * @brief 按屏幕位移平移画布。
- * @param canvas 画布实例。
- * @param delta_screen 屏幕空间位移增量。
- * @return 无。
+ * @brief Pan the canvas by a screen-space displacement.
+ * @param canvas Canvas instance.
+ * @param delta_screen Screen-space displacement delta.
+ * @return No return value.
  */
 void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen);
 
 /**
- * @brief 以指定屏幕锚点执行缩放。
+ * @brief Zoom at a given screen anchor point.
  *
- * 算法要点：先计算缩放前锚点对应世界坐标，再缩放并计算缩放后坐标，
- * 最后用两者差值修正中心点，实现“光标处缩放不漂移”。
+ * Algorithm: compute the world coordinate of the anchor before zoom, zoom,
+ * compute the new world coordinate, then correct the center by the difference
+ * to achieve "zoom without cursor drift."
  *
- * @param canvas 画布实例。
- * @param factor 缩放倍率（大于 1 放大，小于 1 缩小）。
- * @param screen_anchor 屏幕锚点。
- * @return 无。
+ * @param canvas Canvas instance.
+ * @param factor Zoom factor (> 1 zooms in, < 1 zooms out).
+ * @param screen_anchor Screen anchor point.
+ * @return No return value.
  */
 void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 screen_anchor);
 
 /**
- * @brief 将像素容差换算为世界坐标容差。
- * @param canvas 画布实例。
- * @param pixels 像素单位容差。
- * @return 世界坐标单位容差。
+ * @brief Convert pixel tolerance to world-coordinate tolerance.
+ * @param canvas Canvas instance.
+ * @param pixels Tolerance in pixels.
+ * @return Tolerance in world coordinates.
  */
 float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pixels);
 
 /**
- * @brief 获取当前可见世界矩形。
- * @param canvas 画布实例。
- * @return 视口在世界坐标系下覆盖的矩形。
+ * @brief Get the currently visible world rectangle.
+ * @param canvas Canvas instance.
+ * @return Rectangle covered by the viewport in world coordinates.
  */
 RectF canvas_view_visible_world_rect(const CanvasView* canvas);
 
 /**
- * @brief 在屏幕点执行对象拾取。
+ * @brief Pick an object at a screen point.
  *
- * 算法要点：从对象数组末尾逆序遍历（后绘制对象优先命中），
- * 并将像素容差换算到世界坐标后调用对象命中测试。
+ * Algorithm: iterate backward from the end of the object array (later-drawn objects take priority),
+ * convert the pixel tolerance to world coordinates, and call the object's hit-test.
  *
- * @param canvas 画布实例。
- * @param screen_point 屏幕空间待拾取点。
- * @param tolerance_pixels 像素容差。
- * @return 命中对象指针；未命中或参数非法时返回 `NULL`。
+ * @param canvas Canvas instance.
+ * @param screen_point Screen-space point to pick.
+ * @param tolerance_pixels Tolerance in pixels.
+ * @return Pointer to the hit object; returns `NULL` on miss or invalid parameters.
  */
 GraphicObject* canvas_view_pick_object(const CanvasView* canvas, Vec2 screen_point, float tolerance_pixels);
 

--- a/include/document/document.h
+++ b/include/document/document.h
@@ -1,6 +1,6 @@
 /**
  * @file document.h
- * @brief 文档对象容器与选择集操作接口。
+ * @brief Document object container and selection set operation interface.
  */
 #ifndef GLDRAW_DOCUMENT_DOCUMENT_H
 #define GLDRAW_DOCUMENT_DOCUMENT_H
@@ -12,10 +12,10 @@
 
 /**
  * @struct SelectionSet
- * @brief 文档选择集（基于对象 ID）。
+ * @brief Document selection set (based on object IDs).
  *
- * @member ids 选中对象 ID 列表。
- * @member count 当前选中数量。
+ * @member ids Selected object ID list.
+ * @member count Current selection count.
  */
 typedef struct {
   ObjectId ids[DOCUMENT_MAX_SELECTION];
@@ -24,13 +24,13 @@ typedef struct {
 
 /**
  * @struct Document
- * @brief 文档主数据结构。
+ * @brief Document main data structure.
  *
- * @member objects 对象指针数组（由文档拥有生命周期）。
- * @member count 当前对象数量。
- * @member revision 文档修订号（编辑后递增）。
- * @member next_id 新对象自动分配 ID。
- * @member selection 当前选择集。
+ * @member objects Object pointer array (document owns the lifetime).
+ * @member count Current object count.
+ * @member revision Document revision number (incremented after edits).
+ * @member next_id Auto-assigned ID for new objects.
+ * @member selection Current selection set.
  */
 typedef struct Document {
   GraphicObject *objects[DOCUMENT_MAX_OBJECTS];
@@ -41,133 +41,133 @@ typedef struct Document {
 } Document;
 
 /**
- * @brief 初始化文档为全新空状态。
- * @param document 待初始化文档。
- * @return 无。
+ * @brief Initialize the document to a fresh empty state.
+ * @param document Document to initialize.
+ * @return No return value.
  */
 void document_init(Document *document);
 
 /**
- * @brief 释放文档拥有的全部对象并清空运行时状态。
- * @param document 目标文档。
- * @return 无。
+ * @brief Release all objects owned by the document and clear runtime state.
+ * @param document Target document.
+ * @return No return value.
  */
 void document_shutdown(Document *document);
 
 /**
- * @brief 重置文档为“新建文档”状态。
- * @param document 目标文档。
- * @return 无。
- * @note 与 `document_shutdown` 不同，本函数会将 `revision` 与 `next_id` 重置到初始值。
+ * @brief Reset the document to a "new document" state.
+ * @param document Target document.
+ * @return No return value.
+ * @note Unlike `document_shutdown`, this function resets `revision` and `next_id` to initial values.
  */
 void document_reset(Document *document);
 
 /**
- * @brief 向文档追加对象并自动分配 ID。
- * @param document 目标文档。
- * @param object 待插入对象。
- * @return 成功返回非零，容量不足或参数非法返回 0。
+ * @brief Append an object to the document and auto-assign an ID.
+ * @param document Target document.
+ * @param object Object to insert.
+ * @return Non-zero on success; zero on capacity error or invalid parameters.
  */
 int document_add_object(Document *document, GraphicObject *object);
 
 /**
- * @brief 以指定 ID 向文档追加对象。
- * @param document 目标文档。
- * @param object 待插入对象。
- * @param id 指定对象 ID。
- * @return 成功返回非零；ID 冲突、参数非法或容量不足返回 0。
+ * @brief Append an object to the document with a specified ID.
+ * @param document Target document.
+ * @param object Object to insert.
+ * @param id Specified object ID.
+ * @return Non-zero on success; zero on ID conflict, invalid parameters, or capacity error.
  */
 int document_append_object_with_id(Document *document, GraphicObject *object,
                                    ObjectId id);
 
 /**
- * @brief 按对象 ID 查找对象。
- * @param document 文档。
- * @param id 对象 ID。
- * @return 找到时返回对象指针，否则返回 `NULL`。
+ * @brief Find an object by its ID.
+ * @param document Document.
+ * @param id Object ID.
+ * @return Object pointer if found, `NULL` otherwise.
  */
 GraphicObject *document_find_object(const Document *document, ObjectId id);
 
 /**
- * @brief 按数组索引获取对象。
- * @param document 文档。
- * @param index 对象索引。
- * @return 索引有效时返回对象指针，否则返回 `NULL`。
+ * @brief Get an object by array index.
+ * @param document Document.
+ * @param index Object index.
+ * @return Object pointer if index is valid, `NULL` otherwise.
  */
 GraphicObject *document_get_object_at(const Document *document, int index);
 
 /**
- * @brief 按 ID 删除对象并压缩对象数组。
- * @param document 目标文档。
- * @param id 待删除对象 ID。
- * @return 删除成功返回非零，否则返回 0。
+ * @brief Remove an object by ID and compact the object array.
+ * @param document Target document.
+ * @param id Object ID to remove.
+ * @return Non-zero on successful deletion, zero otherwise.
  */
 int document_remove_object(Document *document, ObjectId id);
 
 /**
- * @brief 删除当前选择集中的全部对象。
- * @param document 目标文档。
- * @return 无。
+ * @brief Delete all objects in the current selection set.
+ * @param document Target document.
+ * @return No return value.
  */
 void document_delete_selection(Document *document);
 
 /**
- * @brief 标记一次非结构性修改（修订号递增）。
- * @param document 目标文档。
- * @return 无。
+ * @brief Mark a non-structural modification (increments revision).
+ * @param document Target document.
+ * @return No return value.
  */
 void document_touch(Document *document);
 
 /**
- * @brief 计算文档中当前最大对象 ID。
- * @param document 文档。
- * @return 最大 ID；文档为空或参数非法返回 `0`。
+ * @brief Compute the maximum object ID in the document.
+ * @param document Document.
+ * @return Maximum ID; returns `0` if the document is empty or parameters are invalid.
  */
 ObjectId document_max_id(const Document *document);
 
 /**
- * @brief 清空选择集。
- * @param document 目标文档。
- * @return 无。
+ * @brief Clear the selection set.
+ * @param document Target document.
+ * @return No return value.
  */
 void document_clear_selection(Document *document);
 
 /**
- * @brief 判断对象 ID 是否在选择集中。
- * @param document 文档。
- * @param id 对象 ID。
- * @return 在选择集中返回非零，否则返回 0。
+ * @brief Check whether an object ID is in the selection set.
+ * @param document Document.
+ * @param id Object ID.
+ * @return Non-zero if in the selection set, zero otherwise.
  */
 int document_selection_contains(const Document *document, ObjectId id);
 
 /**
- * @brief 向选择集添加对象 ID。
- * @param document 目标文档。
- * @param id 对象 ID。
- * @return 添加成功或已存在返回非零；参数非法或容量不足返回 0。
+ * @brief Add an object ID to the selection set.
+ * @param document Target document.
+ * @param id Object ID.
+ * @return Non-zero on success or if already present; zero on invalid parameters or capacity error.
  */
 int document_selection_add(Document *document, ObjectId id);
 
 /**
- * @brief 从选择集中移除对象 ID。
- * @param document 目标文档。
- * @param id 对象 ID。
- * @return 无。
+ * @brief Remove an object ID from the selection set.
+ * @param document Target document.
+ * @param id Object ID.
+ * @return No return value.
  */
 void document_selection_remove(Document *document, ObjectId id);
 
 /**
- * @brief 切换对象 ID 的选中状态。
- * @param document 目标文档。
- * @param id 对象 ID。
- * @return 无。
+ * @brief Toggle the selection state of an object ID.
+ * @param document Target document.
+ * @param id Object ID.
+ * @return No return value.
  */
 void document_selection_toggle(Document *document, ObjectId id);
 
 /**
- * @brief 获取“主选中对象”（选择集首元素对应对象）。
- * @param document 文档。
- * @return 主选中对象；无选择时返回 `NULL`。
+ * @brief Get the "primary selected object" (object corresponding to the first element of the selection set).
+ * @param document Document.
+ * @return Primary selected object; returns `NULL` if no selection.
  */
 GraphicObject *document_primary_selection(const Document *document);
 

--- a/include/document/document.h
+++ b/include/document/document.h
@@ -1,17 +1,6 @@
 /**
  * @file document.h
- * @brief Core in-memory document model for drawable objects and selection.
- *
- * Role in project:
- * - Owns object storage, stable IDs, selection state, and revision tracking.
- * - Acts as the authoritative data model for tools, UI, persistence, and render.
- *
- * Module relationships:
- * - Uses object APIs from `document/object.h`.
- * - Consumed by history, canvas picking, tool operations, and save/load.
- *
- * Concurrency note:
- * - This module is not thread-safe; callers must serialize access externally.
+ * @brief 文档对象容器与选择集操作接口。
  */
 #ifndef GLDRAW_DOCUMENT_DOCUMENT_H
 #define GLDRAW_DOCUMENT_DOCUMENT_H
@@ -21,61 +10,165 @@
 #define DOCUMENT_MAX_OBJECTS 1024
 #define DOCUMENT_MAX_SELECTION 128
 
-/** Bounded selection list of object IDs. */
+/**
+ * @struct SelectionSet
+ * @brief 文档选择集（基于对象 ID）。
+ *
+ * @member ids 选中对象 ID 列表。
+ * @member count 当前选中数量。
+ */
 typedef struct {
-    ObjectId ids[DOCUMENT_MAX_SELECTION];
-    int count;
+  ObjectId ids[DOCUMENT_MAX_SELECTION];
+  int count;
 } SelectionSet;
 
 /**
- * @brief In-memory document storing drawable objects, selection, and metadata.
+ * @struct Document
+ * @brief 文档主数据结构。
  *
- * Concurrency note:
- * - This struct is not thread-safe; callers must serialize access externally.
+ * @member objects 对象指针数组（由文档拥有生命周期）。
+ * @member count 当前对象数量。
+ * @member revision 文档修订号（编辑后递增）。
+ * @member next_id 新对象自动分配 ID。
+ * @member selection 当前选择集。
  */
 typedef struct Document {
-    GraphicObject* objects[DOCUMENT_MAX_OBJECTS]; /**< Bounded object array */
-    int count;                                     /**< Number of objects currently stored */
-    unsigned int revision;                         /**< Monotonically increasing edit counter */
-    ObjectId next_id;                              /**< Next auto-assign ID for new objects */
-    SelectionSet selection;                        /**< Current selection set */
+  GraphicObject *objects[DOCUMENT_MAX_OBJECTS];
+  int count;
+  unsigned int revision;
+  ObjectId next_id;
+  SelectionSet selection;
 } Document;
 
-/** Initialize a document to empty state. Complexity: `O(1)`. */
-void document_init(Document* document);
-/** Destroy all owned objects and clear runtime state. Complexity: `O(n)`. */
-void document_shutdown(Document* document);
-/** Reset to pristine empty document (`revision=1`, `next_id=1`). Complexity: `O(n)`. */
-void document_reset(Document* document);
+/**
+ * @brief 初始化文档为全新空状态。
+ * @param document 待初始化文档。
+ * @return 无。
+ */
+void document_init(Document *document);
 
-/** Append object and assign a fresh ID; returns 0 on capacity/null input. Complexity: `O(1)`. */
-int document_add_object(Document* document, GraphicObject* object);
-/** Append object with explicit ID; fails on duplicate/invalid ID. Complexity: `O(n)`. */
-int document_append_object_with_id(Document* document, GraphicObject* object, ObjectId id);
-/** Find object by ID; returns `NULL` when not found. Complexity: `O(n)`. */
-GraphicObject* document_find_object(const Document* document, ObjectId id);
-/** Get object by index; returns `NULL` for invalid index/document. Complexity: `O(1)`. */
-GraphicObject* document_get_object_at(const Document* document, int index);
-/** Remove object by ID and compact array; returns 1 on success. Complexity: `O(n)`. */
-int document_remove_object(Document* document, ObjectId id);
-/** Delete all selected objects. Complexity: up to `O(s*n)` (`s`: selection count). */
-void document_delete_selection(Document* document);
-/** Bump revision for non-structural edits. Complexity: `O(1)`. */
-void document_touch(Document* document);
-/** Compute maximum existing object ID (0 when empty/invalid). Complexity: `O(n)`. */
-ObjectId document_max_id(const Document* document);
+/**
+ * @brief 释放文档拥有的全部对象并清空运行时状态。
+ * @param document 目标文档。
+ * @return 无。
+ */
+void document_shutdown(Document *document);
 
-/** Clear selection set. Complexity: `O(1)`. */
-void document_clear_selection(Document* document);
-/** Check if ID is selected. Complexity: `O(s)` (`s`: selection count). */
-int document_selection_contains(const Document* document, ObjectId id);
-/** Add ID to selection if not already present. Complexity: `O(s)`. */
-int document_selection_add(Document* document, ObjectId id);
-/** Remove ID from selection if present. Complexity: `O(s)`. */
-void document_selection_remove(Document* document, ObjectId id);
-/** Toggle selection state for an ID. Complexity: `O(s)`. */
-void document_selection_toggle(Document* document, ObjectId id);
-/** Get first selected object; returns `NULL` when none. Complexity: `O(n)` (ID lookup). */
-GraphicObject* document_primary_selection(const Document* document);
+/**
+ * @brief 重置文档为“新建文档”状态。
+ * @param document 目标文档。
+ * @return 无。
+ * @note 与 `document_shutdown` 不同，本函数会将 `revision` 与 `next_id` 重置到初始值。
+ */
+void document_reset(Document *document);
+
+/**
+ * @brief 向文档追加对象并自动分配 ID。
+ * @param document 目标文档。
+ * @param object 待插入对象。
+ * @return 成功返回非零，容量不足或参数非法返回 0。
+ */
+int document_add_object(Document *document, GraphicObject *object);
+
+/**
+ * @brief 以指定 ID 向文档追加对象。
+ * @param document 目标文档。
+ * @param object 待插入对象。
+ * @param id 指定对象 ID。
+ * @return 成功返回非零；ID 冲突、参数非法或容量不足返回 0。
+ */
+int document_append_object_with_id(Document *document, GraphicObject *object,
+                                   ObjectId id);
+
+/**
+ * @brief 按对象 ID 查找对象。
+ * @param document 文档。
+ * @param id 对象 ID。
+ * @return 找到时返回对象指针，否则返回 `NULL`。
+ */
+GraphicObject *document_find_object(const Document *document, ObjectId id);
+
+/**
+ * @brief 按数组索引获取对象。
+ * @param document 文档。
+ * @param index 对象索引。
+ * @return 索引有效时返回对象指针，否则返回 `NULL`。
+ */
+GraphicObject *document_get_object_at(const Document *document, int index);
+
+/**
+ * @brief 按 ID 删除对象并压缩对象数组。
+ * @param document 目标文档。
+ * @param id 待删除对象 ID。
+ * @return 删除成功返回非零，否则返回 0。
+ */
+int document_remove_object(Document *document, ObjectId id);
+
+/**
+ * @brief 删除当前选择集中的全部对象。
+ * @param document 目标文档。
+ * @return 无。
+ */
+void document_delete_selection(Document *document);
+
+/**
+ * @brief 标记一次非结构性修改（修订号递增）。
+ * @param document 目标文档。
+ * @return 无。
+ */
+void document_touch(Document *document);
+
+/**
+ * @brief 计算文档中当前最大对象 ID。
+ * @param document 文档。
+ * @return 最大 ID；文档为空或参数非法返回 `0`。
+ */
+ObjectId document_max_id(const Document *document);
+
+/**
+ * @brief 清空选择集。
+ * @param document 目标文档。
+ * @return 无。
+ */
+void document_clear_selection(Document *document);
+
+/**
+ * @brief 判断对象 ID 是否在选择集中。
+ * @param document 文档。
+ * @param id 对象 ID。
+ * @return 在选择集中返回非零，否则返回 0。
+ */
+int document_selection_contains(const Document *document, ObjectId id);
+
+/**
+ * @brief 向选择集添加对象 ID。
+ * @param document 目标文档。
+ * @param id 对象 ID。
+ * @return 添加成功或已存在返回非零；参数非法或容量不足返回 0。
+ */
+int document_selection_add(Document *document, ObjectId id);
+
+/**
+ * @brief 从选择集中移除对象 ID。
+ * @param document 目标文档。
+ * @param id 对象 ID。
+ * @return 无。
+ */
+void document_selection_remove(Document *document, ObjectId id);
+
+/**
+ * @brief 切换对象 ID 的选中状态。
+ * @param document 目标文档。
+ * @param id 对象 ID。
+ * @return 无。
+ */
+void document_selection_toggle(Document *document, ObjectId id);
+
+/**
+ * @brief 获取“主选中对象”（选择集首元素对应对象）。
+ * @param document 文档。
+ * @return 主选中对象；无选择时返回 `NULL`。
+ */
+GraphicObject *document_primary_selection(const Document *document);
 
 #endif /* GLDRAW_DOCUMENT_DOCUMENT_H */

--- a/include/document/history.h
+++ b/include/document/history.h
@@ -1,6 +1,6 @@
 /**
  * @file history.h
- * @brief 文档撤销/重做（快照 + 轻量编辑）接口。
+ * @brief Document undo/redo (snapshot + lightweight edit) interface.
  */
 #ifndef GLDRAW_DOCUMENT_HISTORY_H
 #define GLDRAW_DOCUMENT_HISTORY_H
@@ -11,14 +11,14 @@
 
 /**
  * @struct DocumentSnapshot
- * @brief 文档深拷贝快照。
+ * @brief Deep-copy snapshot of the document.
  *
- * @member objects 深拷贝对象数组。
- * @member capacity `objects` 分配容量。
- * @member count 对象数量。
- * @member revision 快照时文档修订号。
- * @member next_id 快照时下一个可分配 ID。
- * @member selection 快照时选择集。
+ * @member objects Deep-copied object array.
+ * @member capacity Allocation capacity of `objects`.
+ * @member count Object count.
+ * @member revision Document revision at snapshot time.
+ * @member next_id Next allocatable ID at snapshot time.
+ * @member selection Selection set at snapshot time.
  */
 typedef struct {
     GraphicObject** objects;
@@ -31,10 +31,10 @@ typedef struct {
 
 /**
  * @struct DocumentHistoryEntry
- * @brief 一条基于完整快照的历史记录（before -> after）。
+ * @brief A history entry based on complete snapshots (before -> after).
  *
- * @member before 编辑前快照。
- * @member after 编辑后快照。
+ * @member before Snapshot before the edit.
+ * @member after Snapshot after the edit.
  */
 typedef struct {
     DocumentSnapshot before;
@@ -43,13 +43,13 @@ typedef struct {
 
 /**
  * @struct DocumentHistory
- * @brief 撤销/重做历史栈。
+ * @brief Undo/redo history stack.
  *
- * @member undo_stack 撤销栈。
- * @member redo_stack 重做栈。
- * @member capacity 每个栈最大条目数。
- * @member undo_count 当前撤销栈条目数。
- * @member redo_count 当前重做栈条目数。
+ * @member undo_stack Undo stack.
+ * @member redo_stack Redo stack.
+ * @member capacity Maximum entry count per stack.
+ * @member undo_count Current undo stack entry count.
+ * @member redo_count Current redo stack entry count.
  */
 typedef struct DocumentHistory {
     DocumentHistoryEntry* undo_stack;
@@ -60,127 +60,128 @@ typedef struct DocumentHistory {
 } DocumentHistory;
 
 /**
- * @brief 初始化文档快照为空状态。
- * @param snapshot 待初始化快照。
- * @return 无。
+ * @brief Initialize the document snapshot to an empty state.
+ * @param snapshot Snapshot to initialize.
+ * @return No return value.
  */
 void document_snapshot_init(DocumentSnapshot* snapshot);
 
 /**
- * @brief 释放快照拥有的对象拷贝与内部缓冲。
- * @param snapshot 目标快照。
- * @return 无。
+ * @brief Release object copies and internal buffers owned by the snapshot.
+ * @param snapshot Target snapshot.
+ * @return No return value.
  */
 void document_snapshot_free(DocumentSnapshot* snapshot);
 
 /**
- * @brief 捕获文档深拷贝到快照。
- * @param snapshot 目标快照（输出）。
- * @param document 源文档。
- * @return 成功返回非零；内存不足或克隆失败返回 0。
+ * @brief Capture a deep copy of the document into a snapshot.
+ * @param snapshot Target snapshot (output).
+ * @param document Source document.
+ * @return Non-zero on success; zero on out-of-memory or clone failure.
  */
 int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* document);
 
 /**
- * @brief 初始化撤销/重做历史栈。
- * @param history 目标历史对象。
- * @return 成功返回非零；内存分配失败返回 0。
+ * @brief Initialize the undo/redo history stack.
+ * @param history Target history object.
+ * @return Non-zero on success; zero on memory allocation failure.
  */
 int document_history_init(DocumentHistory* history);
 
 /**
- * @brief 释放历史栈中所有条目。
- * @param history 目标历史对象。
- * @return 无。
+ * @brief Release all entries in the history stack.
+ * @param history Target history object.
+ * @return No return value.
  */
 void document_history_shutdown(DocumentHistory* history);
 
 /**
- * @brief 推入一次完整快照编辑记录。
+ * @brief Push a complete snapshot edit record.
  *
- * 算法说明：
- * 1. 复制 `before` 快照作为撤销起点；
- * 2. 从 `after_document` 采集快照作为撤销终点；
- * 3. 写入撤销栈（必要时淘汰最旧项）；
- * 4. 清空重做栈，保证线性历史分支。
+ * Algorithm:
+ * 1. Copy `before` snapshot as the undo starting point;
+ * 2. Capture a snapshot from `after_document` as the undo ending point;
+ * 3. Push onto the undo stack (evicting the oldest entry if necessary);
+ * 4. Clear the redo stack to ensure linear history branching.
  *
- * @param history 历史对象。
- * @param before 编辑前快照（调用后由历史接管内容）。
- * @param after_document 编辑后文档。
- * @return 成功返回非零，失败返回 0。
+ * @param history History object.
+ * @param before Snapshot before the edit (contents are taken over by the history after the call).
+ * @param after_document Document after the edit.
+ * @return Non-zero on success, zero on failure.
  */
 int document_history_push(DocumentHistory* history, DocumentSnapshot* before, const Document* after_document);
 
 /**
- * @brief 推入一次标量属性修改历史。
+ * @brief Push a scalar property edit history record.
  *
- * 该接口用于记录对象单字段变化，避免完整快照开销。
+ * This interface records single-field changes on objects to avoid the cost of full snapshots.
  *
- * @param history 历史对象。
- * @param document 当前文档。
- * @param object_id 目标对象 ID。
- * @param key 标量字段名。
- * @param before_value 修改前值。
- * @param after_value 修改后值。
- * @param revision_before 修改前文档修订号。
- * @param revision_after 修改后文档修订号。
- * @return 成功返回非零，失败返回 0。
+ * @param history History object.
+ * @param document Current document.
+ * @param object_id Target object ID.
+ * @param key Scalar field name.
+ * @param before_value Value before the modification.
+ * @param after_value Value after the modification.
+ * @param revision_before Document revision before modification.
+ * @param revision_after Document revision after modification.
+ * @return Non-zero on success, zero on failure.
  */
 int document_history_push_scalar_edit(DocumentHistory* history, const Document* document, ObjectId object_id, const char* key, float before_value, float after_value, unsigned int revision_before, unsigned int revision_after);
 
 /**
- * @brief 推入一次批量平移历史。
+ * @brief Push a batch translate edit history record.
  *
- * 该接口记录对象 ID 集合与位移向量，撤销/重做时按相反方向应用。
+ * This interface records a set of object IDs and a translation vector;
+ * undo/redo applies the translation in the opposite direction.
  *
- * @param history 历史对象。
- * @param document 当前文档。
- * @param object_ids 对象 ID 数组。
- * @param object_count 对象数量。
- * @param delta 平移增量（世界坐标）。
- * @param revision_before 修改前修订号。
- * @param revision_after 修改后修订号。
- * @return 成功返回非零，失败返回 0。
+ * @param history History object.
+ * @param document Current document.
+ * @param object_ids Object ID array.
+ * @param object_count Object count.
+ * @param delta Translation delta (in world coordinates).
+ * @param revision_before Revision before modification.
+ * @param revision_after Revision after modification.
+ * @return Non-zero on success, zero on failure.
  */
 int document_history_push_translate_edit(DocumentHistory* history, const Document* document, const ObjectId* object_ids, int object_count, Vec2 delta, unsigned int revision_before, unsigned int revision_after);
 
 /**
- * @brief 执行撤销。
+ * @brief Perform an undo.
  *
- * 算法说明：
- * 1. 取撤销栈顶记录；
- * 2. 将记录应用到文档（完整快照或轻量编辑）；
- * 3. 该记录转移到重做栈顶；
- * 4. 返回应用结果。
+ * Algorithm:
+ * 1. Pop the top record from the undo stack;
+ * 2. Apply the record to the document (full snapshot or lightweight edit);
+ * 3. Move the record to the top of the redo stack;
+ * 4. Return the result of the application.
  *
- * @param history 历史对象。
- * @param document 目标文档。
- * @return 有可撤销项且应用成功返回非零，否则返回 0。
+ * @param history History object.
+ * @param document Target document.
+ * @return Non-zero if there is something to undo and the application succeeded, zero otherwise.
  */
 int document_history_undo(DocumentHistory* history, Document* document);
 
 /**
- * @brief 执行重做。
+ * @brief Perform a redo.
  *
- * 算法说明与撤销对称：从重做栈取顶，应用后回推至撤销栈。
+ * The algorithm is symmetric to undo: pop from the redo stack, apply, push back onto the undo stack.
  *
- * @param history 历史对象。
- * @param document 目标文档。
- * @return 有可重做项且应用成功返回非零，否则返回 0。
+ * @param history History object.
+ * @param document Target document.
+ * @return Non-zero if there is something to redo and the application succeeded, zero otherwise.
  */
 int document_history_redo(DocumentHistory* history, Document* document);
 
 /**
- * @brief 判断是否可撤销。
- * @param history 历史对象。
- * @return 可撤销返回非零，否则返回 0。
+ * @brief Check whether undo is available.
+ * @param history History object.
+ * @return Non-zero if undo is available, zero otherwise.
  */
 int document_history_can_undo(const DocumentHistory* history);
 
 /**
- * @brief 判断是否可重做。
- * @param history 历史对象。
- * @return 可重做返回非零，否则返回 0。
+ * @brief Check whether redo is available.
+ * @param history History object.
+ * @return Non-zero if redo is available, zero otherwise.
  */
 int document_history_can_redo(const DocumentHistory* history);
 

--- a/include/document/history.h
+++ b/include/document/history.h
@@ -1,17 +1,6 @@
 /**
  * @file history.h
- * @brief Snapshot-based undo/redo interfaces.
- *
- * Role in project:
- * - Captures deep copies of `Document` state before/after edits.
- * - Maintains bounded undo/redo stacks for reversible operations.
- *
- * Module relationships:
- * - Built on top of `document.h` and `object` cloning.
- * - Called by tools/UI whenever a user-visible edit is committed.
- *
- * Concurrency note:
- * - History stacks are mutable and unsynchronized; use from one thread only.
+ * @brief 文档撤销/重做（快照 + 轻量编辑）接口。
  */
 #ifndef GLDRAW_DOCUMENT_HISTORY_H
 #define GLDRAW_DOCUMENT_HISTORY_H
@@ -20,7 +9,17 @@
 
 #define DOCUMENT_HISTORY_MAX_ENTRIES 128
 
-/** Deep-copied document state stored in history stacks. */
+/**
+ * @struct DocumentSnapshot
+ * @brief 文档深拷贝快照。
+ *
+ * @member objects 深拷贝对象数组。
+ * @member capacity `objects` 分配容量。
+ * @member count 对象数量。
+ * @member revision 快照时文档修订号。
+ * @member next_id 快照时下一个可分配 ID。
+ * @member selection 快照时选择集。
+ */
 typedef struct {
     GraphicObject** objects;
     int capacity;
@@ -30,50 +29,159 @@ typedef struct {
     SelectionSet selection;
 } DocumentSnapshot;
 
-/** One undo/redo transaction pair (`before` -> `after`). */
+/**
+ * @struct DocumentHistoryEntry
+ * @brief 一条基于完整快照的历史记录（before -> after）。
+ *
+ * @member before 编辑前快照。
+ * @member after 编辑后快照。
+ */
 typedef struct {
-    DocumentSnapshot before; /**< Document state before the edit */
-    DocumentSnapshot after;  /**< Document state after the edit */
+    DocumentSnapshot before;
+    DocumentSnapshot after;
 } DocumentHistoryEntry;
 
 /**
- * @brief Undo/redo history with bounded stacks.
+ * @struct DocumentHistory
+ * @brief 撤销/重做历史栈。
  *
- * Concurrency note:
- * - Stacks are mutable and unsynchronized; use from one thread only.
+ * @member undo_stack 撤销栈。
+ * @member redo_stack 重做栈。
+ * @member capacity 每个栈最大条目数。
+ * @member undo_count 当前撤销栈条目数。
+ * @member redo_count 当前重做栈条目数。
  */
 typedef struct DocumentHistory {
-    DocumentHistoryEntry* undo_stack; /**< Uncommitted edits stack */
-    DocumentHistoryEntry* redo_stack; /**< Reverted edits stack */
-    int capacity;                      /**< Max entries per stack */
-    int undo_count;                    /**< Number of entries in undo stack */
-    int redo_count;                    /**< Number of entries in redo stack */
+    DocumentHistoryEntry* undo_stack;
+    DocumentHistoryEntry* redo_stack;
+    int capacity;
+    int undo_count;
+    int redo_count;
 } DocumentHistory;
 
-/** Initialize snapshot to empty state. Complexity: `O(1)`. */
+/**
+ * @brief 初始化文档快照为空状态。
+ * @param snapshot 待初始化快照。
+ * @return 无。
+ */
 void document_snapshot_init(DocumentSnapshot* snapshot);
-/** Free all objects owned by snapshot. Complexity: `O(n)`. */
+
+/**
+ * @brief 释放快照拥有的对象拷贝与内部缓冲。
+ * @param snapshot 目标快照。
+ * @return 无。
+ */
 void document_snapshot_free(DocumentSnapshot* snapshot);
-/** Deep-copy document into snapshot. Returns 0 on allocation/clone failure. Complexity: `O(n)`. */
+
+/**
+ * @brief 捕获文档深拷贝到快照。
+ * @param snapshot 目标快照（输出）。
+ * @param document 源文档。
+ * @return 成功返回非零；内存不足或克隆失败返回 0。
+ */
 int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* document);
 
-/** Allocate undo/redo stacks. Returns 0 on allocation failure. Complexity: `O(capacity)`. */
+/**
+ * @brief 初始化撤销/重做历史栈。
+ * @param history 目标历史对象。
+ * @return 成功返回非零；内存分配失败返回 0。
+ */
 int document_history_init(DocumentHistory* history);
-/** Release all stack entries and internal arrays. Complexity: `O(total_snapshots)`. */
+
+/**
+ * @brief 释放历史栈中所有条目。
+ * @param history 目标历史对象。
+ * @return 无。
+ */
 void document_history_shutdown(DocumentHistory* history);
-/** Push one transaction and clear redo stack. Complexity: `O(n + capacity)` worst-case. */
+
+/**
+ * @brief 推入一次完整快照编辑记录。
+ *
+ * 算法说明：
+ * 1. 复制 `before` 快照作为撤销起点；
+ * 2. 从 `after_document` 采集快照作为撤销终点；
+ * 3. 写入撤销栈（必要时淘汰最旧项）；
+ * 4. 清空重做栈，保证线性历史分支。
+ *
+ * @param history 历史对象。
+ * @param before 编辑前快照（调用后由历史接管内容）。
+ * @param after_document 编辑后文档。
+ * @return 成功返回非零，失败返回 0。
+ */
 int document_history_push(DocumentHistory* history, DocumentSnapshot* before, const Document* after_document);
-/** Push lightweight scalar edit transaction without full document snapshots. Returns 1 on success, 0 on failure. */
+
+/**
+ * @brief 推入一次标量属性修改历史。
+ *
+ * 该接口用于记录对象单字段变化，避免完整快照开销。
+ *
+ * @param history 历史对象。
+ * @param document 当前文档。
+ * @param object_id 目标对象 ID。
+ * @param key 标量字段名。
+ * @param before_value 修改前值。
+ * @param after_value 修改后值。
+ * @param revision_before 修改前文档修订号。
+ * @param revision_after 修改后文档修订号。
+ * @return 成功返回非零，失败返回 0。
+ */
 int document_history_push_scalar_edit(DocumentHistory* history, const Document* document, ObjectId object_id, const char* key, float before_value, float after_value, unsigned int revision_before, unsigned int revision_after);
-/** Push lightweight translate transaction for a fixed object-id set. Returns 1 on success, 0 on failure. */
+
+/**
+ * @brief 推入一次批量平移历史。
+ *
+ * 该接口记录对象 ID 集合与位移向量，撤销/重做时按相反方向应用。
+ *
+ * @param history 历史对象。
+ * @param document 当前文档。
+ * @param object_ids 对象 ID 数组。
+ * @param object_count 对象数量。
+ * @param delta 平移增量（世界坐标）。
+ * @param revision_before 修改前修订号。
+ * @param revision_after 修改后修订号。
+ * @return 成功返回非零，失败返回 0。
+ */
 int document_history_push_translate_edit(DocumentHistory* history, const Document* document, const ObjectId* object_ids, int object_count, Vec2 delta, unsigned int revision_before, unsigned int revision_after);
-/** Apply latest undo entry. Returns 0 when stack empty/failure. Complexity: `O(n + capacity)` worst-case. */
+
+/**
+ * @brief 执行撤销。
+ *
+ * 算法说明：
+ * 1. 取撤销栈顶记录；
+ * 2. 将记录应用到文档（完整快照或轻量编辑）；
+ * 3. 该记录转移到重做栈顶；
+ * 4. 返回应用结果。
+ *
+ * @param history 历史对象。
+ * @param document 目标文档。
+ * @return 有可撤销项且应用成功返回非零，否则返回 0。
+ */
 int document_history_undo(DocumentHistory* history, Document* document);
-/** Apply latest redo entry. Returns 0 when stack empty/failure. Complexity: `O(n + capacity)` worst-case. */
+
+/**
+ * @brief 执行重做。
+ *
+ * 算法说明与撤销对称：从重做栈取顶，应用后回推至撤销栈。
+ *
+ * @param history 历史对象。
+ * @param document 目标文档。
+ * @return 有可重做项且应用成功返回非零，否则返回 0。
+ */
 int document_history_redo(DocumentHistory* history, Document* document);
-/** Check undo availability. Complexity: `O(1)`. */
+
+/**
+ * @brief 判断是否可撤销。
+ * @param history 历史对象。
+ * @return 可撤销返回非零，否则返回 0。
+ */
 int document_history_can_undo(const DocumentHistory* history);
-/** Check redo availability. Complexity: `O(1)`. */
+
+/**
+ * @brief 判断是否可重做。
+ * @param history 历史对象。
+ * @return 可重做返回非零，否则返回 0。
+ */
 int document_history_can_redo(const DocumentHistory* history);
 
 #endif /* GLDRAW_DOCUMENT_HISTORY_H */

--- a/include/document/object.h
+++ b/include/document/object.h
@@ -1,27 +1,29 @@
 /**
  * @file object.h
- * @brief Polymorphic drawable object definitions and operations.
- *
- * Role in project:
- * - Defines object type IDs, style data, and vtable contracts.
- * - Provides creation, mutation, querying, and cloning APIs.
- *
- * Module relationships:
- * - Used by document storage, canvas picking, renderer path extraction, and persistence.
+ * @brief 图元对象多态接口与类型定义。
  */
 #ifndef GLDRAW_DOCUMENT_OBJECT_H
 #define GLDRAW_DOCUMENT_OBJECT_H
 
 #include <base/types.h>
 
-/** Supported built-in object kinds. */
+/**
+ * @enum GraphicObjectType
+ * @brief 内置图元类型枚举。
+ */
 typedef enum {
     GRAPHIC_OBJECT_LINE = 0,
     GRAPHIC_OBJECT_RECT,
     GRAPHIC_OBJECT_ELLIPSE
 } GraphicObjectType;
 
-/** Shared drawing style carried by each object instance. */
+/**
+ * @struct GraphicStyle
+ * @brief 图元通用描边样式。
+ *
+ * @member stroke_color 描边颜色。
+ * @member stroke_width 描边宽度（世界坐标单位）。
+ */
 typedef struct {
     Color stroke_color;
     float stroke_width;
@@ -30,6 +32,20 @@ typedef struct {
 typedef struct GraphicObject GraphicObject;
 typedef struct GraphicObjectVTable GraphicObjectVTable;
 
+/**
+ * @struct GraphicObjectVTable
+ * @brief 图元多态行为表。
+ *
+ * @member name 类型名称。
+ * @member destroy 析构实现。
+ * @member translate 平移实现。
+ * @member get_bounds 包围盒计算实现。
+ * @member hit_test 命中测试实现。
+ * @member get_path_point_count 路径采样点数量实现。
+ * @member write_path_points 路径采样点写出实现。
+ * @member get_scalar 标量属性读取实现。
+ * @member set_scalar 标量属性写入实现。
+ */
 struct GraphicObjectVTable {
     const char* name;
     void (*destroy)(GraphicObject* object);
@@ -42,6 +58,17 @@ struct GraphicObjectVTable {
     int (*set_scalar)(GraphicObject* object, const char* key, float value);
 };
 
+/**
+ * @struct GraphicObject
+ * @brief 运行时图元对象。
+ *
+ * @member id 文档内对象 ID。
+ * @member type 图元类型。
+ * @member vtable 多态行为表。
+ * @member impl 类型私有实现数据。
+ * @member style 绘制样式。
+ * @member revision 对象修订号。
+ */
 struct GraphicObject {
     ObjectId id;
     GraphicObjectType type;
@@ -51,39 +78,129 @@ struct GraphicObject {
     unsigned int revision;
 };
 
-/** Return default style values for newly created objects. Complexity: `O(1)`. */
+/**
+ * @brief 获取新建对象默认样式。
+ * @return 默认 `GraphicStyle`。
+ */
 GraphicStyle object_default_style(void);
-/** Return human-readable type name. Complexity: `O(1)`. */
+
+/**
+ * @brief 获取图元类型名称。
+ * @param type 图元类型枚举值。
+ * @return 对应名称字符串。
+ */
 const char* object_type_name(GraphicObjectType type);
 
-/** Create a line object; returns `NULL` on allocation failure. Complexity: `O(1)`. */
+/**
+ * @brief 创建线段对象。
+ * @param p1 起点。
+ * @param p2 终点。
+ * @param style 描边样式。
+ * @return 成功返回对象指针，失败返回 `NULL`。
+ */
 GraphicObject* object_create_line(Vec2 p1, Vec2 p2, GraphicStyle style);
-/** Create a rectangle object; returns `NULL` on allocation failure. Complexity: `O(1)`. */
+
+/**
+ * @brief 创建矩形对象。
+ * @param rect 矩形边界。
+ * @param style 描边样式。
+ * @return 成功返回对象指针，失败返回 `NULL`。
+ */
 GraphicObject* object_create_rect(RectF rect, GraphicStyle style);
-/** Create an ellipse object; returns `NULL` on allocation failure. Complexity: `O(1)`. */
+
+/**
+ * @brief 创建椭圆对象。
+ * @param bounds 包围矩形。
+ * @param style 描边样式。
+ * @return 成功返回对象指针，失败返回 `NULL`。
+ */
 GraphicObject* object_create_ellipse(RectF bounds, GraphicStyle style);
-/** Deep clone object payload/style/metadata; returns `NULL` on failure. Complexity: `O(1)`. */
+
+/**
+ * @brief 深拷贝图元对象。
+ * @param object 源对象。
+ * @return 成功返回新对象，失败返回 `NULL`。
+ */
 GraphicObject* object_clone(const GraphicObject* object);
 
-/** Destroy object via vtable; safe no-op for invalid input. Complexity: `O(1)`. */
+/**
+ * @brief 销毁图元对象。
+ * @param object 目标对象（可为 `NULL`）。
+ * @return 无。
+ */
 void object_destroy(GraphicObject* object);
-/** Translate geometry in world space and bump object revision. Complexity: `O(1)`. */
+
+/**
+ * @brief 平移图元几何。
+ * @param object 目标对象。
+ * @param delta 平移增量。
+ * @return 无。
+ */
 void object_translate(GraphicObject* object, Vec2 delta);
-/** Get object axis-aligned bounds; returns empty rect for invalid input. Complexity: `O(1)`. */
+
+/**
+ * @brief 获取图元轴对齐包围盒。
+ * @param object 目标对象。
+ * @return 包围盒；参数非法时返回空矩形。
+ */
 RectF object_get_bounds(const GraphicObject* object);
-/** Hit-test a world point against object geometry. Complexity: `O(1)`. */
+
+/**
+ * @brief 图元命中测试。
+ * @param object 目标对象。
+ * @param point 世界坐标测试点。
+ * @param tolerance 命中容差。
+ * @return 命中返回非零，否则返回 0。
+ */
 int object_hit_test(const GraphicObject* object, Vec2 point, float tolerance);
-/** Get polyline sample count for rendering. Complexity: `O(1)`. */
+
+/**
+ * @brief 获取图元路径采样点数量。
+ * @param object 目标对象。
+ * @return 路径点数量。
+ */
 int object_get_path_point_count(const GraphicObject* object);
-/** Write polyline points into caller-provided buffer. Complexity: `O(k)`. */
+
+/**
+ * @brief 写出图元路径采样点。
+ * @param object 目标对象。
+ * @param out_points 输出数组。
+ * @return 无。
+ */
 void object_write_path_points(const GraphicObject* object, Vec2* out_points);
-/** Query scalar property by key. Returns 1 when key is supported. Complexity: `O(1)`. */
+
+/**
+ * @brief 读取图元标量属性。
+ * @param object 目标对象。
+ * @param key 属性键名。
+ * @param out_value 属性输出值。
+ * @return 支持该键并读取成功返回非零，否则返回 0。
+ */
 int object_get_scalar(const GraphicObject* object, const char* key, float* out_value);
-/** Set scalar property by key and bump revision on success. Complexity: `O(1)`. */
+
+/**
+ * @brief 写入图元标量属性。
+ * @param object 目标对象。
+ * @param key 属性键名。
+ * @param value 新值。
+ * @return 写入成功返回非零，否则返回 0。
+ */
 int object_set_scalar(GraphicObject* object, const char* key, float value);
-/** Update stroke color and bump revision. Complexity: `O(1)`. */
+
+/**
+ * @brief 设置图元描边颜色。
+ * @param object 目标对象。
+ * @param color 新颜色。
+ * @return 无。
+ */
 void object_set_stroke_color(GraphicObject* object, Color color);
-/** Update stroke width and bump revision. Complexity: `O(1)`. */
+
+/**
+ * @brief 设置图元描边宽度。
+ * @param object 目标对象。
+ * @param stroke_width 新宽度。
+ * @return 无。
+ */
 void object_set_stroke_width(GraphicObject* object, float stroke_width);
 
 #endif /* GLDRAW_DOCUMENT_OBJECT_H */

--- a/include/document/object.h
+++ b/include/document/object.h
@@ -1,6 +1,6 @@
 /**
  * @file object.h
- * @brief 图元对象多态接口与类型定义。
+ * @brief Graphic object polymorphic interface and type definitions.
  */
 #ifndef GLDRAW_DOCUMENT_OBJECT_H
 #define GLDRAW_DOCUMENT_OBJECT_H
@@ -9,7 +9,7 @@
 
 /**
  * @enum GraphicObjectType
- * @brief 内置图元类型枚举。
+ * @brief Built-in graphic object type enum.
  */
 typedef enum {
     GRAPHIC_OBJECT_LINE = 0,
@@ -19,10 +19,10 @@ typedef enum {
 
 /**
  * @struct GraphicStyle
- * @brief 图元通用描边样式。
+ * @brief Common stroke style for graphic objects.
  *
- * @member stroke_color 描边颜色。
- * @member stroke_width 描边宽度（世界坐标单位）。
+ * @member stroke_color Stroke color.
+ * @member stroke_width Stroke width (in world coordinate units).
  */
 typedef struct {
     Color stroke_color;
@@ -34,17 +34,17 @@ typedef struct GraphicObjectVTable GraphicObjectVTable;
 
 /**
  * @struct GraphicObjectVTable
- * @brief 图元多态行为表。
+ * @brief Graphic object polymorphic behavior table.
  *
- * @member name 类型名称。
- * @member destroy 析构实现。
- * @member translate 平移实现。
- * @member get_bounds 包围盒计算实现。
- * @member hit_test 命中测试实现。
- * @member get_path_point_count 路径采样点数量实现。
- * @member write_path_points 路径采样点写出实现。
- * @member get_scalar 标量属性读取实现。
- * @member set_scalar 标量属性写入实现。
+ * @member name Type name.
+ * @member destroy Destructor implementation.
+ * @member translate Translation implementation.
+ * @member get_bounds Bounding box computation implementation.
+ * @member hit_test Hit-test implementation.
+ * @member get_path_point_count Path sample point count implementation.
+ * @member write_path_points Path sample point write-out implementation.
+ * @member get_scalar Scalar property read implementation.
+ * @member set_scalar Scalar property write implementation.
  */
 struct GraphicObjectVTable {
     const char* name;
@@ -60,14 +60,14 @@ struct GraphicObjectVTable {
 
 /**
  * @struct GraphicObject
- * @brief 运行时图元对象。
+ * @brief Runtime graphic object.
  *
- * @member id 文档内对象 ID。
- * @member type 图元类型。
- * @member vtable 多态行为表。
- * @member impl 类型私有实现数据。
- * @member style 绘制样式。
- * @member revision 对象修订号。
+ * @member id Object ID within the document.
+ * @member type Object type.
+ * @member vtable Polymorphic behavior table.
+ * @member impl Type-private implementation data.
+ * @member style Drawing style.
+ * @member revision Object revision number.
  */
 struct GraphicObject {
     ObjectId id;
@@ -79,127 +79,127 @@ struct GraphicObject {
 };
 
 /**
- * @brief 获取新建对象默认样式。
- * @return 默认 `GraphicStyle`。
+ * @brief Get the default style for newly created objects.
+ * @return Default `GraphicStyle`.
  */
 GraphicStyle object_default_style(void);
 
 /**
- * @brief 获取图元类型名称。
- * @param type 图元类型枚举值。
- * @return 对应名称字符串。
+ * @brief Get the type name of a graphic object.
+ * @param type Graphic object type enum value.
+ * @return Corresponding name string.
  */
 const char* object_type_name(GraphicObjectType type);
 
 /**
- * @brief 创建线段对象。
- * @param p1 起点。
- * @param p2 终点。
- * @param style 描边样式。
- * @return 成功返回对象指针，失败返回 `NULL`。
+ * @brief Create a line object.
+ * @param p1 Start point.
+ * @param p2 End point.
+ * @param style Stroke style.
+ * @return Object pointer on success, `NULL` on failure.
  */
 GraphicObject* object_create_line(Vec2 p1, Vec2 p2, GraphicStyle style);
 
 /**
- * @brief 创建矩形对象。
- * @param rect 矩形边界。
- * @param style 描边样式。
- * @return 成功返回对象指针，失败返回 `NULL`。
+ * @brief Create a rectangle object.
+ * @param rect Rectangle boundary.
+ * @param style Stroke style.
+ * @return Object pointer on success, `NULL` on failure.
  */
 GraphicObject* object_create_rect(RectF rect, GraphicStyle style);
 
 /**
- * @brief 创建椭圆对象。
- * @param bounds 包围矩形。
- * @param style 描边样式。
- * @return 成功返回对象指针，失败返回 `NULL`。
+ * @brief Create an ellipse object.
+ * @param bounds Bounding rectangle.
+ * @param style Stroke style.
+ * @return Object pointer on success, `NULL` on failure.
  */
 GraphicObject* object_create_ellipse(RectF bounds, GraphicStyle style);
 
 /**
- * @brief 深拷贝图元对象。
- * @param object 源对象。
- * @return 成功返回新对象，失败返回 `NULL`。
+ * @brief Deep-copy a graphic object.
+ * @param object Source object.
+ * @return New object on success, `NULL` on failure.
  */
 GraphicObject* object_clone(const GraphicObject* object);
 
 /**
- * @brief 销毁图元对象。
- * @param object 目标对象（可为 `NULL`）。
- * @return 无。
+ * @brief Destroy a graphic object.
+ * @param object Target object (may be `NULL`).
+ * @return No return value.
  */
 void object_destroy(GraphicObject* object);
 
 /**
- * @brief 平移图元几何。
- * @param object 目标对象。
- * @param delta 平移增量。
- * @return 无。
+ * @brief Translate the object geometry.
+ * @param object Target object.
+ * @param delta Translation delta.
+ * @return No return value.
  */
 void object_translate(GraphicObject* object, Vec2 delta);
 
 /**
- * @brief 获取图元轴对齐包围盒。
- * @param object 目标对象。
- * @return 包围盒；参数非法时返回空矩形。
+ * @brief Get the object's axis-aligned bounding box.
+ * @param object Target object.
+ * @return Bounding box; returns an empty rectangle if parameters are invalid.
  */
 RectF object_get_bounds(const GraphicObject* object);
 
 /**
- * @brief 图元命中测试。
- * @param object 目标对象。
- * @param point 世界坐标测试点。
- * @param tolerance 命中容差。
- * @return 命中返回非零，否则返回 0。
+ * @brief Object hit-test.
+ * @param object Target object.
+ * @param point World-coordinate test point.
+ * @param tolerance Hit tolerance.
+ * @return Non-zero on hit, zero otherwise.
  */
 int object_hit_test(const GraphicObject* object, Vec2 point, float tolerance);
 
 /**
- * @brief 获取图元路径采样点数量。
- * @param object 目标对象。
- * @return 路径点数量。
+ * @brief Get the number of path sample points for the object.
+ * @param object Target object.
+ * @return Path point count.
  */
 int object_get_path_point_count(const GraphicObject* object);
 
 /**
- * @brief 写出图元路径采样点。
- * @param object 目标对象。
- * @param out_points 输出数组。
- * @return 无。
+ * @brief Write out the object's path sample points.
+ * @param object Target object.
+ * @param out_points Output array.
+ * @return No return value.
  */
 void object_write_path_points(const GraphicObject* object, Vec2* out_points);
 
 /**
- * @brief 读取图元标量属性。
- * @param object 目标对象。
- * @param key 属性键名。
- * @param out_value 属性输出值。
- * @return 支持该键并读取成功返回非零，否则返回 0。
+ * @brief Read an object scalar property.
+ * @param object Target object.
+ * @param key Property key name.
+ * @param out_value Property output value.
+ * @return Non-zero if the key is supported and read succeeded, zero otherwise.
  */
 int object_get_scalar(const GraphicObject* object, const char* key, float* out_value);
 
 /**
- * @brief 写入图元标量属性。
- * @param object 目标对象。
- * @param key 属性键名。
- * @param value 新值。
- * @return 写入成功返回非零，否则返回 0。
+ * @brief Write an object scalar property.
+ * @param object Target object.
+ * @param key Property key name.
+ * @param value New value.
+ * @return Non-zero on success, zero otherwise.
  */
 int object_set_scalar(GraphicObject* object, const char* key, float value);
 
 /**
- * @brief 设置图元描边颜色。
- * @param object 目标对象。
- * @param color 新颜色。
- * @return 无。
+ * @brief Set the object stroke color.
+ * @param object Target object.
+ * @param color New color.
+ * @return No return value.
  */
 void object_set_stroke_color(GraphicObject* object, Color color);
 
 /**
- * @brief 设置图元描边宽度。
- * @param object 目标对象。
- * @param stroke_width 新宽度。
- * @return 无。
+ * @brief Set the object stroke width.
+ * @param object Target object.
+ * @param stroke_width New width.
+ * @return No return value.
  */
 void object_set_stroke_width(GraphicObject* object, float stroke_width);
 

--- a/include/document/persistence.h
+++ b/include/document/persistence.h
@@ -1,6 +1,6 @@
 /**
  * @file persistence.h
- * @brief 文档 JSON 持久化接口。
+ * @brief Document JSON persistence interface.
  */
 #ifndef GLDRAW_DOCUMENT_PERSISTENCE_H
 #define GLDRAW_DOCUMENT_PERSISTENCE_H
@@ -8,18 +8,18 @@
 #include <document/document.h>
 
 /**
- * @brief 将文档保存为 JSON 文件。
- * @param document 待保存文档。
- * @param path 输出文件路径。
- * @return 保存成功返回非零，失败返回 0。
+ * @brief Save the document as a JSON file.
+ * @param document Document to save.
+ * @param path Output file path.
+ * @return Non-zero on success, zero on failure.
  */
 int document_save_json(const Document* document, const char* path);
 
 /**
- * @brief 从 JSON 文件加载文档。
- * @param document 目标文档（加载前会重置/覆盖）。
- * @param path 输入文件路径。
- * @return 加载成功返回非零，失败返回 0。
+ * @brief Load the document from a JSON file.
+ * @param document Target document (will be reset/overwritten before loading).
+ * @param path Input file path.
+ * @return Non-zero on success, zero on failure.
  */
 int document_load_json(Document* document, const char* path);
 

--- a/include/document/persistence.h
+++ b/include/document/persistence.h
@@ -1,23 +1,26 @@
 /**
  * @file persistence.h
- * @brief Document JSON save/load interface.
- *
- * Role in project:
- * - Serializes in-memory `Document` into stable JSON format.
- * - Deserializes JSON back to runtime objects with IDs and style data.
- *
- * Module relationships:
- * - Called by application and menu actions.
- * - Depends on document/object APIs for object construction and lookup.
+ * @brief 文档 JSON 持久化接口。
  */
 #ifndef GLDRAW_DOCUMENT_PERSISTENCE_H
 #define GLDRAW_DOCUMENT_PERSISTENCE_H
 
 #include <document/document.h>
 
-/** Save document to JSON file path. Returns 1 on success, 0 on I/O/serialization failure. */
+/**
+ * @brief 将文档保存为 JSON 文件。
+ * @param document 待保存文档。
+ * @param path 输出文件路径。
+ * @return 保存成功返回非零，失败返回 0。
+ */
 int document_save_json(const Document* document, const char* path);
-/** Load document from JSON file path. Returns 1 on success, 0 on I/O/parse/validation failure. */
+
+/**
+ * @brief 从 JSON 文件加载文档。
+ * @param document 目标文档（加载前会重置/覆盖）。
+ * @param path 输入文件路径。
+ * @return 加载成功返回非零，失败返回 0。
+ */
 int document_load_json(Document* document, const char* path);
 
 #endif /* GLDRAW_DOCUMENT_PERSISTENCE_H */

--- a/include/platform/window.h
+++ b/include/platform/window.h
@@ -1,6 +1,6 @@
 /**
  * @file window.h
- * @brief GLFW 窗口薄封装接口。
+ * @brief GLFW window thin-wrapper interface.
  */
 #ifndef GLDRAW_PLATFORM_WINDOW_H
 #define GLDRAW_PLATFORM_WINDOW_H
@@ -10,12 +10,12 @@
 
 /**
  * @struct PlatformWindow
- * @brief 平台窗口状态。
+ * @brief Platform window state.
  *
- * @member handle GLFW 原生窗口句柄。
- * @member width 期望窗口宽度。
- * @member height 期望窗口高度。
- * @member title 窗口标题字符串。
+ * @member handle GLFW native window handle.
+ * @member width Desired window width.
+ * @member height Desired window height.
+ * @member title Window title string.
  */
 typedef struct {
     GLFWwindow* handle;
@@ -25,39 +25,39 @@ typedef struct {
 } PlatformWindow;
 
 /**
- * @brief 初始化 GLFW 并创建窗口。
- * @param window 窗口结构体输出地址。
- * @param width 目标宽度。
- * @param height 目标高度。
- * @param title 窗口标题。
- * @return 成功返回 `0`，失败返回 `-1`。
+ * @brief Initialize GLFW and create the window.
+ * @param window Output address for the window structure.
+ * @param width Target width.
+ * @param height Target height.
+ * @param title Window title.
+ * @return `0` on success, `-1` on failure.
  */
 int platform_window_init(PlatformWindow* window, int width, int height, const char* title);
 
 /**
- * @brief 销毁窗口并清理 GLFW。
- * @param window 目标窗口。
- * @return 无。
+ * @brief Destroy the window and shut down GLFW.
+ * @param window Target window.
+ * @return No return value.
  */
 void platform_window_shutdown(PlatformWindow* window);
 
 /**
- * @brief 轮询窗口事件。
- * @return 无。
+ * @brief Poll window events.
+ * @return No return value.
  */
 void platform_window_poll_events(void);
 
 /**
- * @brief 交换窗口前后缓冲。
- * @param window 目标窗口。
- * @return 无。
+ * @brief Swap the window front and back buffers.
+ * @param window Target window.
+ * @return No return value.
  */
 void platform_window_swap_buffers(PlatformWindow* window);
 
 /**
- * @brief 查询窗口是否应关闭。
- * @param window 目标窗口。
- * @return 应关闭返回非零，否则返回 0。
+ * @brief Query whether the window should close.
+ * @param window Target window.
+ * @return Non-zero if the window should close, zero otherwise.
  */
 int platform_window_should_close(const PlatformWindow* window);
 

--- a/include/platform/window.h
+++ b/include/platform/window.h
@@ -1,13 +1,6 @@
 /**
  * @file window.h
- * @brief Thin GLFW window lifecycle wrapper.
- *
- * Role in project:
- * - Encapsulates window/context creation and basic event/buffer calls.
- * - Keeps application code independent from raw GLFW setup details.
- *
- * Module relationships:
- * - Used by application startup loop and renderer initialization.
+ * @brief GLFW 窗口薄封装接口。
  */
 #ifndef GLDRAW_PLATFORM_WINDOW_H
 #define GLDRAW_PLATFORM_WINDOW_H
@@ -15,6 +8,15 @@
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 
+/**
+ * @struct PlatformWindow
+ * @brief 平台窗口状态。
+ *
+ * @member handle GLFW 原生窗口句柄。
+ * @member width 期望窗口宽度。
+ * @member height 期望窗口高度。
+ * @member title 窗口标题字符串。
+ */
 typedef struct {
     GLFWwindow* handle;
     int width;
@@ -22,15 +24,41 @@ typedef struct {
     const char* title;
 } PlatformWindow;
 
-/** Initialize GLFW and create an OpenGL 3.3 Core Profile window. Returns 0 on success, -1 on failure. */
+/**
+ * @brief 初始化 GLFW 并创建窗口。
+ * @param window 窗口结构体输出地址。
+ * @param width 目标宽度。
+ * @param height 目标高度。
+ * @param title 窗口标题。
+ * @return 成功返回 `0`，失败返回 `-1`。
+ */
 int platform_window_init(PlatformWindow* window, int width, int height, const char* title);
-/** Destroy window handle if present and terminate GLFW for this process. */
+
+/**
+ * @brief 销毁窗口并清理 GLFW。
+ * @param window 目标窗口。
+ * @return 无。
+ */
 void platform_window_shutdown(PlatformWindow* window);
-/** Poll pending OS/window events. */
+
+/**
+ * @brief 轮询窗口事件。
+ * @return 无。
+ */
 void platform_window_poll_events(void);
-/** Present current backbuffer if window is valid. */
+
+/**
+ * @brief 交换窗口前后缓冲。
+ * @param window 目标窗口。
+ * @return 无。
+ */
 void platform_window_swap_buffers(PlatformWindow* window);
-/** Return non-zero when window is invalid or close was requested. */
+
+/**
+ * @brief 查询窗口是否应关闭。
+ * @param window 目标窗口。
+ * @return 应关闭返回非零，否则返回 0。
+ */
 int platform_window_should_close(const PlatformWindow* window);
 
 #endif /* GLDRAW_PLATFORM_WINDOW_H */

--- a/include/render/render_system.h
+++ b/include/render/render_system.h
@@ -1,6 +1,6 @@
 /**
  * @file render_system.h
- * @brief OpenGL 渲染系统接口。
+ * @brief OpenGL rendering system interface.
  */
 #ifndef GLDRAW_RENDER_RENDER_SYSTEM_H
 #define GLDRAW_RENDER_RENDER_SYSTEM_H
@@ -12,38 +12,38 @@
 typedef struct RenderSystem RenderSystem;
 
 /**
- * @brief 创建渲染系统并初始化 GPU 资源。
- * @param window 已初始化的窗口与 OpenGL 上下文。
- * @return 创建成功返回渲染系统指针，失败返回 `NULL`。
+ * @brief Create the rendering system and initialize GPU resources.
+ * @param window Already-initialized platform window and OpenGL context.
+ * @return Renderer instance on success, or `NULL` on failure.
  */
 RenderSystem* render_system_create(PlatformWindow* window);
 
 /**
- * @brief 销毁渲染系统并释放 GPU/堆资源。
- * @param renderer 渲染系统实例。
- * @return 无。
+ * @brief Destroy the rendering system and release GPU/heap resources.
+ * @param renderer Renderer instance.
+ * @return No return value.
  */
 void render_system_destroy(RenderSystem* renderer);
 
 /**
- * @brief 处理窗口尺寸变化。
- * @param renderer 渲染系统实例。
- * @param width 新宽度（像素）。
- * @param height 新高度（像素）。
- * @return 无。
+ * @brief Handle window resize events.
+ * @param renderer Renderer instance.
+ * @param width New width in pixels.
+ * @param height New height in pixels.
+ * @return No return value.
  */
 void render_system_resize(RenderSystem* renderer, int width, int height);
 
 /**
- * @brief 绘制一帧画布内容。
+ * @brief Draw one frame of canvas content.
  *
- * 主要流程：清屏 -> 绘制网格/坐标轴 -> 绘制文档对象 -> 绘制工具叠加预览。
+ * Main flow: clear -> draw grid/axes -> draw document objects -> draw tool overlay preview.
  *
- * @param renderer 渲染系统实例。
- * @param document 当前文档。
- * @param canvas 当前画布视图。
- * @param overlay_object 工具预览对象（可为 `NULL`）。
- * @return 无。
+ * @param renderer Renderer instance.
+ * @param document Current document.
+ * @param canvas Current canvas view.
+ * @param overlay_object Tool overlay preview object (may be `NULL`).
+ * @return No return value.
  */
 void render_system_draw(RenderSystem* renderer,
                         const Document* document,

--- a/include/render/render_system.h
+++ b/include/render/render_system.h
@@ -1,14 +1,6 @@
 /**
  * @file render_system.h
- * @brief OpenGL renderer interface for canvas/document drawing.
- *
- * Role in project:
- * - Owns shader program and GPU buffers.
- * - Draws grid, objects, selection emphasis, and tool overlays.
- *
- * Module relationships:
- * - Consumes `Document` geometry and `CanvasView` transforms.
- * - Called each frame by the application loop.
+ * @brief OpenGL 渲染系统接口。
  */
 #ifndef GLDRAW_RENDER_RENDER_SYSTEM_H
 #define GLDRAW_RENDER_RENDER_SYSTEM_H
@@ -19,13 +11,40 @@
 
 typedef struct RenderSystem RenderSystem;
 
-/** Create renderer resources for an existing window/context. Returns `NULL` on failure. */
+/**
+ * @brief 创建渲染系统并初始化 GPU 资源。
+ * @param window 已初始化的窗口与 OpenGL 上下文。
+ * @return 创建成功返回渲染系统指针，失败返回 `NULL`。
+ */
 RenderSystem* render_system_create(PlatformWindow* window);
-/** Release all GL/heap resources owned by renderer. */
+
+/**
+ * @brief 销毁渲染系统并释放 GPU/堆资源。
+ * @param renderer 渲染系统实例。
+ * @return 无。
+ */
 void render_system_destroy(RenderSystem* renderer);
-/** Update framebuffer-dependent renderer state after resize. */
+
+/**
+ * @brief 处理窗口尺寸变化。
+ * @param renderer 渲染系统实例。
+ * @param width 新宽度（像素）。
+ * @param height 新高度（像素）。
+ * @return 无。
+ */
 void render_system_resize(RenderSystem* renderer, int width, int height);
-/** Draw one frame of the canvas scene. Complexity is roughly `O(object_count + grid_lines)`. */
+
+/**
+ * @brief 绘制一帧画布内容。
+ *
+ * 主要流程：清屏 -> 绘制网格/坐标轴 -> 绘制文档对象 -> 绘制工具叠加预览。
+ *
+ * @param renderer 渲染系统实例。
+ * @param document 当前文档。
+ * @param canvas 当前画布视图。
+ * @param overlay_object 工具预览对象（可为 `NULL`）。
+ * @return 无。
+ */
 void render_system_draw(RenderSystem* renderer,
                         const Document* document,
                         const CanvasView* canvas,

--- a/include/tools/tool.h
+++ b/include/tools/tool.h
@@ -1,14 +1,6 @@
 /**
  * @file tool.h
- * @brief Generic tool abstraction and event payload types.
- *
- * Role in project:
- * - Defines polymorphic tool vtable used by the tool controller.
- * - Carries per-event input state in screen/world coordinates.
- *
- * Module relationships:
- * - Implemented by `tool_controller.c` built-in tools.
- * - Consumes workspace/document/canvas/history through `ToolContext`.
+ * @brief 工具系统抽象接口与事件数据结构。
  */
 #ifndef GLDRAW_TOOLS_TOOL_H
 #define GLDRAW_TOOLS_TOOL_H
@@ -21,7 +13,10 @@ struct Document;
 struct CanvasView;
 struct DocumentHistory;
 
-/** Built-in tool identifiers. */
+/**
+ * @enum ToolKind
+ * @brief 内置工具类型。
+ */
 typedef enum {
     TOOL_KIND_SELECT = 0,
     TOOL_KIND_PAN,
@@ -32,62 +27,82 @@ typedef enum {
 } ToolKind;
 
 /**
- * @brief Normalized pointer/keyboard event payload passed to tools.
+ * @struct ToolEvent
+ * @brief 传递给工具的标准化输入事件。
  *
- * Contains screen/world positions, deltas, and input state at the moment
- * of an input event. All coordinates are in the relevant space already
- * (screen or world) so tools can use whichever is appropriate.
+ * @member screen_pos 当前屏幕坐标。
+ * @member world_pos 当前世界坐标。
+ * @member delta_screen 相对上次事件的屏幕位移。
+ * @member delta_world 相对上次事件的世界位移。
+ * @member button 鼠标按键编号（移动事件通常为 `-1`）。
+ * @member mods 修饰键位掩码。
+ * @member wheel_y 滚轮 Y 方向增量。
  */
 typedef struct {
-    Vec2 screen_pos;   /**< Screen-space cursor position at event time */
-    Vec2 world_pos;     /**< World-space cursor position at event time */
-    Vec2 delta_screen;  /**< Screen-space movement since last event */
-    Vec2 delta_world;   /**< World-space movement since last event */
-    int button;         /**< GLFW button index, or -1 for move events */
-    int mods;           /**< Modifier key flags at event time */
-    float wheel_y;      /**< Vertical scroll delta (0 for non-scroll events) */
+    Vec2 screen_pos;
+    Vec2 world_pos;
+    Vec2 delta_screen;
+    Vec2 delta_world;
+    int button;
+    int mods;
+    float wheel_y;
 } ToolEvent;
 
 /**
- * @brief Shared handles a tool uses to safely read/write editor state.
+ * @struct ToolContext
+ * @brief 工具操作上下文。
  *
- * Passed to tool callbacks so tools can access document, canvas, history,
- * and workspace without needing a full workspace reference.
+ * @member workspace 工作区。
+ * @member document 当前文档。
+ * @member history 历史栈。
+ * @member canvas 画布视图。
  */
 typedef struct {
-    struct Workspace* workspace;    /**< Editor state and callbacks */
-    struct Document* document;       /**< Active document objects and selection */
-    struct DocumentHistory* history; /**< Undo/redo stack */
-    struct CanvasView* canvas;       /**< Viewport, zoom, and picking */
+    struct Workspace* workspace;
+    struct Document* document;
+    struct DocumentHistory* history;
+    struct CanvasView* canvas;
 } ToolContext;
 
 typedef struct Tool Tool;
 typedef struct ToolVTable ToolVTable;
 
 /**
- * @brief Virtual dispatch table for polymorphic tool implementations.
+ * @struct ToolVTable
+ * @brief 工具多态回调表。
  *
- * Each tool kind provides function pointers for all input handling callbacks.
- * A `NULL` vtable entry means that event type is not supported by that tool.
+ * @member label 返回工具显示名称。
+ * @member activate 工具激活回调。
+ * @member deactivate 工具停用回调。
+ * @member pointer_down 鼠标按下回调。
+ * @member pointer_move 鼠标移动回调。
+ * @member pointer_up 鼠标释放回调。
+ * @member key_down 键盘按下回调。
  */
 struct ToolVTable {
-    const char* (*label)(const Tool* tool);         /**< Human-readable tool name */
-    void (*activate)(Tool* tool, ToolContext* context);       /**< Called when tool becomes active */
-    void (*deactivate)(Tool* tool, ToolContext* context);       /**< Called when tool stops being active */
-    void (*pointer_down)(Tool* tool, ToolContext* context, const ToolEvent* event);   /**< Left-press handler */
-    void (*pointer_move)(Tool* tool, ToolContext* context, const ToolEvent* event);   /**< Pointer move handler */
-    void (*pointer_up)(Tool* tool, ToolContext* context, const ToolEvent* event);     /**< Left-release handler */
-    void (*key_down)(Tool* tool, ToolContext* context, int key, int mods);           /**< Keyboard handler */
+    const char* (*label)(const Tool* tool);
+    void (*activate)(Tool* tool, ToolContext* context);
+    void (*deactivate)(Tool* tool, ToolContext* context);
+    void (*pointer_down)(Tool* tool, ToolContext* context, const ToolEvent* event);
+    void (*pointer_move)(Tool* tool, ToolContext* context, const ToolEvent* event);
+    void (*pointer_up)(Tool* tool, ToolContext* context, const ToolEvent* event);
+    void (*key_down)(Tool* tool, ToolContext* context, int key, int mods);
 };
 
 /**
- * @brief Runtime instance of a tool with its kind, vtable, and per-tool state.
+ * @struct Tool
+ * @brief 工具运行时实例。
+ *
+ * @member kind 工具类型。
+ * @member vtable 回调表。
+ * @member state 工具私有状态。
+ * @member overlay_object 工具预览图元。
  */
 struct Tool {
-    ToolKind kind;                    /**< Which tool kind this instance represents */
-    const ToolVTable* vtable;        /**< Dispatch table for this tool's callbacks */
-    void* state;                     /**< Per-tool runtime state (e.g., drag state, anchor point) */
-    GraphicObject* overlay_object;    /**< Transient preview object currently being drawn */
+    ToolKind kind;
+    const ToolVTable* vtable;
+    void* state;
+    GraphicObject* overlay_object;
 };
 
 #endif /* GLDRAW_TOOLS_TOOL_H */

--- a/include/tools/tool.h
+++ b/include/tools/tool.h
@@ -1,6 +1,6 @@
 /**
  * @file tool.h
- * @brief 工具系统抽象接口与事件数据结构。
+ * @brief Tool system abstract interface and event data structures.
  */
 #ifndef GLDRAW_TOOLS_TOOL_H
 #define GLDRAW_TOOLS_TOOL_H
@@ -15,7 +15,7 @@ struct DocumentHistory;
 
 /**
  * @enum ToolKind
- * @brief 内置工具类型。
+ * @brief Built-in tool types.
  */
 typedef enum {
     TOOL_KIND_SELECT = 0,
@@ -28,15 +28,15 @@ typedef enum {
 
 /**
  * @struct ToolEvent
- * @brief 传递给工具的标准化输入事件。
+ * @brief Normalized input event passed to tools.
  *
- * @member screen_pos 当前屏幕坐标。
- * @member world_pos 当前世界坐标。
- * @member delta_screen 相对上次事件的屏幕位移。
- * @member delta_world 相对上次事件的世界位移。
- * @member button 鼠标按键编号（移动事件通常为 `-1`）。
- * @member mods 修饰键位掩码。
- * @member wheel_y 滚轮 Y 方向增量。
+ * @member screen_pos Current screen coordinates.
+ * @member world_pos Current world coordinates.
+ * @member delta_screen Screen-space displacement since the last event.
+ * @member delta_world World-space displacement since the last event.
+ * @member button Mouse button number (-1 for move events).
+ * @member mods Modifier key bitmask.
+ * @member wheel_y Scroll wheel Y delta.
  */
 typedef struct {
     Vec2 screen_pos;
@@ -50,12 +50,12 @@ typedef struct {
 
 /**
  * @struct ToolContext
- * @brief 工具操作上下文。
+ * @brief Tool operation context.
  *
- * @member workspace 工作区。
- * @member document 当前文档。
- * @member history 历史栈。
- * @member canvas 画布视图。
+ * @member workspace Workspace.
+ * @member document Current document.
+ * @member history History stack.
+ * @member canvas Canvas view.
  */
 typedef struct {
     struct Workspace* workspace;
@@ -69,15 +69,15 @@ typedef struct ToolVTable ToolVTable;
 
 /**
  * @struct ToolVTable
- * @brief 工具多态回调表。
+ * @brief Tool polymorphic callback table.
  *
- * @member label 返回工具显示名称。
- * @member activate 工具激活回调。
- * @member deactivate 工具停用回调。
- * @member pointer_down 鼠标按下回调。
- * @member pointer_move 鼠标移动回调。
- * @member pointer_up 鼠标释放回调。
- * @member key_down 键盘按下回调。
+ * @member label Returns the tool display name.
+ * @member activate Tool activate callback.
+ * @member deactivate Tool deactivate callback.
+ * @member pointer_down Mouse pointer down callback.
+ * @member pointer_move Mouse pointer move callback.
+ * @member pointer_up Mouse pointer up callback.
+ * @member key_down Key down callback.
  */
 struct ToolVTable {
     const char* (*label)(const Tool* tool);
@@ -91,12 +91,12 @@ struct ToolVTable {
 
 /**
  * @struct Tool
- * @brief 工具运行时实例。
+ * @brief Tool runtime instance.
  *
- * @member kind 工具类型。
- * @member vtable 回调表。
- * @member state 工具私有状态。
- * @member overlay_object 工具预览图元。
+ * @member kind Tool type.
+ * @member vtable Callback table.
+ * @member state Tool-private state.
+ * @member overlay_object Tool preview graphic object.
  */
 struct Tool {
     ToolKind kind;

--- a/include/tools/tool_controller.h
+++ b/include/tools/tool_controller.h
@@ -1,20 +1,22 @@
 /**
  * @file tool_controller.h
- * @brief Active tool routing and input dispatch API.
- *
- * Role in project:
- * - Stores all tool instances and tracks the current active tool.
- * - Forwards pointer/key/scroll events to the active tool implementation.
- *
- * Module relationships:
- * - Built on `tool.h` abstractions.
- * - Called by application event callbacks and UI tool selectors.
+ * @brief 活动工具管理与输入分发接口。
  */
 #ifndef GLDRAW_TOOLS_TOOL_CONTROLLER_H
 #define GLDRAW_TOOLS_TOOL_CONTROLLER_H
 
 #include <tools/tool.h>
 
+/**
+ * @struct ToolController
+ * @brief 工具控制器状态。
+ *
+ * @member tools 工具实例数组。
+ * @member active_kind 当前激活工具类型。
+ * @member pointer_captured 指针是否被工具捕获。
+ * @member last_screen 最近一次屏幕坐标。
+ * @member last_world 最近一次世界坐标。
+ */
 typedef struct {
     Tool tools[TOOL_KIND_COUNT];
     ToolKind active_kind;
@@ -23,29 +25,95 @@ typedef struct {
     Vec2 last_world;
 } ToolController;
 
-/** Initialize all tool slots and internal state. Complexity: `O(tool_count)`. */
+/**
+ * @brief 初始化工具控制器。
+ * @param controller 控制器实例。
+ * @return 无。
+ */
 void tool_controller_init(ToolController* controller);
-/** Shutdown tools and free per-tool state. Complexity: `O(tool_count)`. */
+
+/**
+ * @brief 关闭工具控制器并释放工具状态。
+ * @param controller 控制器实例。
+ * @return 无。
+ */
 void tool_controller_shutdown(ToolController* controller);
 
-/** Switch active tool and run deactivate/activate hooks as needed. Complexity: `O(1)`. */
+/**
+ * @brief 切换当前激活工具。
+ * @param controller 控制器实例。
+ * @param context 工具上下文。
+ * @param kind 目标工具类型。
+ * @return 无。
+ */
 void tool_controller_set_active(ToolController* controller, ToolContext* context, ToolKind kind);
-/** Get mutable pointer to currently active tool, or `NULL` if controller invalid. */
+
+/**
+ * @brief 获取当前激活工具。
+ * @param controller 控制器实例。
+ * @return 激活工具指针；参数非法时返回 `NULL`。
+ */
 Tool* tool_controller_get_active(ToolController* controller);
-/** Get active tool display label. */
+
+/**
+ * @brief 获取当前激活工具标签文本。
+ * @param controller 控制器实例。
+ * @return 工具标签字符串。
+ */
 const char* tool_controller_active_label(const ToolController* controller);
-/** Get overlay object owned by active tool (preview rendering). */
+
+/**
+ * @brief 获取当前激活工具的叠加预览对象。
+ * @param controller 控制器实例。
+ * @return 叠加对象指针；无预览时返回 `NULL`。
+ */
 GraphicObject* tool_controller_overlay_object(const ToolController* controller);
 
-/** Dispatch pointer press and capture pointer ownership. */
+/**
+ * @brief 分发鼠标按下事件。
+ * @param controller 控制器实例。
+ * @param context 工具上下文。
+ * @param event 输入事件。
+ * @return 无。
+ */
 void tool_controller_pointer_down(ToolController* controller, ToolContext* context, const ToolEvent* event);
-/** Dispatch pointer move to active tool. */
+
+/**
+ * @brief 分发鼠标移动事件。
+ * @param controller 控制器实例。
+ * @param context 工具上下文。
+ * @param event 输入事件。
+ * @return 无。
+ */
 void tool_controller_pointer_move(ToolController* controller, ToolContext* context, const ToolEvent* event);
-/** Dispatch pointer release and release pointer capture. */
+
+/**
+ * @brief 分发鼠标释放事件。
+ * @param controller 控制器实例。
+ * @param context 工具上下文。
+ * @param event 输入事件。
+ * @return 无。
+ */
 void tool_controller_pointer_up(ToolController* controller, ToolContext* context, const ToolEvent* event);
-/** Dispatch keyboard input to global shortcuts or active tool. */
+
+/**
+ * @brief 分发键盘按下事件。
+ * @param controller 控制器实例。
+ * @param context 工具上下文。
+ * @param key GLFW 键值。
+ * @param mods 修饰键掩码。
+ * @return 无。
+ */
 void tool_controller_key_down(ToolController* controller, ToolContext* context, int key, int mods);
-/** Handle mouse wheel scroll for zoom around a screen anchor. */
+
+/**
+ * @brief 处理滚轮缩放事件。
+ * @param controller 控制器实例。
+ * @param context 工具上下文。
+ * @param screen_pos 当前屏幕坐标锚点。
+ * @param yoffset 滚轮 Y 增量。
+ * @return 无。
+ */
 void tool_controller_scroll(ToolController* controller, ToolContext* context, Vec2 screen_pos, float yoffset);
 
 #endif /* GLDRAW_TOOLS_TOOL_CONTROLLER_H */

--- a/include/tools/tool_controller.h
+++ b/include/tools/tool_controller.h
@@ -1,6 +1,6 @@
 /**
  * @file tool_controller.h
- * @brief 活动工具管理与输入分发接口。
+ * @brief Active tool management and input dispatch interface.
  */
 #ifndef GLDRAW_TOOLS_TOOL_CONTROLLER_H
 #define GLDRAW_TOOLS_TOOL_CONTROLLER_H
@@ -9,13 +9,13 @@
 
 /**
  * @struct ToolController
- * @brief 工具控制器状态。
+ * @brief Tool controller state.
  *
- * @member tools 工具实例数组。
- * @member active_kind 当前激活工具类型。
- * @member pointer_captured 指针是否被工具捕获。
- * @member last_screen 最近一次屏幕坐标。
- * @member last_world 最近一次世界坐标。
+ * @member tools Tool instance array.
+ * @member active_kind Currently active tool type.
+ * @member pointer_captured Whether the pointer is captured by a tool.
+ * @member last_screen Most recent screen coordinates.
+ * @member last_world Most recent world coordinates.
  */
 typedef struct {
     Tool tools[TOOL_KIND_COUNT];
@@ -26,93 +26,93 @@ typedef struct {
 } ToolController;
 
 /**
- * @brief 初始化工具控制器。
- * @param controller 控制器实例。
- * @return 无。
+ * @brief Initialize the tool controller.
+ * @param controller Controller instance.
+ * @return No return value.
  */
 void tool_controller_init(ToolController* controller);
 
 /**
- * @brief 关闭工具控制器并释放工具状态。
- * @param controller 控制器实例。
- * @return 无。
+ * @brief Shut down the tool controller and release tool state.
+ * @param controller Controller instance.
+ * @return No return value.
  */
 void tool_controller_shutdown(ToolController* controller);
 
 /**
- * @brief 切换当前激活工具。
- * @param controller 控制器实例。
- * @param context 工具上下文。
- * @param kind 目标工具类型。
- * @return 无。
+ * @brief Switch the currently active tool.
+ * @param controller Controller instance.
+ * @param context Tool context.
+ * @param kind Target tool type.
+ * @return No return value.
  */
 void tool_controller_set_active(ToolController* controller, ToolContext* context, ToolKind kind);
 
 /**
- * @brief 获取当前激活工具。
- * @param controller 控制器实例。
- * @return 激活工具指针；参数非法时返回 `NULL`。
+ * @brief Get the currently active tool.
+ * @param controller Controller instance.
+ * @return Pointer to the active tool; returns `NULL` if parameters are invalid.
  */
 Tool* tool_controller_get_active(ToolController* controller);
 
 /**
- * @brief 获取当前激活工具标签文本。
- * @param controller 控制器实例。
- * @return 工具标签字符串。
+ * @brief Get the label text of the currently active tool.
+ * @param controller Controller instance.
+ * @return Tool label string.
  */
 const char* tool_controller_active_label(const ToolController* controller);
 
 /**
- * @brief 获取当前激活工具的叠加预览对象。
- * @param controller 控制器实例。
- * @return 叠加对象指针；无预览时返回 `NULL`。
+ * @brief Get the overlay preview object of the currently active tool.
+ * @param controller Controller instance.
+ * @return Overlay object pointer; returns `NULL` if no preview is available.
  */
 GraphicObject* tool_controller_overlay_object(const ToolController* controller);
 
 /**
- * @brief 分发鼠标按下事件。
- * @param controller 控制器实例。
- * @param context 工具上下文。
- * @param event 输入事件。
- * @return 无。
+ * @brief Dispatch a mouse pointer-down event.
+ * @param controller Controller instance.
+ * @param context Tool context.
+ * @param event Input event.
+ * @return No return value.
  */
 void tool_controller_pointer_down(ToolController* controller, ToolContext* context, const ToolEvent* event);
 
 /**
- * @brief 分发鼠标移动事件。
- * @param controller 控制器实例。
- * @param context 工具上下文。
- * @param event 输入事件。
- * @return 无。
+ * @brief Dispatch a mouse pointer-move event.
+ * @param controller Controller instance.
+ * @param context Tool context.
+ * @param event Input event.
+ * @return No return value.
  */
 void tool_controller_pointer_move(ToolController* controller, ToolContext* context, const ToolEvent* event);
 
 /**
- * @brief 分发鼠标释放事件。
- * @param controller 控制器实例。
- * @param context 工具上下文。
- * @param event 输入事件。
- * @return 无。
+ * @brief Dispatch a mouse pointer-up event.
+ * @param controller Controller instance.
+ * @param context Tool context.
+ * @param event Input event.
+ * @return No return value.
  */
 void tool_controller_pointer_up(ToolController* controller, ToolContext* context, const ToolEvent* event);
 
 /**
- * @brief 分发键盘按下事件。
- * @param controller 控制器实例。
- * @param context 工具上下文。
- * @param key GLFW 键值。
- * @param mods 修饰键掩码。
- * @return 无。
+ * @brief Dispatch a key-down event.
+ * @param controller Controller instance.
+ * @param context Tool context.
+ * @param key GLFW key value.
+ * @param mods Modifier key mask.
+ * @return No return value.
  */
 void tool_controller_key_down(ToolController* controller, ToolContext* context, int key, int mods);
 
 /**
- * @brief 处理滚轮缩放事件。
- * @param controller 控制器实例。
- * @param context 工具上下文。
- * @param screen_pos 当前屏幕坐标锚点。
- * @param yoffset 滚轮 Y 增量。
- * @return 无。
+ * @brief Handle scroll-wheel zoom events.
+ * @param controller Controller instance.
+ * @param context Tool context.
+ * @param screen_pos Current screen coordinate anchor.
+ * @param yoffset Scroll wheel Y delta.
+ * @return No return value.
  */
 void tool_controller_scroll(ToolController* controller, ToolContext* context, Vec2 screen_pos, float yoffset);
 

--- a/include/ui/ui_system.h
+++ b/include/ui/ui_system.h
@@ -1,6 +1,6 @@
 /**
  * @file ui_system.h
- * @brief UI 系统生命周期与布局查询接口。
+ * @brief UI system lifecycle and layout query interface.
  */
 #ifndef GLDRAW_UI_UI_SYSTEM_H
 #define GLDRAW_UI_UI_SYSTEM_H
@@ -13,82 +13,82 @@ struct Workspace;
 typedef struct UiSystem UiSystem;
 
 /**
- * @brief 创建 UI 系统实例。
- * @param window 已初始化的平台窗口。
- * @return 创建成功返回 `UiSystem*`，失败返回 `NULL`。
+ * @brief Create a UI system instance.
+ * @param window Already-initialized platform window.
+ * @return `UiSystem*` on success, `NULL` on failure.
  */
 UiSystem* ui_system_create(PlatformWindow* window);
 
 /**
- * @brief 销毁 UI 系统并释放资源。
- * @param ui UI 系统实例。
- * @return 无。
+ * @brief Destroy the UI system and release resources.
+ * @param ui UI system instance.
+ * @return No return value.
  */
 void ui_system_destroy(UiSystem* ui);
 
 /**
- * @brief 开始一帧 UI 构建。
- * @param ui UI 系统实例。
- * @return 无。
+ * @brief Begin a UI frame.
+ * @param ui UI system instance.
+ * @return No return value.
  */
 void ui_system_begin_frame(UiSystem* ui);
 
 /**
- * @brief 构建整帧 UI 并回写工作区状态。
- * @param ui UI 系统实例。
- * @param workspace 工作区。
- * @return 无。
+ * @brief Build the entire frame UI and write back to workspace state.
+ * @param ui UI system instance.
+ * @param workspace Workspace.
+ * @return No return value.
  */
 void ui_system_build(UiSystem* ui, struct Workspace* workspace);
 
 /**
- * @brief 提交 UI 绘制命令。
- * @param ui UI 系统实例。
- * @return 无。
+ * @brief Commit UI draw commands.
+ * @param ui UI system instance.
+ * @return No return value.
  */
 void ui_system_render(UiSystem* ui);
 
 /**
- * @brief 查询 UI 是否存在进行中的交互。
- * @param ui UI 系统实例。
- * @return 有交互返回非零，否则返回 0。
+ * @brief Query whether the UI has an ongoing interaction.
+ * @param ui UI system instance.
+ * @return Non-zero if an interaction is in progress, zero otherwise.
  */
 int ui_system_has_active_interaction(const UiSystem* ui);
 
 /**
- * @brief 判断屏幕点是否被 UI 区域拦截。
- * @param ui UI 系统实例。
- * @param screen_pos 屏幕坐标点。
- * @return 被 UI 区域拦截返回非零，否则返回 0。
+ * @brief Check whether the screen point is intercepted by the UI region.
+ * @param ui UI system instance.
+ * @param screen_pos Screen coordinate point.
+ * @return Non-zero if intercepted by the UI region, zero otherwise.
  */
 int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos);
 
 /**
- * @brief 获取窗口命中测试边界。
- * @param ui UI 系统实例。
- * @return 窗口边界矩形。
+ * @brief Get window hit-test bounds.
+ * @param ui UI system instance.
+ * @return Window boundary rectangle.
  */
 RectF ui_system_window_bounds(const UiSystem* ui);
 
 /**
- * @brief 获取画布内容区边界。
- * @param ui UI 系统实例。
- * @return 内容区矩形。
+ * @brief Get canvas content area bounds.
+ * @param ui UI system instance.
+ * @return Content area rectangle.
  */
 RectF ui_system_content_bounds(const UiSystem* ui);
 
 /**
- * @brief 判断点是否位于画布内容区。
- * @param ui UI 系统实例。
- * @param screen_pos 屏幕坐标点。
- * @return 位于画布区域返回非零，否则返回 0。
+ * @brief Check whether a point lies inside the canvas content area.
+ * @param ui UI system instance.
+ * @param screen_pos Screen coordinate point.
+ * @return Non-zero if inside the canvas region, zero otherwise.
  */
 int ui_system_point_in_canvas(const UiSystem* ui, Vec2 screen_pos);
 
 /**
- * @brief 获取当前主题的画布背景色。
- * @param ui UI 系统实例。
- * @return 画布背景色。
+ * @brief Get the canvas background color for the current theme.
+ * @param ui UI system instance.
+ * @return Canvas background color.
  */
 Color ui_system_canvas_background(const UiSystem* ui);
 

--- a/include/ui/ui_system.h
+++ b/include/ui/ui_system.h
@@ -1,14 +1,6 @@
 /**
  * @file ui_system.h
- * @brief Nuklear UI system lifecycle and layout query API.
- *
- * Role in project:
- * - Builds toolbar/menu/inspector/status UI each frame.
- * - Publishes UI layout bounds used by app input filtering and canvas viewport.
- *
- * Module relationships:
- * - Created/destroyed by application runtime.
- * - Reads/writes workspace state and consumes platform window context.
+ * @brief UI 系统生命周期与布局查询接口。
  */
 #ifndef GLDRAW_UI_UI_SYSTEM_H
 #define GLDRAW_UI_UI_SYSTEM_H
@@ -20,27 +12,84 @@ struct Workspace;
 
 typedef struct UiSystem UiSystem;
 
-/** Create UI system for an initialized window/context. Returns `NULL` on failure. */
+/**
+ * @brief 创建 UI 系统实例。
+ * @param window 已初始化的平台窗口。
+ * @return 创建成功返回 `UiSystem*`，失败返回 `NULL`。
+ */
 UiSystem* ui_system_create(PlatformWindow* window);
-/** Destroy UI resources and contexts. */
+
+/**
+ * @brief 销毁 UI 系统并释放资源。
+ * @param ui UI 系统实例。
+ * @return 无。
+ */
 void ui_system_destroy(UiSystem* ui);
-/** Begin a new UI frame (input capture/reset). */
+
+/**
+ * @brief 开始一帧 UI 构建。
+ * @param ui UI 系统实例。
+ * @return 无。
+ */
 void ui_system_begin_frame(UiSystem* ui);
-/** Build all UI panels and apply workspace mutations. */
+
+/**
+ * @brief 构建整帧 UI 并回写工作区状态。
+ * @param ui UI 系统实例。
+ * @param workspace 工作区。
+ * @return 无。
+ */
 void ui_system_build(UiSystem* ui, struct Workspace* workspace);
-/** Render prepared UI draw commands. */
+
+/**
+ * @brief 提交 UI 绘制命令。
+ * @param ui UI 系统实例。
+ * @return 无。
+ */
 void ui_system_render(UiSystem* ui);
-/** Return non-zero when any UI widget is actively interacting. */
+
+/**
+ * @brief 查询 UI 是否存在进行中的交互。
+ * @param ui UI 系统实例。
+ * @return 有交互返回非零，否则返回 0。
+ */
 int ui_system_has_active_interaction(const UiSystem* ui);
-/** Return non-zero when a screen point is over UI-occupied regions. */
+
+/**
+ * @brief 判断屏幕点是否被 UI 区域拦截。
+ * @param ui UI 系统实例。
+ * @param screen_pos 屏幕坐标点。
+ * @return 被 UI 区域拦截返回非零，否则返回 0。
+ */
 int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos);
-/** Get clamped UI-published window bounds used for hit testing and viewport fallback. */
+
+/**
+ * @brief 获取窗口命中测试边界。
+ * @param ui UI 系统实例。
+ * @return 窗口边界矩形。
+ */
 RectF ui_system_window_bounds(const UiSystem* ui);
-/** Get computed content area available for canvas. */
+
+/**
+ * @brief 获取画布内容区边界。
+ * @param ui UI 系统实例。
+ * @return 内容区矩形。
+ */
 RectF ui_system_content_bounds(const UiSystem* ui);
-/** Return non-zero when screen point lies inside canvas content region. */
+
+/**
+ * @brief 判断点是否位于画布内容区。
+ * @param ui UI 系统实例。
+ * @param screen_pos 屏幕坐标点。
+ * @return 位于画布区域返回非零，否则返回 0。
+ */
 int ui_system_point_in_canvas(const UiSystem* ui, Vec2 screen_pos);
-/** Get canvas background color derived from active theme. */
+
+/**
+ * @brief 获取当前主题的画布背景色。
+ * @param ui UI 系统实例。
+ * @return 画布背景色。
+ */
 Color ui_system_canvas_background(const UiSystem* ui);
 
 #endif /* GLDRAW_UI_UI_SYSTEM_H */

--- a/include/ui/ui_theme.h
+++ b/include/ui/ui_theme.h
@@ -1,14 +1,6 @@
 /**
  * @file ui_theme.h
- * @brief Theme token definitions and load/apply interfaces.
- *
- * Role in project:
- * - Defines color/spacing/radius animation tokens used by UI rendering.
- * - Supports built-in themes and external theme file hot-reload.
- *
- * Module relationships:
- * - Consumed by `ui_system` and `ui_menubar`.
- * - Applies style values into Nuklear context.
+ * @brief UI 主题令牌与加载/应用接口。
  */
 #ifndef GLDRAW_UI_UI_THEME_H
 #define GLDRAW_UI_UI_THEME_H
@@ -22,6 +14,37 @@ struct nk_color { nk_byte r, g, b, a; };
 struct nk_context;
 #endif
 
+/**
+ * @struct UiThemeTokens
+ * @brief 一组完整的 UI 主题令牌。
+ *
+ * @member primary 主色。
+ * @member primary_hover 主色悬停态。
+ * @member primary_active 主色激活态。
+ * @member background 全局背景色。
+ * @member panel 面板背景色。
+ * @member panel_hover 面板悬停色。
+ * @member canvas_background 画布背景色。
+ * @member text 主文本色。
+ * @member text_secondary 次级文本色。
+ * @member text_disabled 禁用文本色。
+ * @member border 边框色。
+ * @member border_hover 边框悬停色。
+ * @member success 成功状态色。
+ * @member warning 警告状态色。
+ * @member error 错误状态色。
+ * @member row_height 行高。
+ * @member panel_width 面板宽度。
+ * @member menu_height 菜单栏高度。
+ * @member status_height 状态栏高度。
+ * @member tool_rail_width 工具栏宽度。
+ * @member padding 内边距。
+ * @member margin 外边距。
+ * @member gap 间距。
+ * @member border_radius 圆角半径。
+ * @member enable_transitions 是否启用过渡动画。
+ * @member transition_duration 过渡动画时长。
+ */
 typedef struct UiThemeTokens {
     /* Primary */
     struct nk_color primary;
@@ -68,34 +91,100 @@ typedef struct UiThemeTokens {
     float transition_duration;
 } UiThemeTokens;
 
+/**
+ * @struct UiThemeDescriptor
+ * @brief 主题元信息。
+ *
+ * @member id 主题唯一 ID。
+ * @member label 主题显示名称。
+ */
 typedef struct UiThemeDescriptor {
     const char* id;
     const char* label;
 } UiThemeDescriptor;
 
-/** Return default built-in theme tokens. */
+/**
+ * @brief 获取默认内置主题令牌。
+ * @return 默认主题令牌。
+ */
 UiThemeTokens ui_theme_default_tokens(void);
-/** Resolve theme tokens by ID, falling back to default when missing. */
+
+/**
+ * @brief 根据主题 ID 获取主题令牌。
+ * @param theme_id 主题 ID。
+ * @return 匹配主题令牌；找不到时返回默认主题。
+ */
 UiThemeTokens ui_theme_tokens_for_id(const char* theme_id);
-/** Return total theme count (built-in + loaded custom). */
+
+/**
+ * @brief 获取可用主题数量（内置 + 外部）。
+ * @return 主题总数。
+ */
 int ui_theme_count(void);
-/** Return descriptor at index, or `NULL` when out of range. */
+
+/**
+ * @brief 通过索引获取主题描述符。
+ * @param index 主题索引。
+ * @return 索引有效时返回描述符指针，否则返回 `NULL`。
+ */
 const UiThemeDescriptor* ui_theme_descriptor_at(int index);
-/** Find index by theme ID, or `-1` when missing. */
+
+/**
+ * @brief 根据主题 ID 查询索引。
+ * @param theme_id 主题 ID。
+ * @return 找到返回索引，未找到返回 `-1`。
+ */
 int ui_theme_index_of_id(const char* theme_id);
-/** Return default theme ID string. */
+
+/**
+ * @brief 获取默认主题 ID。
+ * @return 默认主题 ID 字符串。
+ */
 const char* ui_theme_default_id(void);
-/** Reload external themes from directory; returns custom theme count. */
+
+/**
+ * @brief 重新加载指定目录下的外部主题。
+ * @param directory_path 主题目录路径。
+ * @return 成功加载的外部主题数量。
+ */
 int ui_theme_reload_external(const char* directory_path);
-/** Compute signature hash of external theme directory contents. */
+
+/**
+ * @brief 计算外部主题目录签名。
+ * @param directory_path 主题目录路径。
+ * @return 目录签名值（用于变更检测）。
+ */
 unsigned long long ui_theme_external_signature(const char* directory_path);
-/** Return last external reload error summary, or empty string when clean. */
+
+/**
+ * @brief 获取最近一次主题重载错误信息。
+ * @return 错误字符串；无错误时返回空字符串。
+ */
 const char* ui_theme_last_reload_error(void);
-/** Load selected theme ID from settings file. Returns 1 on success. */
+
+/**
+ * @brief 从设置文件加载当前主题 ID。
+ * @param path 设置文件路径。
+ * @param out_theme_id 主题 ID 输出缓冲区。
+ * @param out_theme_id_size 输出缓冲区大小。
+ * @return 成功返回非零，否则返回 0。
+ */
 int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_theme_id_size);
-/** Save selected theme ID to settings file. Returns 1 on success. */
+
+/**
+ * @brief 将当前主题 ID 保存到设置文件。
+ * @param path 设置文件路径。
+ * @param theme_id 主题 ID。
+ * @return 成功返回非零，否则返回 0。
+ */
 int ui_theme_save_selected_id(const char* path, const char* theme_id);
-/** Apply tokens to Nuklear style tables. */
+
+/**
+ * @brief 将主题令牌应用到 Nuklear 样式表。
+ * @param ctx Nuklear 上下文。
+ * @param tokens 主题令牌。
+ * @return 无。
+ */
 void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens);
 
 #endif /* GLDRAW_UI_UI_THEME_H */

--- a/include/ui/ui_theme.h
+++ b/include/ui/ui_theme.h
@@ -1,6 +1,6 @@
 /**
  * @file ui_theme.h
- * @brief UI 主题令牌与加载/应用接口。
+ * @brief UI theme tokens and load/apply interface.
  */
 #ifndef GLDRAW_UI_UI_THEME_H
 #define GLDRAW_UI_UI_THEME_H
@@ -16,34 +16,34 @@ struct nk_context;
 
 /**
  * @struct UiThemeTokens
- * @brief 一组完整的 UI 主题令牌。
+ * @brief Complete set of UI theme tokens.
  *
- * @member primary 主色。
- * @member primary_hover 主色悬停态。
- * @member primary_active 主色激活态。
- * @member background 全局背景色。
- * @member panel 面板背景色。
- * @member panel_hover 面板悬停色。
- * @member canvas_background 画布背景色。
- * @member text 主文本色。
- * @member text_secondary 次级文本色。
- * @member text_disabled 禁用文本色。
- * @member border 边框色。
- * @member border_hover 边框悬停色。
- * @member success 成功状态色。
- * @member warning 警告状态色。
- * @member error 错误状态色。
- * @member row_height 行高。
- * @member panel_width 面板宽度。
- * @member menu_height 菜单栏高度。
- * @member status_height 状态栏高度。
- * @member tool_rail_width 工具栏宽度。
- * @member padding 内边距。
- * @member margin 外边距。
- * @member gap 间距。
- * @member border_radius 圆角半径。
- * @member enable_transitions 是否启用过渡动画。
- * @member transition_duration 过渡动画时长。
+ * @member primary Primary color.
+ * @member primary_hover Primary color hover state.
+ * @member primary_active Primary color active state.
+ * @member background Global background color.
+ * @member panel Panel background color.
+ * @member panel_hover Panel hover color.
+ * @member canvas_background Canvas background color.
+ * @member text Primary text color.
+ * @member text_secondary Secondary text color.
+ * @member text_disabled Disabled text color.
+ * @member border Border color.
+ * @member border_hover Border hover color.
+ * @member success Success state color.
+ * @member warning Warning state color.
+ * @member error Error state color.
+ * @member row_height Row height.
+ * @member panel_width Panel width.
+ * @member menu_height Menu bar height.
+ * @member status_height Status bar height.
+ * @member tool_rail_width Tool rail width.
+ * @member padding Inner padding.
+ * @member margin Outer margin.
+ * @member gap Spacing gap.
+ * @member border_radius Corner radius.
+ * @member enable_transitions Whether to enable transitions.
+ * @member transition_duration Transition animation duration.
  */
 typedef struct UiThemeTokens {
     /* Primary */
@@ -93,10 +93,10 @@ typedef struct UiThemeTokens {
 
 /**
  * @struct UiThemeDescriptor
- * @brief 主题元信息。
+ * @brief Theme metadata.
  *
- * @member id 主题唯一 ID。
- * @member label 主题显示名称。
+ * @member id Unique theme ID.
+ * @member label Theme display name.
  */
 typedef struct UiThemeDescriptor {
     const char* id;
@@ -104,86 +104,86 @@ typedef struct UiThemeDescriptor {
 } UiThemeDescriptor;
 
 /**
- * @brief 获取默认内置主题令牌。
- * @return 默认主题令牌。
+ * @brief Get the default built-in theme tokens.
+ * @return Default theme tokens.
  */
 UiThemeTokens ui_theme_default_tokens(void);
 
 /**
- * @brief 根据主题 ID 获取主题令牌。
- * @param theme_id 主题 ID。
- * @return 匹配主题令牌；找不到时返回默认主题。
+ * @brief Get theme tokens for a given theme ID.
+ * @param theme_id Theme ID.
+ * @return Matching theme tokens; returns default theme if not found.
  */
 UiThemeTokens ui_theme_tokens_for_id(const char* theme_id);
 
 /**
- * @brief 获取可用主题数量（内置 + 外部）。
- * @return 主题总数。
+ * @brief Get the total number of available themes (built-in + external).
+ * @return Total theme count.
  */
 int ui_theme_count(void);
 
 /**
- * @brief 通过索引获取主题描述符。
- * @param index 主题索引。
- * @return 索引有效时返回描述符指针，否则返回 `NULL`。
+ * @brief Get a theme descriptor by index.
+ * @param index Theme index.
+ * @return Descriptor pointer if index is valid, `NULL` otherwise.
  */
 const UiThemeDescriptor* ui_theme_descriptor_at(int index);
 
 /**
- * @brief 根据主题 ID 查询索引。
- * @param theme_id 主题 ID。
- * @return 找到返回索引，未找到返回 `-1`。
+ * @brief Look up the index for a given theme ID.
+ * @param theme_id Theme ID.
+ * @return Index if found, `-1` if not found.
  */
 int ui_theme_index_of_id(const char* theme_id);
 
 /**
- * @brief 获取默认主题 ID。
- * @return 默认主题 ID 字符串。
+ * @brief Get the default theme ID.
+ * @return Default theme ID string.
  */
 const char* ui_theme_default_id(void);
 
 /**
- * @brief 重新加载指定目录下的外部主题。
- * @param directory_path 主题目录路径。
- * @return 成功加载的外部主题数量。
+ * @brief Reload external themes from a given directory.
+ * @param directory_path Theme directory path.
+ * @return Number of external themes successfully loaded.
  */
 int ui_theme_reload_external(const char* directory_path);
 
 /**
- * @brief 计算外部主题目录签名。
- * @param directory_path 主题目录路径。
- * @return 目录签名值（用于变更检测）。
+ * @brief Compute the external theme directory signature.
+ * @param directory_path Theme directory path.
+ * @return Directory signature value (used for change detection).
  */
 unsigned long long ui_theme_external_signature(const char* directory_path);
 
 /**
- * @brief 获取最近一次主题重载错误信息。
- * @return 错误字符串；无错误时返回空字符串。
+ * @brief Get the error message from the last theme reload.
+ * @return Error string; returns an empty string if no error occurred.
  */
 const char* ui_theme_last_reload_error(void);
 
 /**
- * @brief 从设置文件加载当前主题 ID。
- * @param path 设置文件路径。
- * @param out_theme_id 主题 ID 输出缓冲区。
- * @param out_theme_id_size 输出缓冲区大小。
- * @return 成功返回非零，否则返回 0。
+ * @brief Load the current theme ID from a settings file.
+ * @param path Settings file path.
+ * @param out_theme_id Theme ID output buffer.
+ * @param out_theme_id_size Output buffer size.
+ * @return Non-zero on success, zero on failure.
  */
 int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_theme_id_size);
 
 /**
- * @brief 将当前主题 ID 保存到设置文件。
- * @param path 设置文件路径。
- * @param theme_id 主题 ID。
- * @return 成功返回非零，否则返回 0。
+ * @brief Save the current theme ID to a settings file.
+ * @param path Settings file path.
+ * @param theme_id Theme ID.
+ * @return Non-zero on success, zero on failure.
  */
 int ui_theme_save_selected_id(const char* path, const char* theme_id);
 
 /**
- * @brief 将主题令牌应用到 Nuklear 样式表。
- * @param ctx Nuklear 上下文。
- * @param tokens 主题令牌。
- * @return 无。
+ * @brief Apply theme tokens to the Nuklear stylesheet.
+ * @param ctx Nuklear context.
+ * @param tokens Theme tokens.
+ * @return No return value.
  */
 void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens);
 

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -71,7 +71,12 @@ static void app_set_status(Application* app, const char* fmt, ...)
     va_end(args);
 }
 
-/** Check if file exists by opening it in read-binary mode. Complexity: `O(1)` (metadata + open). */
+/**
+ * @brief app_file_exists 函数。
+ *
+ * @param path 参数 `path`。
+ * @return 函数返回值。
+ */
 static int app_file_exists(const char* path)
 {
     FILE* file = NULL;
@@ -89,13 +94,23 @@ static int app_file_exists(const char* path)
     return 1;
 }
 
-/** Return fallback document path used when workspace path is empty. Complexity: `O(1)`. */
+/**
+ * @brief app_default_document_path 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 static const char* app_default_document_path(void)
 {
     return "document.json";
 }
 
-/** Resolve active document path (workspace path or default). Complexity: `O(1)`. */
+/**
+ * @brief app_current_document_path 函数。
+ *
+ * @param app 参数 `app`。
+ * @return 函数返回值。
+ */
 static const char* app_current_document_path(const Application* app)
 {
     if (app->workspace.current_document_path[0] != '\0') {
@@ -126,7 +141,12 @@ static void app_set_document_path(Application* app, const char* path)
     app->workspace.current_document_path[sizeof(app->workspace.current_document_path) - 1u] = '\0';
 }
 
-/** Reset tool controller runtime state after major document changes. Complexity: `O(tool_count)`. */
+/**
+ * @brief app_reset_tool_state 函数。
+ *
+ * @param app 参数 `app`。
+ * @return 无。
+ */
 static void app_reset_tool_state(Application* app)
 {
     if (!app) {
@@ -207,21 +227,38 @@ static int app_load_document(Application* app)
     return 1;
 }
 
-/** Workspace save callback adapter. Complexity: same as `app_save_document`. */
+/**
+ * @brief app_workspace_save 函数。
+ *
+ * @param workspace 参数 `workspace`。
+ * @param user_data 参数 `user_data`。
+ * @return 函数返回值。
+ */
 static int app_workspace_save(Workspace* workspace, void* user_data)
 {
     (void)workspace;
     return app_save_document((Application*)user_data);
 }
 
-/** Workspace load callback adapter. Complexity: same as `app_load_document`. */
+/**
+ * @brief app_workspace_load 函数。
+ *
+ * @param workspace 参数 `workspace`。
+ * @param user_data 参数 `user_data`。
+ * @return 函数返回值。
+ */
 static int app_workspace_load(Workspace* workspace, void* user_data)
 {
     (void)workspace;
     return app_load_document((Application*)user_data);
 }
 
-/** Load startup document if present; otherwise keep empty document. Complexity: `O(file_size)` when file exists. */
+/**
+ * @brief app_open_startup_document 函数。
+ *
+ * @param app 参数 `app`。
+ * @return 无。
+ */
 static void app_open_startup_document(Application* app)
 {
     const char* path = app_current_document_path(app);
@@ -240,7 +277,12 @@ static void app_open_startup_document(Application* app)
     app_set_status(app, "New empty document");
 }
 
-/** Build tool context struct from application-owned workspace pointers. Complexity: `O(1)`. */
+/**
+ * @brief app_tool_context 函数。
+ *
+ * @param app 参数 `app`。
+ * @return 函数返回值。
+ */
 static ToolContext app_tool_context(Application* app)
 {
     ToolContext context;
@@ -253,6 +295,8 @@ static ToolContext app_tool_context(Application* app)
 
 /**
  * @brief Decide whether pointer input should be blocked from canvas tools.
+ * @param app [in] Application state.
+ * @param screen_pos [in] 当前光标屏幕坐标。
  * @return Non-zero when UI interaction or non-canvas regions should consume input.
  *
  * Why:
@@ -273,7 +317,12 @@ static int app_pointer_blocks_canvas(const Application* app, Vec2 screen_pos)
     return app->ui && !ui_system_point_in_canvas(app->ui, screen_pos);
 }
 
-/** Sync tool controller's last pointer anchor with current cursor state. Complexity: `O(1)`. */
+/**
+ * @brief app_sync_tool_pointer_anchor 函数。
+ *
+ * @param app 参数 `app`。
+ * @return 无。
+ */
 static void app_sync_tool_pointer_anchor(Application* app)
 {
     if (!app) {
@@ -285,7 +334,12 @@ static void app_sync_tool_pointer_anchor(Application* app)
         canvas_view_screen_to_world(&app->workspace.canvas, app->cursor_screen);
 }
 
-/** Refresh cursor-in-canvas flag for uncaptured pointer movement. Complexity: `O(1)`. */
+/**
+ * @brief app_sync_canvas_boundary 函数。
+ *
+ * @param app 参数 `app`。
+ * @return 无。
+ */
 static void app_sync_canvas_boundary(Application* app)
 {
     int inside_canvas = 0;
@@ -301,7 +355,12 @@ static void app_sync_canvas_boundary(Application* app)
     }
 }
 
-/** Update canvas viewport and theme background from latest UI layout. Complexity: `O(1)`. */
+/**
+ * @brief update_canvas_viewport 函数。
+ *
+ * @param app 参数 `app`。
+ * @return 无。
+ */
 static void update_canvas_viewport(Application* app)
 {
     RectF viewport;
@@ -338,7 +397,15 @@ static void update_canvas_viewport(Application* app)
     app_sync_canvas_boundary(app);
 }
 
-/** Build a `ToolEvent` from current cursor and previous anchor state. Complexity: `O(1)`. */
+/**
+ * @brief make_tool_event 函数。
+ *
+ * @param app 参数 `app`。
+ * @param button 参数 `button`。
+ * @param mods 参数 `mods`。
+ * @param wheel_y 参数 `wheel_y`。
+ * @return 函数返回值。
+ */
 static ToolEvent make_tool_event(Application* app, int button, int mods, float wheel_y)
 {
     ToolEvent event;
@@ -352,7 +419,14 @@ static ToolEvent make_tool_event(Application* app, int button, int mods, float w
     return event;
 }
 
-/** GLFW framebuffer resize callback: update viewport and renderer dimensions. */
+/**
+ * @brief framebuffer_size_callback 函数。
+ *
+ * @param handle 参数 `handle`。
+ * @param width 参数 `width`。
+ * @param height 参数 `height`。
+ * @return 无。
+ */
 static void framebuffer_size_callback(GLFWwindow* handle, int width, int height)
 {
     Application* app = (Application*)glfwGetWindowUserPointer(handle);
@@ -365,7 +439,14 @@ static void framebuffer_size_callback(GLFWwindow* handle, int width, int height)
     render_system_resize(app->renderer, width, height);
 }
 
-/** GLFW cursor callback: route pointer-move to active tool when canvas is interactive. */
+/**
+ * @brief cursor_pos_callback 函数。
+ *
+ * @param handle 参数 `handle`。
+ * @param xpos 参数 `xpos`。
+ * @param ypos 参数 `ypos`。
+ * @return 无。
+ */
 static void cursor_pos_callback(GLFWwindow* handle, double xpos, double ypos)
 {
     Application* app = (Application*)glfwGetWindowUserPointer(handle);
@@ -390,7 +471,15 @@ static void cursor_pos_callback(GLFWwindow* handle, double xpos, double ypos)
     tool_controller_pointer_move(&app->workspace.tools, &context, &event);
 }
 
-/** GLFW mouse callback: route press/release with pointer capture semantics. */
+/**
+ * @brief mouse_button_callback 函数。
+ *
+ * @param handle 参数 `handle`。
+ * @param button 参数 `button`。
+ * @param action 参数 `action`。
+ * @param mods 参数 `mods`。
+ * @return 无。
+ */
 static void mouse_button_callback(GLFWwindow* handle, int button, int action, int mods)
 {
     Application* app = (Application*)glfwGetWindowUserPointer(handle);
@@ -498,7 +587,14 @@ static void key_callback(GLFWwindow* handle, int key, int scancode, int action, 
     tool_controller_key_down(&app->workspace.tools, &context, key, mods);
 }
 
-/** GLFW scroll callback: zoom canvas at cursor unless blocked by UI. */
+/**
+ * @brief scroll_callback 函数。
+ *
+ * @param handle 参数 `handle`。
+ * @param xoffset 参数 `xoffset`。
+ * @param yoffset 参数 `yoffset`。
+ * @return 无。
+ */
 static void scroll_callback(GLFWwindow* handle, double xoffset, double yoffset)
 {
     Application* app = (Application*)glfwGetWindowUserPointer(handle);
@@ -520,11 +616,18 @@ static void scroll_callback(GLFWwindow* handle, double xoffset, double yoffset)
 
 /**
  * @brief Initialize all runtime subsystems in dependency order.
+ * @param app [in,out] Application state.
  * @return `0` on success, `-1` on failure.
  *
  * Risk note:
  * - This function has multiple allocation/init branches; each failure path must
  *   leave state safe for `app_shutdown()` best-effort cleanup.
+ *
+ * Algorithm:
+ * 1. Initialize window + document/history/canvas/tools;
+ * 2. Initialize renderer and UI;
+ * 3. Bind GLFW callbacks;
+ * 4. Sync initial viewport/cursor/tool state and optionally load startup file.
  */
 static int app_init(Application* app)
 {
@@ -607,6 +710,15 @@ static void app_shutdown(Application* app)
  *
  * Time complexity:
  * - Main loop performs per-frame `O(object_count + ui_work)` operations.
+ *
+ * @note Function takes no parameters.
+ */
+
+/**
+ * @brief app_run 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
  */
 int app_run(void)
 {

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -72,10 +72,9 @@ static void app_set_status(Application* app, const char* fmt, ...)
 }
 
 /**
- * @brief app_file_exists 函数。
- *
- * @param path 参数 `path`。
- * @return 函数返回值。
+ * @brief Check if a file exists at the given path.
+ * @param path File path string.
+ * @return `1` if the file exists, `0` otherwise.
  */
 static int app_file_exists(const char* path)
 {
@@ -95,10 +94,8 @@ static int app_file_exists(const char* path)
 }
 
 /**
- * @brief app_default_document_path 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Get the default document path.
+ * @return Default document path string.
  */
 static const char* app_default_document_path(void)
 {
@@ -106,10 +103,9 @@ static const char* app_default_document_path(void)
 }
 
 /**
- * @brief app_current_document_path 函数。
- *
- * @param app 参数 `app`。
- * @return 函数返回值。
+ * @brief Get the current document path from workspace state.
+ * @param app Application instance.
+ * @return Current document path string.
  */
 static const char* app_current_document_path(const Application* app)
 {
@@ -142,10 +138,9 @@ static void app_set_document_path(Application* app, const char* path)
 }
 
 /**
- * @brief app_reset_tool_state 函数。
- *
- * @param app 参数 `app`。
- * @return 无。
+ * @brief Reset tool controller state.
+ * @param app Application instance.
+ * @return No return value.
  */
 static void app_reset_tool_state(Application* app)
 {
@@ -228,11 +223,10 @@ static int app_load_document(Application* app)
 }
 
 /**
- * @brief app_workspace_save 函数。
- *
- * @param workspace 参数 `workspace`。
- * @param user_data 参数 `user_data`。
- * @return 函数返回值。
+ * @brief Workspace save callback.
+ * @param workspace Workspace (unused, accessed via user_data).
+ * @param user_data Application instance.
+ * @return `1` on success, `0` on failure.
  */
 static int app_workspace_save(Workspace* workspace, void* user_data)
 {
@@ -241,11 +235,10 @@ static int app_workspace_save(Workspace* workspace, void* user_data)
 }
 
 /**
- * @brief app_workspace_load 函数。
- *
- * @param workspace 参数 `workspace`。
- * @param user_data 参数 `user_data`。
- * @return 函数返回值。
+ * @brief Workspace load callback.
+ * @param workspace Workspace (unused, accessed via user_data).
+ * @param user_data Application instance.
+ * @return `1` on success, `0` on failure.
  */
 static int app_workspace_load(Workspace* workspace, void* user_data)
 {
@@ -254,10 +247,9 @@ static int app_workspace_load(Workspace* workspace, void* user_data)
 }
 
 /**
- * @brief app_open_startup_document 函数。
- *
- * @param app 参数 `app`。
- * @return 无。
+ * @brief Open the startup document if it exists.
+ * @param app Application instance.
+ * @return No return value.
  */
 static void app_open_startup_document(Application* app)
 {
@@ -278,10 +270,9 @@ static void app_open_startup_document(Application* app)
 }
 
 /**
- * @brief app_tool_context 函数。
- *
- * @param app 参数 `app`。
- * @return 函数返回值。
+ * @brief Build the tool context from application state.
+ * @param app Application instance.
+ * @return Tool context structure.
  */
 static ToolContext app_tool_context(Application* app)
 {
@@ -296,7 +287,7 @@ static ToolContext app_tool_context(Application* app)
 /**
  * @brief Decide whether pointer input should be blocked from canvas tools.
  * @param app [in] Application state.
- * @param screen_pos [in] 当前光标屏幕坐标。
+ * @param screen_pos [in] Current cursor screen coordinate.
  * @return Non-zero when UI interaction or non-canvas regions should consume input.
  *
  * Why:
@@ -318,10 +309,9 @@ static int app_pointer_blocks_canvas(const Application* app, Vec2 screen_pos)
 }
 
 /**
- * @brief app_sync_tool_pointer_anchor 函数。
- *
- * @param app 参数 `app`。
- * @return 无。
+ * @brief Sync the tool pointer anchor to the current cursor position.
+ * @param app Application instance.
+ * @return No return value.
  */
 static void app_sync_tool_pointer_anchor(Application* app)
 {
@@ -335,10 +325,9 @@ static void app_sync_tool_pointer_anchor(Application* app)
 }
 
 /**
- * @brief app_sync_canvas_boundary 函数。
- *
- * @param app 参数 `app`。
- * @return 无。
+ * @brief Sync canvas boundary state based on cursor position.
+ * @param app Application instance.
+ * @return No return value.
  */
 static void app_sync_canvas_boundary(Application* app)
 {
@@ -356,10 +345,9 @@ static void app_sync_canvas_boundary(Application* app)
 }
 
 /**
- * @brief update_canvas_viewport 函数。
- *
- * @param app 参数 `app`。
- * @return 无。
+ * @brief Update the canvas viewport from UI layout or window size.
+ * @param app Application instance.
+ * @return No return value.
  */
 static void update_canvas_viewport(Application* app)
 {
@@ -398,13 +386,12 @@ static void update_canvas_viewport(Application* app)
 }
 
 /**
- * @brief make_tool_event 函数。
- *
- * @param app 参数 `app`。
- * @param button 参数 `button`。
- * @param mods 参数 `mods`。
- * @param wheel_y 参数 `wheel_y`。
- * @return 函数返回值。
+ * @brief Construct a tool event from the current input state.
+ * @param app Application instance.
+ * @param button Mouse button number.
+ * @param mods Modifier key mask.
+ * @param wheel_y Scroll wheel Y delta.
+ * @return Tool event structure.
  */
 static ToolEvent make_tool_event(Application* app, int button, int mods, float wheel_y)
 {
@@ -420,12 +407,11 @@ static ToolEvent make_tool_event(Application* app, int button, int mods, float w
 }
 
 /**
- * @brief framebuffer_size_callback 函数。
- *
- * @param handle 参数 `handle`。
- * @param width 参数 `width`。
- * @param height 参数 `height`。
- * @return 无。
+ * @brief GLFW framebuffer size callback.
+ * @param handle GLFW window handle.
+ * @param width New width in pixels.
+ * @param height New height in pixels.
+ * @return No return value.
  */
 static void framebuffer_size_callback(GLFWwindow* handle, int width, int height)
 {
@@ -440,12 +426,11 @@ static void framebuffer_size_callback(GLFWwindow* handle, int width, int height)
 }
 
 /**
- * @brief cursor_pos_callback 函数。
- *
- * @param handle 参数 `handle`。
- * @param xpos 参数 `xpos`。
- * @param ypos 参数 `ypos`。
- * @return 无。
+ * @brief GLFW cursor position callback.
+ * @param handle GLFW window handle.
+ * @param xpos Cursor X position.
+ * @param ypos Cursor Y position.
+ * @return No return value.
  */
 static void cursor_pos_callback(GLFWwindow* handle, double xpos, double ypos)
 {
@@ -472,13 +457,12 @@ static void cursor_pos_callback(GLFWwindow* handle, double xpos, double ypos)
 }
 
 /**
- * @brief mouse_button_callback 函数。
- *
- * @param handle 参数 `handle`。
- * @param button 参数 `button`。
- * @param action 参数 `action`。
- * @param mods 参数 `mods`。
- * @return 无。
+ * @brief GLFW mouse button callback.
+ * @param handle GLFW window handle.
+ * @param button Mouse button.
+ * @param action Press/release.
+ * @param mods Modifier keys.
+ * @return No return value.
  */
 static void mouse_button_callback(GLFWwindow* handle, int button, int action, int mods)
 {
@@ -588,12 +572,11 @@ static void key_callback(GLFWwindow* handle, int key, int scancode, int action, 
 }
 
 /**
- * @brief scroll_callback 函数。
- *
- * @param handle 参数 `handle`。
- * @param xoffset 参数 `xoffset`。
- * @param yoffset 参数 `yoffset`。
- * @return 无。
+ * @brief GLFW scroll callback.
+ * @param handle GLFW window handle.
+ * @param xoffset Scroll X delta (unused).
+ * @param yoffset Scroll Y delta.
+ * @return No return value.
  */
 static void scroll_callback(GLFWwindow* handle, double xoffset, double yoffset)
 {
@@ -715,10 +698,8 @@ static void app_shutdown(Application* app)
  */
 
 /**
- * @brief app_run 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief GLDraw application entry point.
+ * @return `0` on normal shutdown, `-1` on fatal startup failure.
  */
 int app_run(void)
 {

--- a/src/canvas/canvas_view.c
+++ b/src/canvas/canvas_view.c
@@ -16,7 +16,12 @@
 
 #include <stddef.h>
 
-/** Return current canonical viewport state with safe defaults for invalid input. */
+/**
+ * @brief canvas_view_state 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @return 函数返回值。
+ */
 static CanvasViewportState canvas_view_state(const CanvasView* canvas)
 {
     CanvasViewportState state;
@@ -38,7 +43,13 @@ static CanvasViewportState canvas_view_state(const CanvasView* canvas)
     return state;
 }
 
-/** Transform world point to screen coordinates. Complexity: `O(1)`. */
+/**
+ * @brief canvas_viewport_world_to_screen 函数。
+ *
+ * @param state 参数 `state`。
+ * @param world 参数 `world`。
+ * @return 函数返回值。
+ */
 static Vec2 canvas_viewport_world_to_screen(const CanvasViewportState* state, Vec2 world)
 {
     Vec2 screen = {0.0f, 0.0f};
@@ -52,7 +63,13 @@ static Vec2 canvas_viewport_world_to_screen(const CanvasViewportState* state, Ve
     return screen;
 }
 
-/** Transform screen point to world coordinates. Complexity: `O(1)`. */
+/**
+ * @brief canvas_viewport_screen_to_world 函数。
+ *
+ * @param state 参数 `state`。
+ * @param screen 参数 `screen`。
+ * @return 函数返回值。
+ */
 static Vec2 canvas_viewport_screen_to_world(const CanvasViewportState* state, Vec2 screen)
 {
     Vec2 world = {0.0f, 0.0f};
@@ -66,7 +83,13 @@ static Vec2 canvas_viewport_screen_to_world(const CanvasViewportState* state, Ve
     return world;
 }
 
-/** Pan center by screen delta while preserving zoom mapping. Complexity: `O(1)`. */
+/**
+ * @brief canvas_viewport_pan_screen_delta 函数。
+ *
+ * @param state 参数 `state`。
+ * @param delta_screen 参数 `delta_screen`。
+ * @return 无。
+ */
 static void canvas_viewport_pan_screen_delta(CanvasViewportState* state, Vec2 delta_screen)
 {
     if (!state || state->zoom <= 0.0f) {
@@ -105,7 +128,12 @@ static void canvas_viewport_zoom_at_screen_point(CanvasViewportState* state, flo
     state->center = vec2_add(state->center, vec2_sub(before, after));
 }
 
-/** Compute visible world-space rectangle from viewport and zoom. Complexity: `O(1)`. */
+/**
+ * @brief canvas_viewport_visible_world_rect 函数。
+ *
+ * @param state 参数 `state`。
+ * @return 函数返回值。
+ */
 static RectF canvas_viewport_visible_world_rect(const CanvasViewportState* state)
 {
     RectF rect = {0.0f, 0.0f, 0.0f, 0.0f};
@@ -121,7 +149,14 @@ static RectF canvas_viewport_visible_world_rect(const CanvasViewportState* state
     return rect;
 }
 
-/** Initialize canvas defaults and bind document. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_init 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param document 参数 `document`。
+ * @param viewport 参数 `viewport`。
+ * @return 无。
+ */
 void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport)
 {
     if (!canvas) {
@@ -139,7 +174,13 @@ void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport)
     canvas->background.a = 1.0f;
 }
 
-/** Rebind document pointer. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_set_document 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param document 参数 `document`。
+ * @return 无。
+ */
 void canvas_view_set_document(CanvasView* canvas, Document* document)
 {
     if (canvas) {
@@ -147,7 +188,13 @@ void canvas_view_set_document(CanvasView* canvas, Document* document)
     }
 }
 
-/** Set viewport rectangle. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_set_viewport 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param viewport 参数 `viewport`。
+ * @return 无。
+ */
 void canvas_view_set_viewport(CanvasView* canvas, RectF viewport)
 {
     if (!canvas) {
@@ -157,7 +204,13 @@ void canvas_view_set_viewport(CanvasView* canvas, RectF viewport)
     canvas->viewport_state.viewport = viewport;
 }
 
-/** Set world center. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_set_center 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param center 参数 `center`。
+ * @return 无。
+ */
 void canvas_view_set_center(CanvasView* canvas, Vec2 center)
 {
     if (!canvas) {
@@ -167,7 +220,13 @@ void canvas_view_set_center(CanvasView* canvas, Vec2 center)
     canvas->viewport_state.center = center;
 }
 
-/** Set zoom with clamp. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_set_zoom 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param zoom 参数 `zoom`。
+ * @return 无。
+ */
 void canvas_view_set_zoom(CanvasView* canvas, float zoom)
 {
     if (!canvas) {
@@ -177,7 +236,14 @@ void canvas_view_set_zoom(CanvasView* canvas, float zoom)
     canvas->viewport_state.zoom = clampf(zoom, 0.1f, 12.0f);
 }
 
-/** Set center and zoom together. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_set_center_zoom 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param center 参数 `center`。
+ * @param zoom 参数 `zoom`。
+ * @return 无。
+ */
 void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom)
 {
     if (!canvas) {
@@ -188,39 +254,72 @@ void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom)
     canvas->viewport_state.zoom = clampf(zoom, 0.1f, 12.0f);
 }
 
-/** Return viewport rectangle. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_viewport 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @return 函数返回值。
+ */
 RectF canvas_view_viewport(const CanvasView* canvas)
 {
     return canvas_view_state(canvas).viewport;
 }
 
-/** Return world center. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_center 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @return 函数返回值。
+ */
 Vec2 canvas_view_center(const CanvasView* canvas)
 {
     return canvas_view_state(canvas).center;
 }
 
-/** Return zoom factor. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_zoom 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @return 函数返回值。
+ */
 float canvas_view_zoom(const CanvasView* canvas)
 {
     return canvas_view_state(canvas).zoom;
 }
 
-/** Public world->screen conversion wrapper. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_world_to_screen 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param world 参数 `world`。
+ * @return 函数返回值。
+ */
 Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world)
 {
     CanvasViewportState state = canvas_view_state(canvas);
     return canvas_viewport_world_to_screen(&state, world);
 }
 
-/** Public screen->world conversion wrapper. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_screen_to_world 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param screen 参数 `screen`。
+ * @return 函数返回值。
+ */
 Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen)
 {
     CanvasViewportState state = canvas_view_state(canvas);
     return canvas_viewport_screen_to_world(&state, screen);
 }
 
-/** Pan camera from screen delta. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_pan_screen_delta 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param delta_screen 参数 `delta_screen`。
+ * @return 无。
+ */
 void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen)
 {
     CanvasViewportState state;
@@ -234,7 +333,14 @@ void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen)
     canvas->viewport_state = state;
 }
 
-/** Zoom camera around cursor/specified anchor. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_zoom_at_screen_point 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param factor 参数 `factor`。
+ * @param screen_anchor 参数 `screen_anchor`。
+ * @return 无。
+ */
 void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 screen_anchor)
 {
     CanvasViewportState state;
@@ -248,7 +354,13 @@ void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 scr
     canvas->viewport_state = state;
 }
 
-/** Convert pixel tolerance to world units based on zoom. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_world_tolerance_for_pixels 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param pixels 参数 `pixels`。
+ * @return 函数返回值。
+ */
 float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pixels)
 {
     float zoom = canvas_view_zoom(canvas);
@@ -260,7 +372,12 @@ float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pix
     return pixels / zoom;
 }
 
-/** Get visible world rectangle. Complexity: `O(1)`. */
+/**
+ * @brief canvas_view_visible_world_rect 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @return 函数返回值。
+ */
 RectF canvas_view_visible_world_rect(const CanvasView* canvas)
 {
     CanvasViewportState state = canvas_view_state(canvas);
@@ -275,6 +392,15 @@ RectF canvas_view_visible_world_rect(const CanvasView* canvas)
  * - Newer objects are drawn later and visually on top, so picking scans from end.
  *
  * Time complexity: `O(n)` where `n` is document object count.
+ */
+
+/**
+ * @brief canvas_view_pick_object 函数。
+ *
+ * @param canvas 参数 `canvas`。
+ * @param screen_point 参数 `screen_point`。
+ * @param tolerance_pixels 参数 `tolerance_pixels`。
+ * @return 函数返回值。
  */
 GraphicObject* canvas_view_pick_object(const CanvasView* canvas, Vec2 screen_point, float tolerance_pixels)
 {

--- a/src/canvas/canvas_view.c
+++ b/src/canvas/canvas_view.c
@@ -17,10 +17,9 @@
 #include <stddef.h>
 
 /**
- * @brief canvas_view_state 函数。
- *
- * @param canvas 参数 `canvas`。
- * @return 函数返回值。
+ * @brief Gets the current viewport state from canvas.
+ * @param canvas Canvas view instance.
+ * @return Current viewport state.
  */
 static CanvasViewportState canvas_view_state(const CanvasView* canvas)
 {
@@ -44,11 +43,10 @@ static CanvasViewportState canvas_view_state(const CanvasView* canvas)
 }
 
 /**
- * @brief canvas_viewport_world_to_screen 函数。
- *
- * @param state 参数 `state`。
- * @param world 参数 `world`。
- * @return 函数返回值。
+ * @brief Converts world coordinates to screen coordinates.
+ * @param state Viewport state.
+ * @param world World coordinate point.
+ * @return Screen coordinate point.
  */
 static Vec2 canvas_viewport_world_to_screen(const CanvasViewportState* state, Vec2 world)
 {
@@ -64,11 +62,10 @@ static Vec2 canvas_viewport_world_to_screen(const CanvasViewportState* state, Ve
 }
 
 /**
- * @brief canvas_viewport_screen_to_world 函数。
- *
- * @param state 参数 `state`。
- * @param screen 参数 `screen`。
- * @return 函数返回值。
+ * @brief Converts screen coordinates to world coordinates.
+ * @param state Viewport state.
+ * @param screen Screen coordinate point.
+ * @return World coordinate point.
  */
 static Vec2 canvas_viewport_screen_to_world(const CanvasViewportState* state, Vec2 screen)
 {
@@ -84,11 +81,10 @@ static Vec2 canvas_viewport_screen_to_world(const CanvasViewportState* state, Ve
 }
 
 /**
- * @brief canvas_viewport_pan_screen_delta 函数。
- *
- * @param state 参数 `state`。
- * @param delta_screen 参数 `delta_screen`。
- * @return 无。
+ * @brief Pans the viewport by a screen-space delta.
+ * @param state Viewport state.
+ * @param delta_screen Screen space delta.
+ * @return None.
  */
 static void canvas_viewport_pan_screen_delta(CanvasViewportState* state, Vec2 delta_screen)
 {
@@ -129,10 +125,9 @@ static void canvas_viewport_zoom_at_screen_point(CanvasViewportState* state, flo
 }
 
 /**
- * @brief canvas_viewport_visible_world_rect 函数。
- *
- * @param state 参数 `state`。
- * @return 函数返回值。
+ * @brief Computes the visible world rectangle.
+ * @param state Viewport state.
+ * @return Visible world rectangle.
  */
 static RectF canvas_viewport_visible_world_rect(const CanvasViewportState* state)
 {
@@ -150,12 +145,11 @@ static RectF canvas_viewport_visible_world_rect(const CanvasViewportState* state
 }
 
 /**
- * @brief canvas_view_init 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param document 参数 `document`。
- * @param viewport 参数 `viewport`。
- * @return 无。
+ * @brief Initializes a canvas view.
+ * @param canvas Canvas view to initialize.
+ * @param document Document to reference.
+ * @param viewport Initial viewport rectangle.
+ * @return None.
  */
 void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport)
 {
@@ -175,11 +169,10 @@ void canvas_view_init(CanvasView* canvas, Document* document, RectF viewport)
 }
 
 /**
- * @brief canvas_view_set_document 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param document 参数 `document`。
- * @return 无。
+ * @brief Sets the document reference.
+ * @param canvas Canvas view instance.
+ * @param document Document to reference.
+ * @return None.
  */
 void canvas_view_set_document(CanvasView* canvas, Document* document)
 {
@@ -189,11 +182,10 @@ void canvas_view_set_document(CanvasView* canvas, Document* document)
 }
 
 /**
- * @brief canvas_view_set_viewport 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param viewport 参数 `viewport`。
- * @return 无。
+ * @brief Sets the viewport rectangle.
+ * @param canvas Canvas view instance.
+ * @param viewport New viewport rectangle.
+ * @return None.
  */
 void canvas_view_set_viewport(CanvasView* canvas, RectF viewport)
 {
@@ -205,11 +197,10 @@ void canvas_view_set_viewport(CanvasView* canvas, RectF viewport)
 }
 
 /**
- * @brief canvas_view_set_center 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param center 参数 `center`。
- * @return 无。
+ * @brief Sets the viewport center point.
+ * @param canvas Canvas view instance.
+ * @param center New center point.
+ * @return None.
  */
 void canvas_view_set_center(CanvasView* canvas, Vec2 center)
 {
@@ -221,11 +212,10 @@ void canvas_view_set_center(CanvasView* canvas, Vec2 center)
 }
 
 /**
- * @brief canvas_view_set_zoom 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param zoom 参数 `zoom`。
- * @return 无。
+ * @brief Sets the zoom level.
+ * @param canvas Canvas view instance.
+ * @param zoom New zoom level.
+ * @return None.
  */
 void canvas_view_set_zoom(CanvasView* canvas, float zoom)
 {
@@ -237,12 +227,11 @@ void canvas_view_set_zoom(CanvasView* canvas, float zoom)
 }
 
 /**
- * @brief canvas_view_set_center_zoom 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param center 参数 `center`。
- * @param zoom 参数 `zoom`。
- * @return 无。
+ * @brief Sets center and zoom atomically.
+ * @param canvas Canvas view instance.
+ * @param center New center point.
+ * @param zoom New zoom level.
+ * @return None.
  */
 void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom)
 {
@@ -255,10 +244,9 @@ void canvas_view_set_center_zoom(CanvasView* canvas, Vec2 center, float zoom)
 }
 
 /**
- * @brief canvas_view_viewport 函数。
- *
- * @param canvas 参数 `canvas`。
- * @return 函数返回值。
+ * @brief Gets the viewport rectangle.
+ * @param canvas Canvas view instance.
+ * @return Viewport rectangle.
  */
 RectF canvas_view_viewport(const CanvasView* canvas)
 {
@@ -266,10 +254,9 @@ RectF canvas_view_viewport(const CanvasView* canvas)
 }
 
 /**
- * @brief canvas_view_center 函数。
- *
- * @param canvas 参数 `canvas`。
- * @return 函数返回值。
+ * @brief Gets the viewport center point.
+ * @param canvas Canvas view instance.
+ * @return Center point.
  */
 Vec2 canvas_view_center(const CanvasView* canvas)
 {
@@ -277,10 +264,9 @@ Vec2 canvas_view_center(const CanvasView* canvas)
 }
 
 /**
- * @brief canvas_view_zoom 函数。
- *
- * @param canvas 参数 `canvas`。
- * @return 函数返回值。
+ * @brief Gets the current zoom level.
+ * @param canvas Canvas view instance.
+ * @return Zoom level.
  */
 float canvas_view_zoom(const CanvasView* canvas)
 {
@@ -288,11 +274,10 @@ float canvas_view_zoom(const CanvasView* canvas)
 }
 
 /**
- * @brief canvas_view_world_to_screen 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param world 参数 `world`。
- * @return 函数返回值。
+ * @brief Converts world coordinates to screen coordinates.
+ * @param canvas Canvas view instance.
+ * @param world World coordinate point.
+ * @return Screen coordinate point.
  */
 Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world)
 {
@@ -301,11 +286,10 @@ Vec2 canvas_view_world_to_screen(const CanvasView* canvas, Vec2 world)
 }
 
 /**
- * @brief canvas_view_screen_to_world 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param screen 参数 `screen`。
- * @return 函数返回值。
+ * @brief Converts screen coordinates to world coordinates.
+ * @param canvas Canvas view instance.
+ * @param screen Screen coordinate point.
+ * @return World coordinate point.
  */
 Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen)
 {
@@ -314,11 +298,10 @@ Vec2 canvas_view_screen_to_world(const CanvasView* canvas, Vec2 screen)
 }
 
 /**
- * @brief canvas_view_pan_screen_delta 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param delta_screen 参数 `delta_screen`。
- * @return 无。
+ * @brief Pans the viewport by a screen-space delta.
+ * @param canvas Canvas view instance.
+ * @param delta_screen Screen space delta.
+ * @return None.
  */
 void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen)
 {
@@ -334,12 +317,11 @@ void canvas_view_pan_screen_delta(CanvasView* canvas, Vec2 delta_screen)
 }
 
 /**
- * @brief canvas_view_zoom_at_screen_point 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param factor 参数 `factor`。
- * @param screen_anchor 参数 `screen_anchor`。
- * @return 无。
+ * @brief Zooms around a screen-space anchor point.
+ * @param canvas Canvas view instance.
+ * @param factor Zoom factor.
+ * @param screen_anchor Anchor point in screen coordinates.
+ * @return None.
  */
 void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 screen_anchor)
 {
@@ -355,11 +337,10 @@ void canvas_view_zoom_at_screen_point(CanvasView* canvas, float factor, Vec2 scr
 }
 
 /**
- * @brief canvas_view_world_tolerance_for_pixels 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param pixels 参数 `pixels`。
- * @return 函数返回值。
+ * @brief Converts pixel tolerance to world-space tolerance.
+ * @param canvas Canvas view instance.
+ * @param pixels Pixel tolerance.
+ * @return World-space tolerance.
  */
 float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pixels)
 {
@@ -373,10 +354,9 @@ float canvas_view_world_tolerance_for_pixels(const CanvasView* canvas, float pix
 }
 
 /**
- * @brief canvas_view_visible_world_rect 函数。
- *
- * @param canvas 参数 `canvas`。
- * @return 函数返回值。
+ * @brief Gets the visible world rectangle.
+ * @param canvas Canvas view instance.
+ * @return Visible world rectangle.
  */
 RectF canvas_view_visible_world_rect(const CanvasView* canvas)
 {
@@ -395,12 +375,11 @@ RectF canvas_view_visible_world_rect(const CanvasView* canvas)
  */
 
 /**
- * @brief canvas_view_pick_object 函数。
- *
- * @param canvas 参数 `canvas`。
- * @param screen_point 参数 `screen_point`。
- * @param tolerance_pixels 参数 `tolerance_pixels`。
- * @return 函数返回值。
+ * @brief Picks the top-most object under a screen point.
+ * @param canvas Canvas view instance.
+ * @param screen_point Point in screen coordinates.
+ * @param tolerance_pixels Pick tolerance in pixels.
+ * @return Pointer to hit object or NULL.
  */
 GraphicObject* canvas_view_pick_object(const CanvasView* canvas, Vec2 screen_point, float tolerance_pixels)
 {

--- a/src/document/document.c
+++ b/src/document/document.c
@@ -15,10 +15,9 @@
 #include <string.h>
 
 /**
- * @brief document_init 函数。
- *
- * @param document 参数 `document`。
- * @return 无。
+ * @brief Initializes a document.
+ * @param document Document to initialize.
+ * @return None.
  */
 void document_init(Document* document)
 {
@@ -32,10 +31,9 @@ void document_init(Document* document)
 }
 
 /**
- * @brief document_shutdown 函数。
- *
- * @param document 参数 `document`。
- * @return 无。
+ * @brief Shuts down a document and frees resources.
+ * @param document Document to shut down.
+ * @return None.
  */
 void document_shutdown(Document* document)
 {
@@ -56,10 +54,9 @@ void document_shutdown(Document* document)
 }
 
 /**
- * @brief document_reset 函数。
- *
- * @param document 参数 `document`。
- * @return 无。
+ * @brief Resets a document to initial empty state.
+ * @param document Document to reset.
+ * @return None.
  */
 void document_reset(Document* document)
 {
@@ -81,11 +78,10 @@ void document_reset(Document* document)
 }
 
 /**
- * @brief document_add_object 函数。
- *
- * @param document 参数 `document`。
- * @param object 参数 `object`。
- * @return 函数返回值。
+ * @brief Adds an object to the document.
+ * @param document Document instance.
+ * @param object Object to add.
+ * @return 1 on success, 0 on failure.
  */
 int document_add_object(Document* document, GraphicObject* object)
 {
@@ -100,12 +96,11 @@ int document_add_object(Document* document, GraphicObject* object)
 }
 
 /**
- * @brief document_append_object_with_id 函数。
- *
- * @param document 参数 `document`。
- * @param object 参数 `object`。
- * @param id 参数 `id`。
- * @return 函数返回值。
+ * @brief Appends an object with a specific ID.
+ * @param document Document instance.
+ * @param object Object to append.
+ * @param id Desired object ID.
+ * @return 1 on success, 0 on failure.
  */
 int document_append_object_with_id(Document* document, GraphicObject* object, ObjectId id)
 {
@@ -127,11 +122,10 @@ int document_append_object_with_id(Document* document, GraphicObject* object, Ob
 }
 
 /**
- * @brief document_find_object 函数。
- *
- * @param document 参数 `document`。
- * @param id 参数 `id`。
- * @return 函数返回值。
+ * @brief Finds an object by ID.
+ * @param document Document instance.
+ * @param id Object ID to find.
+ * @return Pointer to object or NULL.
  */
 GraphicObject* document_find_object(const Document* document, ObjectId id)
 {
@@ -151,11 +145,10 @@ GraphicObject* document_find_object(const Document* document, ObjectId id)
 }
 
 /**
- * @brief document_get_object_at 函数。
- *
- * @param document 参数 `document`。
- * @param index 参数 `index`。
- * @return 函数返回值。
+ * @brief Gets an object at a specific index.
+ * @param document Document instance.
+ * @param index Object index.
+ * @return Pointer to object or NULL.
  */
 GraphicObject* document_get_object_at(const Document* document, int index)
 {
@@ -166,11 +159,10 @@ GraphicObject* document_get_object_at(const Document* document, int index)
 }
 
 /**
- * @brief document_selection_contains 函数。
- *
- * @param document 参数 `document`。
- * @param id 参数 `id`。
- * @return 函数返回值。
+ * @brief Checks if an object is in the selection.
+ * @param document Document instance.
+ * @param id Object ID to check.
+ * @return 1 if selected, 0 otherwise.
  */
 int document_selection_contains(const Document* document, ObjectId id)
 {
@@ -190,10 +182,9 @@ int document_selection_contains(const Document* document, ObjectId id)
 }
 
 /**
- * @brief document_clear_selection 函数。
- *
- * @param document 参数 `document`。
- * @return 无。
+ * @brief Clears the selection.
+ * @param document Document instance.
+ * @return None.
  */
 void document_clear_selection(Document* document)
 {
@@ -203,11 +194,10 @@ void document_clear_selection(Document* document)
 }
 
 /**
- * @brief document_selection_add 函数。
- *
- * @param document 参数 `document`。
- * @param id 参数 `id`。
- * @return 函数返回值。
+ * @brief Adds an object to the selection.
+ * @param document Document instance.
+ * @param id Object ID to add.
+ * @return 1 on success, 0 on failure.
  */
 int document_selection_add(Document* document, ObjectId id)
 {
@@ -228,11 +218,10 @@ int document_selection_add(Document* document, ObjectId id)
 }
 
 /**
- * @brief document_selection_remove 函数。
- *
- * @param document 参数 `document`。
- * @param id 参数 `id`。
- * @return 无。
+ * @brief Removes an object from the selection.
+ * @param document Document instance.
+ * @param id Object ID to remove.
+ * @return None.
  */
 void document_selection_remove(Document* document, ObjectId id)
 {
@@ -255,11 +244,10 @@ void document_selection_remove(Document* document, ObjectId id)
 }
 
 /**
- * @brief document_selection_toggle 函数。
- *
- * @param document 参数 `document`。
- * @param id 参数 `id`。
- * @return 无。
+ * @brief Toggles an object in the selection.
+ * @param document Document instance.
+ * @param id Object ID to toggle.
+ * @return None.
  */
 void document_selection_toggle(Document* document, ObjectId id)
 {
@@ -275,10 +263,9 @@ void document_selection_toggle(Document* document, ObjectId id)
 }
 
 /**
- * @brief document_primary_selection 函数。
- *
- * @param document 参数 `document`。
- * @return 函数返回值。
+ * @brief Gets the primary (first) selected object.
+ * @param document Document instance.
+ * @return Pointer to primary selected object or NULL.
  */
 GraphicObject* document_primary_selection(const Document* document)
 {
@@ -289,11 +276,10 @@ GraphicObject* document_primary_selection(const Document* document)
 }
 
 /**
- * @brief document_remove_object 函数。
- *
- * @param document 参数 `document`。
- * @param id 参数 `id`。
- * @return 函数返回值。
+ * @brief Removes an object from the document.
+ * @param document Document instance.
+ * @param id Object ID to remove.
+ * @return 1 on success, 0 on failure.
  */
 int document_remove_object(Document* document, ObjectId id)
 {
@@ -322,10 +308,9 @@ int document_remove_object(Document* document, ObjectId id)
 }
 
 /**
- * @brief document_delete_selection 函数。
- *
- * @param document 参数 `document`。
- * @return 无。
+ * @brief Deletes all selected objects.
+ * @param document Document instance.
+ * @return None.
  */
 void document_delete_selection(Document* document)
 {
@@ -350,10 +335,9 @@ void document_delete_selection(Document* document)
 }
 
 /**
- * @brief document_touch 函数。
- *
- * @param document 参数 `document`。
- * @return 无。
+ * @brief Increments the document revision.
+ * @param document Document instance.
+ * @return None.
  */
 void document_touch(Document* document)
 {
@@ -363,10 +347,9 @@ void document_touch(Document* document)
 }
 
 /**
- * @brief document_max_id 函数。
- *
- * @param document 参数 `document`。
- * @return 函数返回值。
+ * @brief Gets the maximum object ID in the document.
+ * @param document Document instance.
+ * @return Maximum object ID.
  */
 ObjectId document_max_id(const Document* document)
 {

--- a/src/document/document.c
+++ b/src/document/document.c
@@ -14,7 +14,12 @@
 
 #include <string.h>
 
-/** Initialize document fields to empty defaults. Complexity: `O(1)`. */
+/**
+ * @brief document_init 函数。
+ *
+ * @param document 参数 `document`。
+ * @return 无。
+ */
 void document_init(Document* document)
 {
     if (!document) {
@@ -26,7 +31,12 @@ void document_init(Document* document)
     document->revision = 1;
 }
 
-/** Destroy all objects and clear selection while preserving struct storage. Complexity: `O(n)`. */
+/**
+ * @brief document_shutdown 函数。
+ *
+ * @param document 参数 `document`。
+ * @return 无。
+ */
 void document_shutdown(Document* document)
 {
     int i = 0;
@@ -45,7 +55,12 @@ void document_shutdown(Document* document)
     document->revision++;
 }
 
-/** Reset document to pristine empty state. Complexity: `O(n)`. */
+/**
+ * @brief document_reset 函数。
+ *
+ * @param document 参数 `document`。
+ * @return 无。
+ */
 void document_reset(Document* document)
 {
     int i = 0;
@@ -65,7 +80,13 @@ void document_reset(Document* document)
     document->revision = 1;
 }
 
-/** Append object with auto-assigned ID. Complexity: `O(1)`. */
+/**
+ * @brief document_add_object 函数。
+ *
+ * @param document 参数 `document`。
+ * @param object 参数 `object`。
+ * @return 函数返回值。
+ */
 int document_add_object(Document* document, GraphicObject* object)
 {
     if (!document || !object || document->count >= DOCUMENT_MAX_OBJECTS) {
@@ -78,7 +99,14 @@ int document_add_object(Document* document, GraphicObject* object)
     return 1;
 }
 
-/** Append object with explicit ID and duplicate check. Complexity: `O(n)`. */
+/**
+ * @brief document_append_object_with_id 函数。
+ *
+ * @param document 参数 `document`。
+ * @param object 参数 `object`。
+ * @param id 参数 `id`。
+ * @return 函数返回值。
+ */
 int document_append_object_with_id(Document* document, GraphicObject* object, ObjectId id)
 {
     if (!document || !object || id == 0 || document->count >= DOCUMENT_MAX_OBJECTS) {
@@ -98,7 +126,13 @@ int document_append_object_with_id(Document* document, GraphicObject* object, Ob
     return 1;
 }
 
-/** Find object by ID by linear scan. Complexity: `O(n)`. */
+/**
+ * @brief document_find_object 函数。
+ *
+ * @param document 参数 `document`。
+ * @param id 参数 `id`。
+ * @return 函数返回值。
+ */
 GraphicObject* document_find_object(const Document* document, ObjectId id)
 {
     int i = 0;
@@ -116,7 +150,13 @@ GraphicObject* document_find_object(const Document* document, ObjectId id)
     return NULL;
 }
 
-/** Access object by index. Complexity: `O(1)`. */
+/**
+ * @brief document_get_object_at 函数。
+ *
+ * @param document 参数 `document`。
+ * @param index 参数 `index`。
+ * @return 函数返回值。
+ */
 GraphicObject* document_get_object_at(const Document* document, int index)
 {
     if (!document || index < 0 || index >= document->count) {
@@ -125,7 +165,13 @@ GraphicObject* document_get_object_at(const Document* document, int index)
     return document->objects[index];
 }
 
-/** Check whether ID is in selection set. Complexity: `O(s)`. */
+/**
+ * @brief document_selection_contains 函数。
+ *
+ * @param document 参数 `document`。
+ * @param id 参数 `id`。
+ * @return 函数返回值。
+ */
 int document_selection_contains(const Document* document, ObjectId id)
 {
     int i = 0;
@@ -143,7 +189,12 @@ int document_selection_contains(const Document* document, ObjectId id)
     return 0;
 }
 
-/** Clear selection count only (IDs remain irrelevant beyond count). Complexity: `O(1)`. */
+/**
+ * @brief document_clear_selection 函数。
+ *
+ * @param document 参数 `document`。
+ * @return 无。
+ */
 void document_clear_selection(Document* document)
 {
     if (document) {
@@ -151,7 +202,13 @@ void document_clear_selection(Document* document)
     }
 }
 
-/** Add ID to selection if missing and capacity permits. Complexity: `O(s)`. */
+/**
+ * @brief document_selection_add 函数。
+ *
+ * @param document 参数 `document`。
+ * @param id 参数 `id`。
+ * @return 函数返回值。
+ */
 int document_selection_add(Document* document, ObjectId id)
 {
     if (!document || id == 0) {
@@ -170,7 +227,13 @@ int document_selection_add(Document* document, ObjectId id)
     return 1;
 }
 
-/** Remove one ID from selection and compact array. Complexity: `O(s)`. */
+/**
+ * @brief document_selection_remove 函数。
+ *
+ * @param document 参数 `document`。
+ * @param id 参数 `id`。
+ * @return 无。
+ */
 void document_selection_remove(Document* document, ObjectId id)
 {
     int i = 0;
@@ -191,7 +254,13 @@ void document_selection_remove(Document* document, ObjectId id)
     }
 }
 
-/** Toggle selection membership for ID. Complexity: `O(s)`. */
+/**
+ * @brief document_selection_toggle 函数。
+ *
+ * @param document 参数 `document`。
+ * @param id 参数 `id`。
+ * @return 无。
+ */
 void document_selection_toggle(Document* document, ObjectId id)
 {
     if (!document) {
@@ -205,7 +274,12 @@ void document_selection_toggle(Document* document, ObjectId id)
     }
 }
 
-/** Resolve first selected object. Complexity: `O(n)` due to ID lookup. */
+/**
+ * @brief document_primary_selection 函数。
+ *
+ * @param document 参数 `document`。
+ * @return 函数返回值。
+ */
 GraphicObject* document_primary_selection(const Document* document)
 {
     if (!document || document->selection.count <= 0) {
@@ -214,7 +288,13 @@ GraphicObject* document_primary_selection(const Document* document)
     return document_find_object(document, document->selection.ids[0]);
 }
 
-/** Remove object by ID, destroy it, and compact object array. Complexity: `O(n)`. */
+/**
+ * @brief document_remove_object 函数。
+ *
+ * @param document 参数 `document`。
+ * @param id 参数 `id`。
+ * @return 函数返回值。
+ */
 int document_remove_object(Document* document, ObjectId id)
 {
     int i = 0;
@@ -242,13 +322,10 @@ int document_remove_object(Document* document, ObjectId id)
 }
 
 /**
- * @brief Delete all currently selected objects.
+ * @brief document_delete_selection 函数。
  *
- * Why copy IDs first:
- * - Removing objects mutates selection/order, so direct iteration over
- *   `selection.ids` while deleting would skip or misread entries.
- *
- * Complexity: up to `O(s*n)`.
+ * @param document 参数 `document`。
+ * @return 无。
  */
 void document_delete_selection(Document* document)
 {
@@ -272,7 +349,12 @@ void document_delete_selection(Document* document)
     document_clear_selection(document);
 }
 
-/** Increment document revision marker. Complexity: `O(1)`. */
+/**
+ * @brief document_touch 函数。
+ *
+ * @param document 参数 `document`。
+ * @return 无。
+ */
 void document_touch(Document* document)
 {
     if (document) {
@@ -280,7 +362,12 @@ void document_touch(Document* document)
     }
 }
 
-/** Return max object ID currently present. Complexity: `O(n)`. */
+/**
+ * @brief document_max_id 函数。
+ *
+ * @param document 参数 `document`。
+ * @return 函数返回值。
+ */
 ObjectId document_max_id(const Document* document)
 {
     ObjectId max_id = 0;

--- a/src/document/history.c
+++ b/src/document/history.c
@@ -58,7 +58,12 @@ static HistoryInternals* g_history_internals_head = NULL;
 static void history_entry_free(DocumentHistoryEntry* entry);
 static void history_entry_reset(DocumentHistoryEntry* entry);
 
-/** Find internal sidecar metadata for one history instance. */
+/**
+ * @brief history_find_internals 函数。
+ *
+ * @param history 参数 `history`。
+ * @return 函数返回值。
+ */
 static HistoryInternals* history_find_internals(const DocumentHistory* history)
 {
     HistoryInternals* cursor = g_history_internals_head;
@@ -71,7 +76,12 @@ static HistoryInternals* history_find_internals(const DocumentHistory* history)
     return NULL;
 }
 
-/** Free sidecar metadata arrays for one history instance. */
+/**
+ * @brief history_free_internals 函数。
+ *
+ * @param internals 参数 `internals`。
+ * @return 无。
+ */
 static void history_free_internals(HistoryInternals* internals)
 {
     if (!internals) {
@@ -92,7 +102,12 @@ static void history_free_internals(HistoryInternals* internals)
     internals->redo_transform_edits = NULL;
 }
 
-/** Remove and destroy sidecar metadata for history. */
+/**
+ * @brief history_unregister_internals 函数。
+ *
+ * @param history 参数 `history`。
+ * @return 无。
+ */
 static void history_unregister_internals(DocumentHistory* history)
 {
     HistoryInternals* prev = NULL;
@@ -114,7 +129,12 @@ static void history_unregister_internals(DocumentHistory* history)
     }
 }
 
-/** Allocate and register sidecar metadata arrays for history. */
+/**
+ * @brief history_register_internals 函数。
+ *
+ * @param history 参数 `history`。
+ * @return 函数返回值。
+ */
 static int history_register_internals(DocumentHistory* history)
 {
     HistoryInternals* internals = NULL;
@@ -153,13 +173,24 @@ static int history_register_internals(DocumentHistory* history)
     return 1;
 }
 
-/** Get sidecar metadata for history. */
+/**
+ * @brief history_get_internals 函数。
+ *
+ * @param history 参数 `history`。
+ * @return 函数返回值。
+ */
 static HistoryInternals* history_get_internals(const DocumentHistory* history)
 {
     return history_find_internals(history);
 }
 
-/** Move snapshot ownership from `src` to `dst`. Complexity: `O(1)`. */
+/**
+ * @brief snapshot_move 函数。
+ *
+ * @param dst 参数 `dst`。
+ * @param src 参数 `src`。
+ * @return 无。
+ */
 static void snapshot_move(DocumentSnapshot* dst, DocumentSnapshot* src)
 {
     document_snapshot_free(dst);
@@ -172,7 +203,13 @@ static void snapshot_move(DocumentSnapshot* dst, DocumentSnapshot* src)
     src->selection.count = 0;
 }
 
-/** Find target object for scalar edit by stable ID. */
+/**
+ * @brief history_find_scalar_object 函数。
+ *
+ * @param document 参数 `document`。
+ * @param id 参数 `id`。
+ * @return 函数返回值。
+ */
 static GraphicObject* history_find_scalar_object(Document* document, ObjectId id)
 {
     if (!document || id == 0) {
@@ -181,7 +218,13 @@ static GraphicObject* history_find_scalar_object(Document* document, ObjectId id
     return document_find_object(document, id);
 }
 
-/** Apply scalar-edit undo by writing previous value to the same object/key. */
+/**
+ * @brief history_apply_scalar_edit_undo 函数。
+ *
+ * @param document 参数 `document`。
+ * @param edit 参数 `edit`。
+ * @return 函数返回值。
+ */
 static int history_apply_scalar_edit_undo(Document* document, const HistoryScalarEdit* edit)
 {
     GraphicObject* object = history_find_scalar_object(document, edit ? edit->object_id : 0);
@@ -196,7 +239,13 @@ static int history_apply_scalar_edit_undo(Document* document, const HistoryScala
     return 1;
 }
 
-/** Apply scalar-edit redo by writing new value to the same object/key. */
+/**
+ * @brief history_apply_scalar_edit_redo 函数。
+ *
+ * @param document 参数 `document`。
+ * @param edit 参数 `edit`。
+ * @return 函数返回值。
+ */
 static int history_apply_scalar_edit_redo(Document* document, const HistoryScalarEdit* edit)
 {
     GraphicObject* object = history_find_scalar_object(document, edit ? edit->object_id : 0);
@@ -211,7 +260,15 @@ static int history_apply_scalar_edit_redo(Document* document, const HistoryScala
     return 1;
 }
 
-/** Apply one transform edit by translating all recorded objects with `delta`. */
+/**
+ * @brief history_apply_transform 函数。
+ *
+ * @param document 参数 `document`。
+ * @param edit 参数 `edit`。
+ * @param delta 参数 `delta`。
+ * @param target_revision 参数 `target_revision`。
+ * @return 函数返回值。
+ */
 static int history_apply_transform(Document* document,
                                    const HistoryTransformEdit* edit,
                                    Vec2 delta,
@@ -235,7 +292,13 @@ static int history_apply_transform(Document* document,
     return 1;
 }
 
-/** Apply transform edit undo (reverse delta). */
+/**
+ * @brief history_apply_transform_edit_undo 函数。
+ *
+ * @param document 参数 `document`。
+ * @param edit 参数 `edit`。
+ * @return 函数返回值。
+ */
 static int history_apply_transform_edit_undo(Document* document, const HistoryTransformEdit* edit)
 {
     Vec2 undo_delta = {0.0f, 0.0f};
@@ -249,7 +312,13 @@ static int history_apply_transform_edit_undo(Document* document, const HistoryTr
     return history_apply_transform(document, edit, undo_delta, edit->revision_before);
 }
 
-/** Apply transform edit redo (forward delta). */
+/**
+ * @brief history_apply_transform_edit_redo 函数。
+ *
+ * @param document 参数 `document`。
+ * @param edit 参数 `edit`。
+ * @return 函数返回值。
+ */
 static int history_apply_transform_edit_redo(Document* document, const HistoryTransformEdit* edit)
 {
     if (!edit) {
@@ -258,7 +327,25 @@ static int history_apply_transform_edit_redo(Document* document, const HistoryTr
     return history_apply_transform(document, edit, edit->delta, edit->revision_after);
 }
 
-/** Push one scalar edit entry to undo stack and clear redo chain. */
+/**
+ * @brief 记录一次标量属性编辑并压入撤销栈。
+ *
+ * 算法步骤：
+ * 1. 构造 `HistoryScalarEdit` 载荷；
+ * 2. 清空 redo 栈（新分支写入）；
+ * 3. 必要时淘汰 undo 栈最旧项；
+ * 4. 将新条目写入 undo 栈尾。
+ *
+ * @param history [in,out] 历史对象。
+ * @param document [in] 当前文档（用于参数合法性校验）。
+ * @param object_id [in] 对象 ID。
+ * @param key [in] 属性键名。
+ * @param before_value [in] 修改前值。
+ * @param after_value [in] 修改后值。
+ * @param revision_before [in] 修改前修订号。
+ * @param revision_after [in] 修改后修订号。
+ * @return 成功返回 `1`，失败返回 `0`。
+ */
 static int history_push_scalar_edit(DocumentHistory* history,
                                     const Document* document,
                                     ObjectId object_id,
@@ -316,7 +403,18 @@ static int history_push_scalar_edit(DocumentHistory* history,
     return 1;
 }
 
-/** Push one transform edit entry to undo stack and clear redo chain. */
+/**
+ * @brief 记录一次平移编辑并压入撤销栈。
+ *
+ * @param history [in,out] 历史对象。
+ * @param document [in] 当前文档。
+ * @param object_ids [in] 参与平移的对象 ID 数组。
+ * @param object_count [in] 对象数量。
+ * @param delta [in] 平移向量。
+ * @param revision_before [in] 修改前修订号。
+ * @param revision_after [in] 修改后修订号。
+ * @return 成功返回 `1`，失败返回 `0`。
+ */
 static int history_push_transform_edit(DocumentHistory* history,
                                        const Document* document,
                                        const ObjectId* object_ids,
@@ -375,14 +473,24 @@ static int history_push_transform_edit(DocumentHistory* history,
     return 1;
 }
 
-/** Free both snapshots in a history entry. Complexity: `O(n_before + n_after)`. */
+/**
+ * @brief history_entry_free 函数。
+ *
+ * @param entry 参数 `entry`。
+ * @return 无。
+ */
 static void history_entry_free(DocumentHistoryEntry* entry)
 {
     document_snapshot_free(&entry->before);
     document_snapshot_free(&entry->after);
 }
 
-/** Reset history entry to empty snapshots. Complexity: `O(1)`. */
+/**
+ * @brief history_entry_reset 函数。
+ *
+ * @param entry 参数 `entry`。
+ * @return 无。
+ */
 static void history_entry_reset(DocumentHistoryEntry* entry)
 {
     if (!entry) {
@@ -393,7 +501,12 @@ static void history_entry_reset(DocumentHistoryEntry* entry)
     document_snapshot_init(&entry->after);
 }
 
-/** Allocate and initialize history entry array. Complexity: `O(capacity)`. */
+/**
+ * @brief history_alloc_entries 函数。
+ *
+ * @param capacity 参数 `capacity`。
+ * @return 函数返回值。
+ */
 static DocumentHistoryEntry* history_alloc_entries(int capacity)
 {
     DocumentHistoryEntry* entries = NULL;
@@ -417,6 +530,8 @@ static DocumentHistoryEntry* history_alloc_entries(int capacity)
 
 /**
  * @brief Replace document contents with deep-cloned snapshot objects.
+ * @param document [in,out] 目标文档。
+ * @param snapshot [in] 快照数据。
  * @return `1` on success, `0` on validation/allocation/clone failure.
  *
  * Risk note:
@@ -469,7 +584,12 @@ static int document_restore_snapshot(Document* document, const DocumentSnapshot*
     return 1;
 }
 
-/** Initialize snapshot to zeroed state. Complexity: `O(1)`. */
+/**
+ * @brief document_snapshot_init 函数。
+ *
+ * @param snapshot 参数 `snapshot`。
+ * @return 无。
+ */
 void document_snapshot_init(DocumentSnapshot* snapshot)
 {
     if (snapshot) {
@@ -477,7 +597,12 @@ void document_snapshot_init(DocumentSnapshot* snapshot)
     }
 }
 
-/** Free heap memory owned by snapshot. Complexity: `O(n)`. */
+/**
+ * @brief document_snapshot_free 函数。
+ *
+ * @param snapshot 参数 `snapshot`。
+ * @return 无。
+ */
 void document_snapshot_free(DocumentSnapshot* snapshot)
 {
     int i = 0;
@@ -498,7 +623,14 @@ void document_snapshot_free(DocumentSnapshot* snapshot)
     snapshot->next_id = 0;
 }
 
-/** Capture deep copy of document into snapshot. Complexity: `O(n)`. */
+/**
+ * @brief 深拷贝文档到快照。
+ * @param snapshot [in,out] 目标快照（原内容会先释放）。
+ * @param document [in] 源文档。
+ * @return 成功返回 `1`，失败返回 `0`。
+ *
+ * @note 拷贝过程按对象逐个 clone，任一失败会回滚已分配内容。
+ */
 int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* document)
 {
     int i = 0;
@@ -534,7 +666,12 @@ int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* docume
     return 1;
 }
 
-/** Initialize history stacks and capacity. Complexity: `O(capacity)`. */
+/**
+ * @brief document_history_init 函数。
+ *
+ * @param history 参数 `history`。
+ * @return 函数返回值。
+ */
 int document_history_init(DocumentHistory* history)
 {
     if (!history) {
@@ -560,7 +697,12 @@ int document_history_init(DocumentHistory* history)
     return 1;
 }
 
-/** Free all history entries and internal arrays. Complexity: `O(total_snapshots)`. */
+/**
+ * @brief document_history_shutdown 函数。
+ *
+ * @param history 参数 `history`。
+ * @return 无。
+ */
 void document_history_shutdown(DocumentHistory* history)
 {
     int i = 0;
@@ -587,6 +729,9 @@ void document_history_shutdown(DocumentHistory* history)
 
 /**
  * @brief Push edit transaction (`before` + captured `after`) to undo stack.
+ * @param history [in,out] 历史对象。
+ * @param before [in,out] 编辑前快照（会被消费/转移所有权）。
+ * @param after_document [in] 编辑后文档。
  * @return `1` on success, `0` on failure.
  *
  * Why clear redo:
@@ -652,6 +797,14 @@ int document_history_push(DocumentHistory* history, DocumentSnapshot* before, co
 
 /**
  * @brief Push lightweight scalar edit transaction without capturing full document snapshots.
+ * @param history [in,out] 历史对象。
+ * @param document [in] 当前文档。
+ * @param object_id [in] 对象 ID。
+ * @param key [in] 属性键名。
+ * @param before_value [in] 修改前值。
+ * @param after_value [in] 修改后值。
+ * @param revision_before [in] 修改前修订号。
+ * @param revision_after [in] 修改后修订号。
  * @return `1` on success, `0` on validation/allocation failure.
  */
 int document_history_push_scalar_edit(DocumentHistory* history,
@@ -681,6 +834,13 @@ int document_history_push_scalar_edit(DocumentHistory* history,
 
 /**
  * @brief Push lightweight translate transaction for a fixed object-id set.
+ * @param history [in,out] 历史对象。
+ * @param document [in] 当前文档。
+ * @param object_ids [in] 对象 ID 列表。
+ * @param object_count [in] 对象数量。
+ * @param delta [in] 位移向量。
+ * @param revision_before [in] 修改前修订号。
+ * @param revision_after [in] 修改后修订号。
  * @return `1` on success, `0` on validation/allocation failure.
  */
 int document_history_push_translate_edit(DocumentHistory* history,
@@ -708,7 +868,19 @@ int document_history_push_translate_edit(DocumentHistory* history,
                                        revision_after);
 }
 
-/** Undo latest transaction and move entry to redo stack. Complexity: `O(n + capacity)` worst-case. */
+/**
+ * @brief 执行一次撤销并将条目移入重做栈。
+ *
+ * 算法步骤：
+ * 1. 弹出 undo 栈顶；
+ * 2. 按条目类型应用逆操作（快照恢复/标量回退/平移反向）；
+ * 3. 条目转存到 redo 栈；
+ * 4. 清理原 undo 槽位的辅助元数据。
+ *
+ * @param history [in,out] 历史对象。
+ * @param document [in,out] 目标文档。
+ * @return 成功返回 `1`，失败返回 `0`。
+ */
 int document_history_undo(DocumentHistory* history, Document* document)
 {
     DocumentHistoryEntry entry;
@@ -764,7 +936,12 @@ int document_history_undo(DocumentHistory* history, Document* document)
     return 1;
 }
 
-/** Redo latest undone transaction and move entry back to undo stack. Complexity: `O(n + capacity)` worst-case. */
+/**
+ * @brief 执行一次重做并将条目移回撤销栈。
+ * @param history [in,out] 历史对象。
+ * @param document [in,out] 目标文档。
+ * @return 成功返回 `1`，失败返回 `0`。
+ */
 int document_history_redo(DocumentHistory* history, Document* document)
 {
     DocumentHistoryEntry entry;
@@ -820,13 +997,23 @@ int document_history_redo(DocumentHistory* history, Document* document)
     return 1;
 }
 
-/** Check if undo stack has entries. Complexity: `O(1)`. */
+/**
+ * @brief document_history_can_undo 函数。
+ *
+ * @param history 参数 `history`。
+ * @return 函数返回值。
+ */
 int document_history_can_undo(const DocumentHistory* history)
 {
     return history && history->undo_count > 0;
 }
 
-/** Check if redo stack has entries. Complexity: `O(1)`. */
+/**
+ * @brief document_history_can_redo 函数。
+ *
+ * @param history 参数 `history`。
+ * @return 函数返回值。
+ */
 int document_history_can_redo(const DocumentHistory* history)
 {
     return history && history->redo_count > 0;

--- a/src/document/history.c
+++ b/src/document/history.c
@@ -59,10 +59,9 @@ static void history_entry_free(DocumentHistoryEntry* entry);
 static void history_entry_reset(DocumentHistoryEntry* entry);
 
 /**
- * @brief history_find_internals 函数。
- *
- * @param history 参数 `history`。
- * @return 函数返回值。
+ * @brief Finds internal history state.
+ * @param history Document history instance.
+ * @return Internal state or NULL.
  */
 static HistoryInternals* history_find_internals(const DocumentHistory* history)
 {
@@ -77,10 +76,9 @@ static HistoryInternals* history_find_internals(const DocumentHistory* history)
 }
 
 /**
- * @brief history_free_internals 函数。
- *
- * @param internals 参数 `internals`。
- * @return 无。
+ * @brief Frees internal history state.
+ * @param internals Internal state to free.
+ * @return None.
  */
 static void history_free_internals(HistoryInternals* internals)
 {
@@ -103,10 +101,9 @@ static void history_free_internals(HistoryInternals* internals)
 }
 
 /**
- * @brief history_unregister_internals 函数。
- *
- * @param history 参数 `history`。
- * @return 无。
+ * @brief Unregisters internal history state.
+ * @param history Document history instance.
+ * @return None.
  */
 static void history_unregister_internals(DocumentHistory* history)
 {
@@ -130,10 +127,9 @@ static void history_unregister_internals(DocumentHistory* history)
 }
 
 /**
- * @brief history_register_internals 函数。
- *
- * @param history 参数 `history`。
- * @return 函数返回值。
+ * @brief Registers internal history state.
+ * @param history Document history instance.
+ * @return 1 on success, 0 on failure.
  */
 static int history_register_internals(DocumentHistory* history)
 {
@@ -174,10 +170,9 @@ static int history_register_internals(DocumentHistory* history)
 }
 
 /**
- * @brief history_get_internals 函数。
- *
- * @param history 参数 `history`。
- * @return 函数返回值。
+ * @brief Gets internal history state.
+ * @param history Document history instance.
+ * @return Internal state or NULL.
  */
 static HistoryInternals* history_get_internals(const DocumentHistory* history)
 {
@@ -185,11 +180,10 @@ static HistoryInternals* history_get_internals(const DocumentHistory* history)
 }
 
 /**
- * @brief snapshot_move 函数。
- *
- * @param dst 参数 `dst`。
- * @param src 参数 `src`。
- * @return 无。
+ * @brief Moves a snapshot (transferring ownership).
+ * @param dst Destination snapshot.
+ * @param src Source snapshot.
+ * @return None.
  */
 static void snapshot_move(DocumentSnapshot* dst, DocumentSnapshot* src)
 {
@@ -204,11 +198,10 @@ static void snapshot_move(DocumentSnapshot* dst, DocumentSnapshot* src)
 }
 
 /**
- * @brief history_find_scalar_object 函数。
- *
- * @param document 参数 `document`。
- * @param id 参数 `id`。
- * @return 函数返回值。
+ * @brief Finds an object by ID for scalar edit operations.
+ * @param document Document instance.
+ * @param id Object ID.
+ * @return Object pointer or NULL.
  */
 static GraphicObject* history_find_scalar_object(Document* document, ObjectId id)
 {
@@ -219,11 +212,10 @@ static GraphicObject* history_find_scalar_object(Document* document, ObjectId id
 }
 
 /**
- * @brief history_apply_scalar_edit_undo 函数。
- *
- * @param document 参数 `document`。
- * @param edit 参数 `edit`。
- * @return 函数返回值。
+ * @brief Applies scalar edit undo.
+ * @param document Document instance.
+ * @param edit Scalar edit to undo.
+ * @return 1 on success, 0 on failure.
  */
 static int history_apply_scalar_edit_undo(Document* document, const HistoryScalarEdit* edit)
 {
@@ -240,11 +232,10 @@ static int history_apply_scalar_edit_undo(Document* document, const HistoryScala
 }
 
 /**
- * @brief history_apply_scalar_edit_redo 函数。
- *
- * @param document 参数 `document`。
- * @param edit 参数 `edit`。
- * @return 函数返回值。
+ * @brief Applies scalar edit redo.
+ * @param document Document instance.
+ * @param edit Scalar edit to redo.
+ * @return 1 on success, 0 on failure.
  */
 static int history_apply_scalar_edit_redo(Document* document, const HistoryScalarEdit* edit)
 {
@@ -261,13 +252,12 @@ static int history_apply_scalar_edit_redo(Document* document, const HistoryScala
 }
 
 /**
- * @brief history_apply_transform 函数。
- *
- * @param document 参数 `document`。
- * @param edit 参数 `edit`。
- * @param delta 参数 `delta`。
- * @param target_revision 参数 `target_revision`。
- * @return 函数返回值。
+ * @brief Applies a transform edit.
+ * @param document Document instance.
+ * @param edit Transform edit data.
+ * @param delta Translation delta.
+ * @param target_revision Target revision number.
+ * @return 1 on success, 0 on failure.
  */
 static int history_apply_transform(Document* document,
                                    const HistoryTransformEdit* edit,
@@ -293,11 +283,10 @@ static int history_apply_transform(Document* document,
 }
 
 /**
- * @brief history_apply_transform_edit_undo 函数。
- *
- * @param document 参数 `document`。
- * @param edit 参数 `edit`。
- * @return 函数返回值。
+ * @brief Applies transform edit undo.
+ * @param document Document instance.
+ * @param edit Transform edit to undo.
+ * @return 1 on success, 0 on failure.
  */
 static int history_apply_transform_edit_undo(Document* document, const HistoryTransformEdit* edit)
 {
@@ -313,11 +302,10 @@ static int history_apply_transform_edit_undo(Document* document, const HistoryTr
 }
 
 /**
- * @brief history_apply_transform_edit_redo 函数。
- *
- * @param document 参数 `document`。
- * @param edit 参数 `edit`。
- * @return 函数返回值。
+ * @brief Applies transform edit redo.
+ * @param document Document instance.
+ * @param edit Transform edit to redo.
+ * @return 1 on success, 0 on failure.
  */
 static int history_apply_transform_edit_redo(Document* document, const HistoryTransformEdit* edit)
 {
@@ -328,23 +316,23 @@ static int history_apply_transform_edit_redo(Document* document, const HistoryTr
 }
 
 /**
- * @brief 记录一次标量属性编辑并压入撤销栈。
+ * @brief Records a scalar property edit and pushes to undo stack.
  *
- * 算法步骤：
- * 1. 构造 `HistoryScalarEdit` 载荷；
- * 2. 清空 redo 栈（新分支写入）；
- * 3. 必要时淘汰 undo 栈最旧项；
- * 4. 将新条目写入 undo 栈尾。
+ * Algorithm steps:
+ * 1. Constructs HistoryScalarEdit payload.
+ * 2. Clears redo stack (new branch).
+ * 3. Evicts oldest undo entry if needed.
+ * 4. Writes new entry to end of undo stack.
  *
- * @param history [in,out] 历史对象。
- * @param document [in] 当前文档（用于参数合法性校验）。
- * @param object_id [in] 对象 ID。
- * @param key [in] 属性键名。
- * @param before_value [in] 修改前值。
- * @param after_value [in] 修改后值。
- * @param revision_before [in] 修改前修订号。
- * @param revision_after [in] 修改后修订号。
- * @return 成功返回 `1`，失败返回 `0`。
+ * @param history [in,out] History instance.
+ * @param document [in] Current document for validation.
+ * @param object_id [in] Object ID.
+ * @param key [in] Property key.
+ * @param before_value [in] Value before change.
+ * @param after_value [in] Value after change.
+ * @param revision_before [in] Revision before change.
+ * @param revision_after [in] Revision after change.
+ * @return 1 on success, 0 on failure.
  */
 static int history_push_scalar_edit(DocumentHistory* history,
                                     const Document* document,
@@ -404,16 +392,16 @@ static int history_push_scalar_edit(DocumentHistory* history,
 }
 
 /**
- * @brief 记录一次平移编辑并压入撤销栈。
+ * @brief Records a translate edit and pushes to undo stack.
  *
- * @param history [in,out] 历史对象。
- * @param document [in] 当前文档。
- * @param object_ids [in] 参与平移的对象 ID 数组。
- * @param object_count [in] 对象数量。
- * @param delta [in] 平移向量。
- * @param revision_before [in] 修改前修订号。
- * @param revision_after [in] 修改后修订号。
- * @return 成功返回 `1`，失败返回 `0`。
+ * @param history [in,out] History instance.
+ * @param document [in] Current document.
+ * @param object_ids [in] Array of object IDs to translate.
+ * @param object_count [in] Number of objects.
+ * @param delta [in] Translation vector.
+ * @param revision_before [in] Revision before change.
+ * @param revision_after [in] Revision after change.
+ * @return 1 on success, 0 on failure.
  */
 static int history_push_transform_edit(DocumentHistory* history,
                                        const Document* document,
@@ -474,10 +462,9 @@ static int history_push_transform_edit(DocumentHistory* history,
 }
 
 /**
- * @brief history_entry_free 函数。
- *
- * @param entry 参数 `entry`。
- * @return 无。
+ * @brief Frees a history entry.
+ * @param entry History entry to free.
+ * @return None.
  */
 static void history_entry_free(DocumentHistoryEntry* entry)
 {
@@ -486,10 +473,9 @@ static void history_entry_free(DocumentHistoryEntry* entry)
 }
 
 /**
- * @brief history_entry_reset 函数。
- *
- * @param entry 参数 `entry`。
- * @return 无。
+ * @brief Resets a history entry.
+ * @param entry History entry to reset.
+ * @return None.
  */
 static void history_entry_reset(DocumentHistoryEntry* entry)
 {
@@ -502,10 +488,9 @@ static void history_entry_reset(DocumentHistoryEntry* entry)
 }
 
 /**
- * @brief history_alloc_entries 函数。
- *
- * @param capacity 参数 `capacity`。
- * @return 函数返回值。
+ * @brief Allocates history entries.
+ * @param capacity Number of entries to allocate.
+ * @return Allocated entries or NULL.
  */
 static DocumentHistoryEntry* history_alloc_entries(int capacity)
 {
@@ -529,10 +514,10 @@ static DocumentHistoryEntry* history_alloc_entries(int capacity)
 }
 
 /**
- * @brief Replace document contents with deep-cloned snapshot objects.
- * @param document [in,out] 目标文档。
- * @param snapshot [in] 快照数据。
- * @return `1` on success, `0` on validation/allocation/clone failure.
+ * @brief Replaces document contents with deep-cloned snapshot objects.
+ * @param document [in,out] Target document.
+ * @param snapshot [in] Snapshot data.
+ * @return 1 on success, 0 on validation/allocation/clone failure.
  *
  * Risk note:
  * - Uses temporary clone array first; document is only replaced after all clones
@@ -585,10 +570,9 @@ static int document_restore_snapshot(Document* document, const DocumentSnapshot*
 }
 
 /**
- * @brief document_snapshot_init 函数。
- *
- * @param snapshot 参数 `snapshot`。
- * @return 无。
+ * @brief Initializes a document snapshot.
+ * @param snapshot Snapshot to initialize.
+ * @return None.
  */
 void document_snapshot_init(DocumentSnapshot* snapshot)
 {
@@ -598,10 +582,9 @@ void document_snapshot_init(DocumentSnapshot* snapshot)
 }
 
 /**
- * @brief document_snapshot_free 函数。
- *
- * @param snapshot 参数 `snapshot`。
- * @return 无。
+ * @brief Frees a document snapshot.
+ * @param snapshot Snapshot to free.
+ * @return None.
  */
 void document_snapshot_free(DocumentSnapshot* snapshot)
 {
@@ -624,12 +607,12 @@ void document_snapshot_free(DocumentSnapshot* snapshot)
 }
 
 /**
- * @brief 深拷贝文档到快照。
- * @param snapshot [in,out] 目标快照（原内容会先释放）。
- * @param document [in] 源文档。
- * @return 成功返回 `1`，失败返回 `0`。
+ * @brief Deep copies a document to a snapshot.
+ * @param snapshot [in,out] Target snapshot (previous content freed first).
+ * @param document [in] Source document.
+ * @return 1 on success, 0 on failure.
  *
- * @note 拷贝过程按对象逐个 clone，任一失败会回滚已分配内容。
+ * @note Clones objects one by one; failure rolls back allocated content.
  */
 int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* document)
 {
@@ -667,10 +650,9 @@ int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* docume
 }
 
 /**
- * @brief document_history_init 函数。
- *
- * @param history 参数 `history`。
- * @return 函数返回值。
+ * @brief Initializes document history.
+ * @param history History instance to initialize.
+ * @return 1 on success, 0 on failure.
  */
 int document_history_init(DocumentHistory* history)
 {
@@ -698,10 +680,9 @@ int document_history_init(DocumentHistory* history)
 }
 
 /**
- * @brief document_history_shutdown 函数。
- *
- * @param history 参数 `history`。
- * @return 无。
+ * @brief Shuts down document history.
+ * @param history History instance.
+ * @return None.
  */
 void document_history_shutdown(DocumentHistory* history)
 {
@@ -728,11 +709,11 @@ void document_history_shutdown(DocumentHistory* history)
 }
 
 /**
- * @brief Push edit transaction (`before` + captured `after`) to undo stack.
- * @param history [in,out] 历史对象。
- * @param before [in,out] 编辑前快照（会被消费/转移所有权）。
- * @param after_document [in] 编辑后文档。
- * @return `1` on success, `0` on failure.
+ * @brief Pushes edit transaction (`before` + captured `after`) to undo stack.
+ * @param history [in,out] History instance.
+ * @param before [in,out] Before snapshot (consumed/transferred ownership).
+ * @param after_document [in] After-edit document.
+ * @return 1 on success, 0 on failure.
  *
  * Why clear redo:
  * - Any new forward edit invalidates previous redo chain by definition.
@@ -796,16 +777,16 @@ int document_history_push(DocumentHistory* history, DocumentSnapshot* before, co
 }
 
 /**
- * @brief Push lightweight scalar edit transaction without capturing full document snapshots.
- * @param history [in,out] 历史对象。
- * @param document [in] 当前文档。
- * @param object_id [in] 对象 ID。
- * @param key [in] 属性键名。
- * @param before_value [in] 修改前值。
- * @param after_value [in] 修改后值。
- * @param revision_before [in] 修改前修订号。
- * @param revision_after [in] 修改后修订号。
- * @return `1` on success, `0` on validation/allocation failure.
+ * @brief Pushes lightweight scalar edit transaction without capturing full document snapshots.
+ * @param history [in,out] History instance.
+ * @param document [in] Current document.
+ * @param object_id [in] Object ID.
+ * @param key [in] Property key.
+ * @param before_value [in] Value before change.
+ * @param after_value [in] Value after change.
+ * @param revision_before [in] Revision before change.
+ * @param revision_after [in] Revision after change.
+ * @return 1 on success, 0 on validation/allocation failure.
  */
 int document_history_push_scalar_edit(DocumentHistory* history,
                                       const Document* document,
@@ -833,15 +814,15 @@ int document_history_push_scalar_edit(DocumentHistory* history,
 }
 
 /**
- * @brief Push lightweight translate transaction for a fixed object-id set.
- * @param history [in,out] 历史对象。
- * @param document [in] 当前文档。
- * @param object_ids [in] 对象 ID 列表。
- * @param object_count [in] 对象数量。
- * @param delta [in] 位移向量。
- * @param revision_before [in] 修改前修订号。
- * @param revision_after [in] 修改后修订号。
- * @return `1` on success, `0` on validation/allocation failure.
+ * @brief Pushes lightweight translate transaction for a fixed object-id set.
+ * @param history [in,out] History instance.
+ * @param document [in] Current document.
+ * @param object_ids [in] Object ID list.
+ * @param object_count [in] Number of objects.
+ * @param delta [in] Translation vector.
+ * @param revision_before [in] Revision before change.
+ * @param revision_after [in] Revision after change.
+ * @return 1 on success, 0 on validation/allocation failure.
  */
 int document_history_push_translate_edit(DocumentHistory* history,
                                          const Document* document,
@@ -869,17 +850,17 @@ int document_history_push_translate_edit(DocumentHistory* history,
 }
 
 /**
- * @brief 执行一次撤销并将条目移入重做栈。
+ * @brief Performs one undo and moves entry to redo stack.
  *
- * 算法步骤：
- * 1. 弹出 undo 栈顶；
- * 2. 按条目类型应用逆操作（快照恢复/标量回退/平移反向）；
- * 3. 条目转存到 redo 栈；
- * 4. 清理原 undo 槽位的辅助元数据。
+ * Algorithm steps:
+ * 1. Pops top of undo stack.
+ * 2. Applies inverse operation by entry type (snapshot restore/scalar revert/translate reverse).
+ * 3. Transfers entry to redo stack.
+ * 4. Cleans up auxiliary metadata at original undo slot.
  *
- * @param history [in,out] 历史对象。
- * @param document [in,out] 目标文档。
- * @return 成功返回 `1`，失败返回 `0`。
+ * @param history [in,out] History instance.
+ * @param document [in,out] Target document.
+ * @return 1 on success, 0 on failure.
  */
 int document_history_undo(DocumentHistory* history, Document* document)
 {
@@ -937,10 +918,10 @@ int document_history_undo(DocumentHistory* history, Document* document)
 }
 
 /**
- * @brief 执行一次重做并将条目移回撤销栈。
- * @param history [in,out] 历史对象。
- * @param document [in,out] 目标文档。
- * @return 成功返回 `1`，失败返回 `0`。
+ * @brief Performs one redo and moves entry back to undo stack.
+ * @param history [in,out] History instance.
+ * @param document [in,out] Target document.
+ * @return 1 on success, 0 on failure.
  */
 int document_history_redo(DocumentHistory* history, Document* document)
 {
@@ -998,10 +979,9 @@ int document_history_redo(DocumentHistory* history, Document* document)
 }
 
 /**
- * @brief document_history_can_undo 函数。
- *
- * @param history 参数 `history`。
- * @return 函数返回值。
+ * @brief Checks if undo is available.
+ * @param history History instance.
+ * @return 1 if undo available, 0 otherwise.
  */
 int document_history_can_undo(const DocumentHistory* history)
 {
@@ -1009,10 +989,9 @@ int document_history_can_undo(const DocumentHistory* history)
 }
 
 /**
- * @brief document_history_can_redo 函数。
- *
- * @param history 参数 `history`。
- * @return 函数返回值。
+ * @brief Checks if redo is available.
+ * @param history History instance.
+ * @return 1 if redo available, 0 otherwise.
  */
 int document_history_can_redo(const DocumentHistory* history)
 {

--- a/src/document/object.c
+++ b/src/document/object.c
@@ -35,10 +35,9 @@ typedef struct {
 } EllipseData;
 
 /**
- * @brief object_bump_revision 函数。
- *
- * @param object 参数 `object`。
- * @return 无。
+ * @brief Increments the object revision.
+ * @param object Object instance.
+ * @return None.
  */
 static void object_bump_revision(GraphicObject* object)
 {
@@ -48,12 +47,11 @@ static void object_bump_revision(GraphicObject* object)
 }
 
 /**
- * @brief style_get_scalar 函数。
- *
- * @param object 参数 `object`。
- * @param key 参数 `key`。
- * @param out_value 参数 `out_value`。
- * @return 函数返回值。
+ * @brief Gets a style scalar value.
+ * @param object Object instance.
+ * @param key Style key name.
+ * @param out_value Output value pointer.
+ * @return 1 on success, 0 on failure.
  */
 static int style_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
@@ -66,12 +64,11 @@ static int style_get_scalar(const GraphicObject* object, const char* key, float*
 }
 
 /**
- * @brief style_set_scalar 函数。
- *
- * @param object 参数 `object`。
- * @param key 参数 `key`。
- * @param value 参数 `value`。
- * @return 函数返回值。
+ * @brief Sets a style scalar value.
+ * @param object Object instance.
+ * @param key Style key name.
+ * @param value New value.
+ * @return 1 on success, 0 on failure.
  */
 static int style_set_scalar(GraphicObject* object, const char* key, float value)
 {
@@ -84,10 +81,9 @@ static int style_set_scalar(GraphicObject* object, const char* key, float value)
 }
 
 /**
- * @brief line_destroy 函数。
- *
- * @param object 参数 `object`。
- * @return 无。
+ * @brief Destroys a line object.
+ * @param object Line object instance.
+ * @return None.
  */
 static void line_destroy(GraphicObject* object)
 {
@@ -96,11 +92,10 @@ static void line_destroy(GraphicObject* object)
 }
 
 /**
- * @brief line_translate 函数。
- *
- * @param object 参数 `object`。
- * @param delta 参数 `delta`。
- * @return 无。
+ * @brief Translates a line object.
+ * @param object Line object instance.
+ * @param delta Translation vector.
+ * @return None.
  */
 static void line_translate(GraphicObject* object, Vec2 delta)
 {
@@ -110,10 +105,9 @@ static void line_translate(GraphicObject* object, Vec2 delta)
 }
 
 /**
- * @brief line_bounds 函数。
- *
- * @param object 参数 `object`。
- * @return 函数返回值。
+ * @brief Gets the bounding box of a line.
+ * @param object Line object instance.
+ * @return Bounding rectangle.
  */
 static RectF line_bounds(const GraphicObject* object)
 {
@@ -127,12 +121,11 @@ static RectF line_bounds(const GraphicObject* object)
 }
 
 /**
- * @brief line_distance_to_segment 函数。
- *
- * @param point 参数 `point`。
- * @param a 参数 `a`。
- * @param b 参数 `b`。
- * @return 函数返回值。
+ * @brief Calculates distance from point to line segment.
+ * @param point Point to test.
+ * @param a Line segment start point.
+ * @param b Line segment end point.
+ * @return Distance to segment.
  */
 static float line_distance_to_segment(Vec2 point, Vec2 a, Vec2 b)
 {
@@ -151,12 +144,11 @@ static float line_distance_to_segment(Vec2 point, Vec2 a, Vec2 b)
 }
 
 /**
- * @brief line_hit_test 函数。
- *
- * @param object 参数 `object`。
- * @param point 参数 `point`。
- * @param tolerance 参数 `tolerance`。
- * @return 函数返回值。
+ * @brief Hit tests a line object.
+ * @param object Line object instance.
+ * @param point Test point.
+ * @param tolerance Hit tolerance.
+ * @return 1 if hit, 0 otherwise.
  */
 static int line_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
@@ -165,10 +157,9 @@ static int line_hit_test(const GraphicObject* object, Vec2 point, float toleranc
 }
 
 /**
- * @brief line_get_path_point_count 函数。
- *
- * @param object 参数 `object`。
- * @return 函数返回值。
+ * @brief Gets the path point count for a line.
+ * @param object Line object instance.
+ * @return Number of path points.
  */
 static int line_get_path_point_count(const GraphicObject* object)
 {
@@ -177,11 +168,10 @@ static int line_get_path_point_count(const GraphicObject* object)
 }
 
 /**
- * @brief line_write_path_points 函数。
- *
- * @param object 参数 `object`。
- * @param out_points 参数 `out_points`。
- * @return 无。
+ * @brief Writes path points for a line.
+ * @param object Line object instance.
+ * @param out_points Output array for path points.
+ * @return None.
  */
 static void line_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
@@ -191,12 +181,11 @@ static void line_write_path_points(const GraphicObject* object, Vec2* out_points
 }
 
 /**
- * @brief line_get_scalar 函数。
- *
- * @param object 参数 `object`。
- * @param key 参数 `key`。
- * @param out_value 参数 `out_value`。
- * @return 函数返回值。
+ * @brief Gets a scalar property of a line.
+ * @param object Line object instance.
+ * @param key Property key.
+ * @param out_value Output value pointer.
+ * @return 1 on success, 0 on failure.
  */
 static int line_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
@@ -209,12 +198,11 @@ static int line_get_scalar(const GraphicObject* object, const char* key, float* 
 }
 
 /**
- * @brief line_set_scalar 函数。
- *
- * @param object 参数 `object`。
- * @param key 参数 `key`。
- * @param value 参数 `value`。
- * @return 函数返回值。
+ * @brief Sets a scalar property of a line.
+ * @param object Line object instance.
+ * @param key Property key.
+ * @param value New value.
+ * @return 1 on success, 0 on failure.
  */
 static int line_set_scalar(GraphicObject* object, const char* key, float value)
 {
@@ -227,10 +215,9 @@ static int line_set_scalar(GraphicObject* object, const char* key, float value)
 }
 
 /**
- * @brief rect_destroy 函数。
- *
- * @param object 参数 `object`。
- * @return 无。
+ * @brief Destroys a rectangle object.
+ * @param object Rectangle object instance.
+ * @return None.
  */
 static void rect_destroy(GraphicObject* object)
 {
@@ -239,11 +226,10 @@ static void rect_destroy(GraphicObject* object)
 }
 
 /**
- * @brief rect_translate 函数。
- *
- * @param object 参数 `object`。
- * @param delta 参数 `delta`。
- * @return 无。
+ * @brief Translates a rectangle object.
+ * @param object Rectangle object instance.
+ * @param delta Translation vector.
+ * @return None.
  */
 static void rect_translate(GraphicObject* object, Vec2 delta)
 {
@@ -253,10 +239,9 @@ static void rect_translate(GraphicObject* object, Vec2 delta)
 }
 
 /**
- * @brief rect_bounds 函数。
- *
- * @param object 参数 `object`。
- * @return 函数返回值。
+ * @brief Gets the bounding box of a rectangle.
+ * @param object Rectangle object instance.
+ * @return Bounding rectangle.
  */
 static RectF rect_bounds(const GraphicObject* object)
 {
@@ -265,12 +250,11 @@ static RectF rect_bounds(const GraphicObject* object)
 }
 
 /**
- * @brief rect_hit_test 函数。
- *
- * @param object 参数 `object`。
- * @param point 参数 `point`。
- * @param tolerance 参数 `tolerance`。
- * @return 函数返回值。
+ * @brief Hit tests a rectangle object.
+ * @param object Rectangle object instance.
+ * @param point Test point.
+ * @param tolerance Hit tolerance.
+ * @return 1 if hit, 0 otherwise.
  */
 static int rect_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
@@ -283,10 +267,9 @@ static int rect_hit_test(const GraphicObject* object, Vec2 point, float toleranc
 }
 
 /**
- * @brief rect_get_path_point_count 函数。
- *
- * @param object 参数 `object`。
- * @return 函数返回值。
+ * @brief Gets the path point count for a rectangle.
+ * @param object Rectangle object instance.
+ * @return Number of path points.
  */
 static int rect_get_path_point_count(const GraphicObject* object)
 {
@@ -295,11 +278,10 @@ static int rect_get_path_point_count(const GraphicObject* object)
 }
 
 /**
- * @brief rect_write_path_points 函数。
- *
- * @param object 参数 `object`。
- * @param out_points 参数 `out_points`。
- * @return 无。
+ * @brief Writes path points for a rectangle.
+ * @param object Rectangle object instance.
+ * @param out_points Output array for path points.
+ * @return None.
  */
 static void rect_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
@@ -312,12 +294,11 @@ static void rect_write_path_points(const GraphicObject* object, Vec2* out_points
 }
 
 /**
- * @brief rect_get_scalar 函数。
- *
- * @param object 参数 `object`。
- * @param key 参数 `key`。
- * @param out_value 参数 `out_value`。
- * @return 函数返回值。
+ * @brief Gets a scalar property of a rectangle.
+ * @param object Rectangle object instance.
+ * @param key Property key.
+ * @param out_value Output value pointer.
+ * @return 1 on success, 0 on failure.
  */
 static int rect_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
@@ -330,12 +311,11 @@ static int rect_get_scalar(const GraphicObject* object, const char* key, float* 
 }
 
 /**
- * @brief rect_set_scalar 函数。
- *
- * @param object 参数 `object`。
- * @param key 参数 `key`。
- * @param value 参数 `value`。
- * @return 函数返回值。
+ * @brief Sets a scalar property of a rectangle.
+ * @param object Rectangle object instance.
+ * @param key Property key.
+ * @param value New value.
+ * @return 1 on success, 0 on failure.
  */
 static int rect_set_scalar(GraphicObject* object, const char* key, float value)
 {
@@ -348,10 +328,9 @@ static int rect_set_scalar(GraphicObject* object, const char* key, float value)
 }
 
 /**
- * @brief ellipse_destroy 函数。
- *
- * @param object 参数 `object`。
- * @return 无。
+ * @brief Destroys an ellipse object.
+ * @param object Ellipse object instance.
+ * @return None.
  */
 static void ellipse_destroy(GraphicObject* object)
 {
@@ -360,11 +339,10 @@ static void ellipse_destroy(GraphicObject* object)
 }
 
 /**
- * @brief ellipse_translate 函数。
- *
- * @param object 参数 `object`。
- * @param delta 参数 `delta`。
- * @return 无。
+ * @brief Translates an ellipse object.
+ * @param object Ellipse object instance.
+ * @param delta Translation vector.
+ * @return None.
  */
 static void ellipse_translate(GraphicObject* object, Vec2 delta)
 {
@@ -374,10 +352,9 @@ static void ellipse_translate(GraphicObject* object, Vec2 delta)
 }
 
 /**
- * @brief ellipse_bounds 函数。
- *
- * @param object 参数 `object`。
- * @return 函数返回值。
+ * @brief Gets the bounding box of an ellipse.
+ * @param object Ellipse object instance.
+ * @return Bounding rectangle.
  */
 static RectF ellipse_bounds(const GraphicObject* object)
 {
@@ -386,12 +363,11 @@ static RectF ellipse_bounds(const GraphicObject* object)
 }
 
 /**
- * @brief ellipse_hit_test 函数。
- *
- * @param object 参数 `object`。
- * @param point 参数 `point`。
- * @param tolerance 参数 `tolerance`。
- * @return 函数返回值。
+ * @brief Hit tests an ellipse object.
+ * @param object Ellipse object instance.
+ * @param point Test point.
+ * @param tolerance Hit tolerance.
+ * @return 1 if hit, 0 otherwise.
  */
 static int ellipse_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
@@ -412,10 +388,9 @@ static int ellipse_hit_test(const GraphicObject* object, Vec2 point, float toler
 }
 
 /**
- * @brief ellipse_get_path_point_count 函数。
- *
- * @param object 参数 `object`。
- * @return 函数返回值。
+ * @brief Gets the path point count for an ellipse.
+ * @param object Ellipse object instance.
+ * @return Number of path points.
  */
 static int ellipse_get_path_point_count(const GraphicObject* object)
 {
@@ -424,11 +399,10 @@ static int ellipse_get_path_point_count(const GraphicObject* object)
 }
 
 /**
- * @brief ellipse_write_path_points 函数。
- *
- * @param object 参数 `object`。
- * @param out_points 参数 `out_points`。
- * @return 无。
+ * @brief Writes path points for an ellipse.
+ * @param object Ellipse object instance.
+ * @param out_points Output array for path points.
+ * @return None.
  */
 static void ellipse_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
@@ -448,12 +422,11 @@ static void ellipse_write_path_points(const GraphicObject* object, Vec2* out_poi
 }
 
 /**
- * @brief ellipse_get_scalar 函数。
- *
- * @param object 参数 `object`。
- * @param key 参数 `key`。
- * @param out_value 参数 `out_value`。
- * @return 函数返回值。
+ * @brief Gets a scalar property of an ellipse.
+ * @param object Ellipse object instance.
+ * @param key Property key.
+ * @param out_value Output value pointer.
+ * @return 1 on success, 0 on failure.
  */
 static int ellipse_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
@@ -466,12 +439,11 @@ static int ellipse_get_scalar(const GraphicObject* object, const char* key, floa
 }
 
 /**
- * @brief ellipse_set_scalar 函数。
- *
- * @param object 参数 `object`。
- * @param key 参数 `key`。
- * @param value 参数 `value`。
- * @return 函数返回值。
+ * @brief Sets a scalar property of an ellipse.
+ * @param object Ellipse object instance.
+ * @param key Property key.
+ * @param value New value.
+ * @return 1 on success, 0 on failure.
  */
 static int ellipse_set_scalar(GraphicObject* object, const char* key, float value)
 {
@@ -523,13 +495,12 @@ static const GraphicObjectVTable g_ellipse_vtable = {
 };
 
 /**
- * @brief object_alloc 函数。
- *
- * @param type 参数 `type`。
- * @param vtable 参数 `vtable`。
- * @param impl 参数 `impl`。
- * @param style 参数 `style`。
- * @return 函数返回值。
+ * @brief Allocates a new graphic object.
+ * @param type Object type.
+ * @param vtable Virtual function table.
+ * @param impl Type-specific implementation data.
+ * @param style Graphic style.
+ * @return New object or NULL.
  */
 static GraphicObject* object_alloc(GraphicObjectType type,
                                    const GraphicObjectVTable* vtable,
@@ -551,10 +522,9 @@ static GraphicObject* object_alloc(GraphicObjectType type,
 }
 
 /**
- * @brief object_default_style 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Gets the default graphic style.
+ * @param void No parameters.
+ * @return Default graphic style.
  */
 GraphicStyle object_default_style(void)
 {
@@ -568,10 +538,9 @@ GraphicStyle object_default_style(void)
 }
 
 /**
- * @brief object_type_name 函数。
- *
- * @param type 参数 `type`。
- * @return 函数返回值。
+ * @brief Gets the type name string.
+ * @param type Object type.
+ * @return Type name string.
  */
 const char* object_type_name(GraphicObjectType type)
 {
@@ -588,12 +557,11 @@ const char* object_type_name(GraphicObjectType type)
 }
 
 /**
- * @brief object_create_line 函数。
- *
- * @param p1 参数 `p1`。
- * @param p2 参数 `p2`。
- * @param style 参数 `style`。
- * @return 函数返回值。
+ * @brief Creates a line object.
+ * @param p1 Start point.
+ * @param p2 End point.
+ * @param style Graphic style.
+ * @return New line object or NULL.
  */
 GraphicObject* object_create_line(Vec2 p1, Vec2 p2, GraphicStyle style)
 {
@@ -607,11 +575,10 @@ GraphicObject* object_create_line(Vec2 p1, Vec2 p2, GraphicStyle style)
 }
 
 /**
- * @brief object_create_rect 函数。
- *
- * @param rect 参数 `rect`。
- * @param style 参数 `style`。
- * @return 函数返回值。
+ * @brief Creates a rectangle object.
+ * @param rect Rectangle bounds.
+ * @param style Graphic style.
+ * @return New rectangle object or NULL.
  */
 GraphicObject* object_create_rect(RectF rect, GraphicStyle style)
 {
@@ -624,11 +591,10 @@ GraphicObject* object_create_rect(RectF rect, GraphicStyle style)
 }
 
 /**
- * @brief object_create_ellipse 函数。
- *
- * @param bounds 参数 `bounds`。
- * @param style 参数 `style`。
- * @return 函数返回值。
+ * @brief Creates an ellipse object.
+ * @param bounds Ellipse bounds.
+ * @param style Graphic style.
+ * @return New ellipse object or NULL.
  */
 GraphicObject* object_create_ellipse(RectF bounds, GraphicStyle style)
 {
@@ -646,10 +612,9 @@ GraphicObject* object_create_ellipse(RectF bounds, GraphicStyle style)
  */
 
 /**
- * @brief object_clone 函数。
- *
- * @param object 参数 `object`。
- * @return 函数返回值。
+ * @brief Clones an object by concrete type.
+ * @param object Object to clone.
+ * @return New object with copied ID/style/revision, or NULL on failure.
  */
 GraphicObject* object_clone(const GraphicObject* object)
 {
@@ -692,10 +657,9 @@ GraphicObject* object_clone(const GraphicObject* object)
 }
 
 /**
- * @brief object_destroy 函数。
- *
- * @param object 参数 `object`。
- * @return 无。
+ * @brief Destroys an object.
+ * @param object Object to destroy.
+ * @return None.
  */
 void object_destroy(GraphicObject* object)
 {
@@ -705,11 +669,10 @@ void object_destroy(GraphicObject* object)
 }
 
 /**
- * @brief object_translate 函数。
- *
- * @param object 参数 `object`。
- * @param delta 参数 `delta`。
- * @return 无。
+ * @brief Translates an object.
+ * @param object Object instance.
+ * @param delta Translation vector.
+ * @return None.
  */
 void object_translate(GraphicObject* object, Vec2 delta)
 {
@@ -721,10 +684,9 @@ void object_translate(GraphicObject* object, Vec2 delta)
 }
 
 /**
- * @brief object_get_bounds 函数。
- *
- * @param object 参数 `object`。
- * @return 函数返回值。
+ * @brief Gets the bounding box of an object.
+ * @param object Object instance.
+ * @return Bounding rectangle.
  */
 RectF object_get_bounds(const GraphicObject* object)
 {
@@ -736,12 +698,11 @@ RectF object_get_bounds(const GraphicObject* object)
 }
 
 /**
- * @brief object_hit_test 函数。
- *
- * @param object 参数 `object`。
- * @param point 参数 `point`。
- * @param tolerance 参数 `tolerance`。
- * @return 函数返回值。
+ * @brief Hit tests an object.
+ * @param object Object instance.
+ * @param point Test point.
+ * @param tolerance Hit tolerance.
+ * @return 1 if hit, 0 otherwise.
  */
 int object_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
@@ -752,10 +713,9 @@ int object_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 }
 
 /**
- * @brief object_get_path_point_count 函数。
- *
- * @param object 参数 `object`。
- * @return 函数返回值。
+ * @brief Gets the path point count.
+ * @param object Object instance.
+ * @return Number of path points.
  */
 int object_get_path_point_count(const GraphicObject* object)
 {
@@ -766,11 +726,10 @@ int object_get_path_point_count(const GraphicObject* object)
 }
 
 /**
- * @brief object_write_path_points 函数。
- *
- * @param object 参数 `object`。
- * @param out_points 参数 `out_points`。
- * @return 无。
+ * @brief Writes path points for an object.
+ * @param object Object instance.
+ * @param out_points Output array for path points.
+ * @return None.
  */
 void object_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
@@ -781,12 +740,11 @@ void object_write_path_points(const GraphicObject* object, Vec2* out_points)
 }
 
 /**
- * @brief object_get_scalar 函数。
- *
- * @param object 参数 `object`。
- * @param key 参数 `key`。
- * @param out_value 参数 `out_value`。
- * @return 函数返回值。
+ * @brief Gets a scalar property of an object.
+ * @param object Object instance.
+ * @param key Property key.
+ * @param out_value Output value pointer.
+ * @return 1 on success, 0 on failure.
  */
 int object_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
@@ -797,12 +755,11 @@ int object_get_scalar(const GraphicObject* object, const char* key, float* out_v
 }
 
 /**
- * @brief object_set_scalar 函数。
- *
- * @param object 参数 `object`。
- * @param key 参数 `key`。
- * @param value 参数 `value`。
- * @return 函数返回值。
+ * @brief Sets a scalar property of an object.
+ * @param object Object instance.
+ * @param key Property key.
+ * @param value New value.
+ * @return 1 on success, 0 on failure.
  */
 int object_set_scalar(GraphicObject* object, const char* key, float value)
 {
@@ -817,11 +774,10 @@ int object_set_scalar(GraphicObject* object, const char* key, float value)
 }
 
 /**
- * @brief object_set_stroke_color 函数。
- *
- * @param object 参数 `object`。
- * @param color 参数 `color`。
- * @return 无。
+ * @brief Sets the stroke color of an object.
+ * @param object Object instance.
+ * @param color Stroke color.
+ * @return None.
  */
 void object_set_stroke_color(GraphicObject* object, Color color)
 {
@@ -833,11 +789,10 @@ void object_set_stroke_color(GraphicObject* object, Color color)
 }
 
 /**
- * @brief object_set_stroke_width 函数。
- *
- * @param object 参数 `object`。
- * @param stroke_width 参数 `stroke_width`。
- * @return 无。
+ * @brief Sets the stroke width of an object.
+ * @param object Object instance.
+ * @param stroke_width Stroke width.
+ * @return None.
  */
 void object_set_stroke_width(GraphicObject* object, float stroke_width)
 {

--- a/src/document/object.c
+++ b/src/document/object.c
@@ -34,7 +34,12 @@ typedef struct {
     RectF bounds;
 } EllipseData;
 
-/** Bump per-object revision after successful mutations. Complexity: `O(1)`. */
+/**
+ * @brief object_bump_revision 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 无。
+ */
 static void object_bump_revision(GraphicObject* object)
 {
     if (object) {
@@ -42,7 +47,14 @@ static void object_bump_revision(GraphicObject* object)
     }
 }
 
-/** Read style scalar by key. Complexity: `O(1)` with small fixed key set. */
+/**
+ * @brief style_get_scalar 函数。
+ *
+ * @param object 参数 `object`。
+ * @param key 参数 `key`。
+ * @param out_value 参数 `out_value`。
+ * @return 函数返回值。
+ */
 static int style_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
     if (strcmp(key, "stroke_r") == 0) { *out_value = object->style.stroke_color.r; return 1; }
@@ -53,7 +65,14 @@ static int style_get_scalar(const GraphicObject* object, const char* key, float*
     return 0;
 }
 
-/** Write style scalar by key. Complexity: `O(1)` with small fixed key set. */
+/**
+ * @brief style_set_scalar 函数。
+ *
+ * @param object 参数 `object`。
+ * @param key 参数 `key`。
+ * @param value 参数 `value`。
+ * @return 函数返回值。
+ */
 static int style_set_scalar(GraphicObject* object, const char* key, float value)
 {
     if (strcmp(key, "stroke_r") == 0) { object->style.stroke_color.r = value; return 1; }
@@ -64,14 +83,25 @@ static int style_set_scalar(GraphicObject* object, const char* key, float value)
     return 0;
 }
 
-/** Line object destructor; releases `impl` then wrapper object. */
+/**
+ * @brief line_destroy 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 无。
+ */
 static void line_destroy(GraphicObject* object)
 {
     free(object->impl);
     free(object);
 }
 
-/** Translate line endpoints by world delta. Complexity: `O(1)`. */
+/**
+ * @brief line_translate 函数。
+ *
+ * @param object 参数 `object`。
+ * @param delta 参数 `delta`。
+ * @return 无。
+ */
 static void line_translate(GraphicObject* object, Vec2 delta)
 {
     LineData* line = (LineData*)object->impl;
@@ -79,7 +109,12 @@ static void line_translate(GraphicObject* object, Vec2 delta)
     line->p2 = vec2_add(line->p2, delta);
 }
 
-/** Axis-aligned bounds for line segment. Complexity: `O(1)`. */
+/**
+ * @brief line_bounds 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 函数返回值。
+ */
 static RectF line_bounds(const GraphicObject* object)
 {
     const LineData* line = (const LineData*)object->impl;
@@ -92,10 +127,12 @@ static RectF line_bounds(const GraphicObject* object)
 }
 
 /**
- * @brief Compute shortest distance from point to line segment AB.
- * Why:
- * - Projecting onto AB and clamping `t` gives nearest on-segment point robustly.
- * Complexity: `O(1)`.
+ * @brief line_distance_to_segment 函数。
+ *
+ * @param point 参数 `point`。
+ * @param a 参数 `a`。
+ * @param b 参数 `b`。
+ * @return 函数返回值。
  */
 static float line_distance_to_segment(Vec2 point, Vec2 a, Vec2 b)
 {
@@ -113,21 +150,39 @@ static float line_distance_to_segment(Vec2 point, Vec2 a, Vec2 b)
     return vec2_length(vec2_sub(point, nearest));
 }
 
-/** Line hit-test uses geometric point-to-segment distance. Complexity: `O(1)`. */
+/**
+ * @brief line_hit_test 函数。
+ *
+ * @param object 参数 `object`。
+ * @param point 参数 `point`。
+ * @param tolerance 参数 `tolerance`。
+ * @return 函数返回值。
+ */
 static int line_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
     const LineData* line = (const LineData*)object->impl;
     return line_distance_to_segment(point, line->p1, line->p2) <= tolerance;
 }
 
-/** Returns 2 (the line segment endpoints p1 and p2). */
+/**
+ * @brief line_get_path_point_count 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 函数返回值。
+ */
 static int line_get_path_point_count(const GraphicObject* object)
 {
     (void)object;
     return 2;
 }
 
-/** Write line path points (p1, p2) into caller buffer (caller must provide at least 2 elements). */
+/**
+ * @brief line_write_path_points 函数。
+ *
+ * @param object 参数 `object`。
+ * @param out_points 参数 `out_points`。
+ * @return 无。
+ */
 static void line_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
     const LineData* line = (const LineData*)object->impl;
@@ -135,7 +190,14 @@ static void line_write_path_points(const GraphicObject* object, Vec2* out_points
     out_points[1] = line->p2;
 }
 
-/** Read line scalar property or fallback to style scalar. */
+/**
+ * @brief line_get_scalar 函数。
+ *
+ * @param object 参数 `object`。
+ * @param key 参数 `key`。
+ * @param out_value 参数 `out_value`。
+ * @return 函数返回值。
+ */
 static int line_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
     const LineData* line = (const LineData*)object->impl;
@@ -146,7 +208,14 @@ static int line_get_scalar(const GraphicObject* object, const char* key, float* 
     return style_get_scalar(object, key, out_value);
 }
 
-/** Write line scalar property or fallback to style scalar. */
+/**
+ * @brief line_set_scalar 函数。
+ *
+ * @param object 参数 `object`。
+ * @param key 参数 `key`。
+ * @param value 参数 `value`。
+ * @return 函数返回值。
+ */
 static int line_set_scalar(GraphicObject* object, const char* key, float value)
 {
     LineData* line = (LineData*)object->impl;
@@ -157,14 +226,25 @@ static int line_set_scalar(GraphicObject* object, const char* key, float value)
     return style_set_scalar(object, key, value);
 }
 
-/** Rectangle object destructor. */
+/**
+ * @brief rect_destroy 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 无。
+ */
 static void rect_destroy(GraphicObject* object)
 {
     free(object->impl);
     free(object);
 }
 
-/** Translate rectangle origin by world delta. */
+/**
+ * @brief rect_translate 函数。
+ *
+ * @param object 参数 `object`。
+ * @param delta 参数 `delta`。
+ * @return 无。
+ */
 static void rect_translate(GraphicObject* object, Vec2 delta)
 {
     RectData* rect = (RectData*)object->impl;
@@ -172,14 +252,26 @@ static void rect_translate(GraphicObject* object, Vec2 delta)
     rect->rect.y += delta.y;
 }
 
-/** Return rectangle bounds directly from payload. */
+/**
+ * @brief rect_bounds 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 函数返回值。
+ */
 static RectF rect_bounds(const GraphicObject* object)
 {
     const RectData* rect = (const RectData*)object->impl;
     return rect->rect;
 }
 
-/** Rectangle hit-test expands bounds by tolerance for easier selection. */
+/**
+ * @brief rect_hit_test 函数。
+ *
+ * @param object 参数 `object`。
+ * @param point 参数 `point`。
+ * @param tolerance 参数 `tolerance`。
+ * @return 函数返回值。
+ */
 static int rect_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
     RectF bounds = rect_bounds(object);
@@ -190,14 +282,25 @@ static int rect_hit_test(const GraphicObject* object, Vec2 point, float toleranc
     return rectf_contains_point(&bounds, point);
 }
 
-/** Returns 5 (4 corners plus closing repeat of first corner to close the polyline). */
+/**
+ * @brief rect_get_path_point_count 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 函数返回值。
+ */
 static int rect_get_path_point_count(const GraphicObject* object)
 {
     (void)object;
     return 5;
 }
 
-/** Emit rectangle corners plus closing point. */
+/**
+ * @brief rect_write_path_points 函数。
+ *
+ * @param object 参数 `object`。
+ * @param out_points 参数 `out_points`。
+ * @return 无。
+ */
 static void rect_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
     const RectData* rect = (const RectData*)object->impl;
@@ -208,7 +311,14 @@ static void rect_write_path_points(const GraphicObject* object, Vec2* out_points
     out_points[4] = out_points[0];
 }
 
-/** Read rectangle scalar property or style scalar. */
+/**
+ * @brief rect_get_scalar 函数。
+ *
+ * @param object 参数 `object`。
+ * @param key 参数 `key`。
+ * @param out_value 参数 `out_value`。
+ * @return 函数返回值。
+ */
 static int rect_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
     const RectData* rect = (const RectData*)object->impl;
@@ -219,7 +329,14 @@ static int rect_get_scalar(const GraphicObject* object, const char* key, float* 
     return style_get_scalar(object, key, out_value);
 }
 
-/** Write rectangle scalar property or style scalar. */
+/**
+ * @brief rect_set_scalar 函数。
+ *
+ * @param object 参数 `object`。
+ * @param key 参数 `key`。
+ * @param value 参数 `value`。
+ * @return 函数返回值。
+ */
 static int rect_set_scalar(GraphicObject* object, const char* key, float value)
 {
     RectData* rect = (RectData*)object->impl;
@@ -230,14 +347,25 @@ static int rect_set_scalar(GraphicObject* object, const char* key, float value)
     return style_set_scalar(object, key, value);
 }
 
-/** Ellipse object destructor. */
+/**
+ * @brief ellipse_destroy 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 无。
+ */
 static void ellipse_destroy(GraphicObject* object)
 {
     free(object->impl);
     free(object);
 }
 
-/** Translate ellipse bounds origin by world delta. */
+/**
+ * @brief ellipse_translate 函数。
+ *
+ * @param object 参数 `object`。
+ * @param delta 参数 `delta`。
+ * @return 无。
+ */
 static void ellipse_translate(GraphicObject* object, Vec2 delta)
 {
     EllipseData* ellipse = (EllipseData*)object->impl;
@@ -245,14 +373,26 @@ static void ellipse_translate(GraphicObject* object, Vec2 delta)
     ellipse->bounds.y += delta.y;
 }
 
-/** Return ellipse axis-aligned bounds. */
+/**
+ * @brief ellipse_bounds 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 函数返回值。
+ */
 static RectF ellipse_bounds(const GraphicObject* object)
 {
     const EllipseData* ellipse = (const EllipseData*)object->impl;
     return ellipse->bounds;
 }
 
-/** Hit-test in ellipse's normalized unit-circle coordinate space. Complexity: `O(1)`. */
+/**
+ * @brief ellipse_hit_test 函数。
+ *
+ * @param object 参数 `object`。
+ * @param point 参数 `point`。
+ * @param tolerance 参数 `tolerance`。
+ * @return 函数返回值。
+ */
 static int ellipse_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
     RectF bounds = ellipse_bounds(object);
@@ -271,7 +411,12 @@ static int ellipse_hit_test(const GraphicObject* object, Vec2 point, float toler
     return (nx * nx + ny * ny) <= 1.0f;
 }
 
-/** Ellipse polyline uses fixed segment count plus closure point. */
+/**
+ * @brief ellipse_get_path_point_count 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 函数返回值。
+ */
 static int ellipse_get_path_point_count(const GraphicObject* object)
 {
     (void)object;
@@ -279,9 +424,11 @@ static int ellipse_get_path_point_count(const GraphicObject* object)
 }
 
 /**
- * @brief Emit sampled ellipse perimeter.
- * Risk note:
- * - Caller must provide at least `ELLIPSE_SEGMENTS + 1` output points.
+ * @brief ellipse_write_path_points 函数。
+ *
+ * @param object 参数 `object`。
+ * @param out_points 参数 `out_points`。
+ * @return 无。
  */
 static void ellipse_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
@@ -300,7 +447,14 @@ static void ellipse_write_path_points(const GraphicObject* object, Vec2* out_poi
     out_points[ELLIPSE_SEGMENTS] = out_points[0];
 }
 
-/** Read ellipse scalar property or style scalar. */
+/**
+ * @brief ellipse_get_scalar 函数。
+ *
+ * @param object 参数 `object`。
+ * @param key 参数 `key`。
+ * @param out_value 参数 `out_value`。
+ * @return 函数返回值。
+ */
 static int ellipse_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
     const EllipseData* ellipse = (const EllipseData*)object->impl;
@@ -311,7 +465,14 @@ static int ellipse_get_scalar(const GraphicObject* object, const char* key, floa
     return style_get_scalar(object, key, out_value);
 }
 
-/** Write ellipse scalar property or style scalar. */
+/**
+ * @brief ellipse_set_scalar 函数。
+ *
+ * @param object 参数 `object`。
+ * @param key 参数 `key`。
+ * @param value 参数 `value`。
+ * @return 函数返回值。
+ */
 static int ellipse_set_scalar(GraphicObject* object, const char* key, float value)
 {
     EllipseData* ellipse = (EllipseData*)object->impl;
@@ -361,7 +522,15 @@ static const GraphicObjectVTable g_ellipse_vtable = {
     ellipse_set_scalar
 };
 
-/** Allocate common object wrapper; takes ownership of `impl` on success. */
+/**
+ * @brief object_alloc 函数。
+ *
+ * @param type 参数 `type`。
+ * @param vtable 参数 `vtable`。
+ * @param impl 参数 `impl`。
+ * @param style 参数 `style`。
+ * @return 函数返回值。
+ */
 static GraphicObject* object_alloc(GraphicObjectType type,
                                    const GraphicObjectVTable* vtable,
                                    void* impl,
@@ -381,7 +550,12 @@ static GraphicObject* object_alloc(GraphicObjectType type,
     return object;
 }
 
-/** Return default stroke style for new objects. */
+/**
+ * @brief object_default_style 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 GraphicStyle object_default_style(void)
 {
     GraphicStyle style;
@@ -393,7 +567,12 @@ GraphicStyle object_default_style(void)
     return style;
 }
 
-/** Return debug/display name by object type. */
+/**
+ * @brief object_type_name 函数。
+ *
+ * @param type 参数 `type`。
+ * @return 函数返回值。
+ */
 const char* object_type_name(GraphicObjectType type)
 {
     switch (type) {
@@ -408,7 +587,14 @@ const char* object_type_name(GraphicObjectType type)
     }
 }
 
-/** Create line object from two endpoints. */
+/**
+ * @brief object_create_line 函数。
+ *
+ * @param p1 参数 `p1`。
+ * @param p2 参数 `p2`。
+ * @param style 参数 `style`。
+ * @return 函数返回值。
+ */
 GraphicObject* object_create_line(Vec2 p1, Vec2 p2, GraphicStyle style)
 {
     LineData* line = (LineData*)calloc(1, sizeof(*line));
@@ -420,7 +606,13 @@ GraphicObject* object_create_line(Vec2 p1, Vec2 p2, GraphicStyle style)
     return object_alloc(GRAPHIC_OBJECT_LINE, &g_line_vtable, line, style);
 }
 
-/** Create rectangle object from bounds. */
+/**
+ * @brief object_create_rect 函数。
+ *
+ * @param rect 参数 `rect`。
+ * @param style 参数 `style`。
+ * @return 函数返回值。
+ */
 GraphicObject* object_create_rect(RectF rect, GraphicStyle style)
 {
     RectData* data = (RectData*)calloc(1, sizeof(*data));
@@ -431,7 +623,13 @@ GraphicObject* object_create_rect(RectF rect, GraphicStyle style)
     return object_alloc(GRAPHIC_OBJECT_RECT, &g_rect_vtable, data, style);
 }
 
-/** Create ellipse object from bounds. */
+/**
+ * @brief object_create_ellipse 函数。
+ *
+ * @param bounds 参数 `bounds`。
+ * @param style 参数 `style`。
+ * @return 函数返回值。
+ */
 GraphicObject* object_create_ellipse(RectF bounds, GraphicStyle style)
 {
     EllipseData* data = (EllipseData*)calloc(1, sizeof(*data));
@@ -445,6 +643,13 @@ GraphicObject* object_create_ellipse(RectF bounds, GraphicStyle style)
 /**
  * @brief Deep clone object by concrete type.
  * @return New object with copied ID/style/revision, or `NULL` on failure.
+ */
+
+/**
+ * @brief object_clone 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 函数返回值。
  */
 GraphicObject* object_clone(const GraphicObject* object)
 {
@@ -486,7 +691,12 @@ GraphicObject* object_clone(const GraphicObject* object)
     return clone;
 }
 
-/** Dispatch destruction through vtable. */
+/**
+ * @brief object_destroy 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 无。
+ */
 void object_destroy(GraphicObject* object)
 {
     if (object && object->vtable && object->vtable->destroy) {
@@ -494,7 +704,13 @@ void object_destroy(GraphicObject* object)
     }
 }
 
-/** Translate object and bump revision on success. */
+/**
+ * @brief object_translate 函数。
+ *
+ * @param object 参数 `object`。
+ * @param delta 参数 `delta`。
+ * @return 无。
+ */
 void object_translate(GraphicObject* object, Vec2 delta)
 {
     if (!object || !object->vtable || !object->vtable->translate) {
@@ -504,7 +720,12 @@ void object_translate(GraphicObject* object, Vec2 delta)
     object_bump_revision(object);
 }
 
-/** Query object bounds via vtable, fallback to empty rect. */
+/**
+ * @brief object_get_bounds 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 函数返回值。
+ */
 RectF object_get_bounds(const GraphicObject* object)
 {
     RectF empty = {0.0f, 0.0f, 0.0f, 0.0f};
@@ -514,7 +735,14 @@ RectF object_get_bounds(const GraphicObject* object)
     return object->vtable->get_bounds(object);
 }
 
-/** Hit-test object via vtable. */
+/**
+ * @brief object_hit_test 函数。
+ *
+ * @param object 参数 `object`。
+ * @param point 参数 `point`。
+ * @param tolerance 参数 `tolerance`。
+ * @return 函数返回值。
+ */
 int object_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
 {
     if (!object || !object->vtable || !object->vtable->hit_test) {
@@ -523,7 +751,12 @@ int object_hit_test(const GraphicObject* object, Vec2 point, float tolerance)
     return object->vtable->hit_test(object, point, tolerance);
 }
 
-/** Query path sample count via vtable. */
+/**
+ * @brief object_get_path_point_count 函数。
+ *
+ * @param object 参数 `object`。
+ * @return 函数返回值。
+ */
 int object_get_path_point_count(const GraphicObject* object)
 {
     if (!object || !object->vtable || !object->vtable->get_path_point_count) {
@@ -532,7 +765,13 @@ int object_get_path_point_count(const GraphicObject* object)
     return object->vtable->get_path_point_count(object);
 }
 
-/** Write path points via vtable. */
+/**
+ * @brief object_write_path_points 函数。
+ *
+ * @param object 参数 `object`。
+ * @param out_points 参数 `out_points`。
+ * @return 无。
+ */
 void object_write_path_points(const GraphicObject* object, Vec2* out_points)
 {
     if (!object || !object->vtable || !object->vtable->write_path_points) {
@@ -541,7 +780,14 @@ void object_write_path_points(const GraphicObject* object, Vec2* out_points)
     object->vtable->write_path_points(object, out_points);
 }
 
-/** Query scalar property via vtable. */
+/**
+ * @brief object_get_scalar 函数。
+ *
+ * @param object 参数 `object`。
+ * @param key 参数 `key`。
+ * @param out_value 参数 `out_value`。
+ * @return 函数返回值。
+ */
 int object_get_scalar(const GraphicObject* object, const char* key, float* out_value)
 {
     if (!object || !object->vtable || !object->vtable->get_scalar) {
@@ -550,7 +796,14 @@ int object_get_scalar(const GraphicObject* object, const char* key, float* out_v
     return object->vtable->get_scalar(object, key, out_value);
 }
 
-/** Set scalar property via vtable and bump revision on success. */
+/**
+ * @brief object_set_scalar 函数。
+ *
+ * @param object 参数 `object`。
+ * @param key 参数 `key`。
+ * @param value 参数 `value`。
+ * @return 函数返回值。
+ */
 int object_set_scalar(GraphicObject* object, const char* key, float value)
 {
     if (!object || !object->vtable || !object->vtable->set_scalar) {
@@ -563,7 +816,13 @@ int object_set_scalar(GraphicObject* object, const char* key, float value)
     return 1;
 }
 
-/** Update stroke color and revision. */
+/**
+ * @brief object_set_stroke_color 函数。
+ *
+ * @param object 参数 `object`。
+ * @param color 参数 `color`。
+ * @return 无。
+ */
 void object_set_stroke_color(GraphicObject* object, Color color)
 {
     if (!object) {
@@ -573,7 +832,13 @@ void object_set_stroke_color(GraphicObject* object, Color color)
     object_bump_revision(object);
 }
 
-/** Update stroke width and revision. */
+/**
+ * @brief object_set_stroke_width 函数。
+ *
+ * @param object 参数 `object`。
+ * @param stroke_width 参数 `stroke_width`。
+ * @return 无。
+ */
 void object_set_stroke_width(GraphicObject* object, float stroke_width)
 {
     if (!object) {

--- a/src/document/persistence.c
+++ b/src/document/persistence.c
@@ -85,7 +85,12 @@ typedef struct {
     int has_height;
 } LoadedObjectData;
 
-/** Read entire file into heap buffer (NUL-terminated). Caller owns returned memory. */
+/**
+ * @brief read_text_file 函数。
+ *
+ * @param path 参数 `path`。
+ * @return 函数返回值。
+ */
 static char* read_text_file(const char* path)
 {
     FILE* file = NULL;
@@ -125,7 +130,13 @@ static char* read_text_file(const char* path)
     return buffer;
 }
 
-/** Allocate `path + suffix` string. Caller owns returned memory. */
+/**
+ * @brief duplicate_path_with_suffix 函数。
+ *
+ * @param path 参数 `path`。
+ * @param suffix 参数 `suffix`。
+ * @return 函数返回值。
+ */
 static char* duplicate_path_with_suffix(const char* path, const char* suffix)
 {
     size_t path_length = 0;
@@ -149,7 +160,12 @@ static char* duplicate_path_with_suffix(const char* path, const char* suffix)
     return result;
 }
 
-/** Cheap file-exists check via open attempt. */
+/**
+ * @brief file_exists_at_path 函数。
+ *
+ * @param path 参数 `path`。
+ * @return 函数返回值。
+ */
 static int file_exists_at_path(const char* path)
 {
     FILE* file = NULL;
@@ -167,7 +183,12 @@ static int file_exists_at_path(const char* path)
     return 1;
 }
 
-/** Map object type enum to persisted JSON tag. */
+/**
+ * @brief object_type_tag 函数。
+ *
+ * @param type 参数 `type`。
+ * @return 函数返回值。
+ */
 static const char* object_type_tag(GraphicObjectType type)
 {
     switch (type) {
@@ -183,9 +204,11 @@ static const char* object_type_tag(GraphicObjectType type)
 }
 
 /**
- * @brief Atomically replace target file with temp file.
- * Why:
- * - Write-then-replace avoids corrupting existing file on partial write failure.
+ * @brief replace_file_with_temp 函数。
+ *
+ * @param temp_path 参数 `temp_path`。
+ * @param target_path 参数 `target_path`。
+ * @return 函数返回值。
  */
 static int replace_file_with_temp(const char* temp_path, const char* target_path)
 {
@@ -215,9 +238,12 @@ static int replace_file_with_temp(const char* temp_path, const char* target_path
 }
 
 /**
- * Serialize document as JSON into already-open file handle.
- * Risk note: individual `fprintf` returns are not checked line-by-line; final
- * `ferror(file)` is used as aggregate write-failure detection.
+ * @brief 将文档序列化为 JSON 并写入已打开文件。
+ * @param file [in,out] 目标文件句柄。
+ * @param document [in] 待序列化文档。
+ * @return 写入成功返回 `1`，失败返回 `0`。
+ *
+ * @note 使用 `ferror(file)` 作为整体写入失败检测。
  */
 static int write_document_json(FILE* file, const Document* document)
 {
@@ -279,7 +305,13 @@ static int write_document_json(FILE* file, const Document* document)
     return ferror(file) == 0;
 }
 
-/** Check whether parser position matches keyword and token boundary. */
+/**
+ * @brief json_match_keyword 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @param keyword 参数 `keyword`。
+ * @return 函数返回值。
+ */
 static int json_match_keyword(const JsonParser* parser, const char* keyword)
 {
     size_t length = 0;
@@ -306,7 +338,12 @@ static int json_match_keyword(const JsonParser* parser, const char* keyword)
     return !(isalnum((unsigned char)next) || next == '_');
 }
 
-/** Skip JSON whitespace from current parser position. */
+/**
+ * @brief json_parser_skip_ws 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @return 无。
+ */
 static void json_parser_skip_ws(JsonParser* parser)
 {
     while (parser->pos < parser->length &&
@@ -317,6 +354,9 @@ static void json_parser_skip_ws(JsonParser* parser)
 
 /**
  * @brief Advance parser to next token.
+ * @param parser [in,out] JSON 解析器状态。
+ * @return 无。
+ *
  * Risk note:
  * - Keeps implementation intentionally strict; malformed escape/number forms
  *   become `JSON_TOKEN_INVALID` to fail-fast during load.
@@ -426,7 +466,13 @@ static void json_parser_next(JsonParser* parser)
     parser->type = JSON_TOKEN_INVALID;
 }
 
-/** Compare current string token with literal. */
+/**
+ * @brief json_token_is_string 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @param literal 参数 `literal`。
+ * @return 函数返回值。
+ */
 static int json_token_is_string(const JsonParser* parser, const char* literal)
 {
     size_t literal_length = 0;
@@ -440,13 +486,25 @@ static int json_token_is_string(const JsonParser* parser, const char* literal)
            strncmp(parser->token_start, literal, literal_length) == 0;
 }
 
-/** Check expected token type. */
+/**
+ * @brief json_expect 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @param type 参数 `type`。
+ * @return 函数返回值。
+ */
 static int json_expect(JsonParser* parser, JsonTokenType type)
 {
     return parser && parser->type == type;
 }
 
-/** Parse unsigned integer token with integer range validation. */
+/**
+ * @brief json_parse_u32 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @param out_value 参数 `out_value`。
+ * @return 函数返回值。
+ */
 static int json_parse_u32(JsonParser* parser, unsigned int* out_value)
 {
     double value = 0.0;
@@ -466,7 +524,13 @@ static int json_parse_u32(JsonParser* parser, unsigned int* out_value)
     return 1;
 }
 
-/** Parse float token and advance parser. */
+/**
+ * @brief json_parse_float 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @param out_value 参数 `out_value`。
+ * @return 函数返回值。
+ */
 static int json_parse_float(JsonParser* parser, float* out_value)
 {
     if (!parser || !out_value || parser->type != JSON_TOKEN_NUMBER) {
@@ -480,7 +544,12 @@ static int json_parse_float(JsonParser* parser, float* out_value)
 
 static int json_skip_value(JsonParser* parser);
 
-/** Skip unknown JSON object recursively. */
+/**
+ * @brief json_skip_object 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @return 函数返回值。
+ */
 static int json_skip_object(JsonParser* parser)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACE)) {
@@ -517,7 +586,12 @@ static int json_skip_object(JsonParser* parser)
     }
 }
 
-/** Skip unknown JSON array recursively. */
+/**
+ * @brief json_skip_array 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @return 函数返回值。
+ */
 static int json_skip_array(JsonParser* parser)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACKET)) {
@@ -546,7 +620,12 @@ static int json_skip_array(JsonParser* parser)
     }
 }
 
-/** Skip arbitrary JSON value recursively. */
+/**
+ * @brief json_skip_value 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @return 函数返回值。
+ */
 static int json_skip_value(JsonParser* parser)
 {
     switch (parser->type) {
@@ -566,7 +645,13 @@ static int json_skip_value(JsonParser* parser)
     }
 }
 
-/** Parse `"stroke"` sub-object into loaded object staging struct. */
+/**
+ * @brief parse_stroke_object 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @param data 参数 `data`。
+ * @return 函数返回值。
+ */
 static int parse_stroke_object(JsonParser* parser, LoadedObjectData* data)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACE)) {
@@ -666,7 +751,13 @@ static int parse_stroke_object(JsonParser* parser, LoadedObjectData* data)
     }
 }
 
-/** Parse `"geometry"` sub-object into loaded object staging struct. */
+/**
+ * @brief parse_geometry_object 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @param data 参数 `data`。
+ * @return 函数返回值。
+ */
 static int parse_geometry_object(JsonParser* parser, LoadedObjectData* data)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACE)) {
@@ -754,7 +845,13 @@ static int parse_geometry_object(JsonParser* parser, LoadedObjectData* data)
     }
 }
 
-/** Parse and validate object `"type"` token. */
+/**
+ * @brief parse_object_type 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @param data 参数 `data`。
+ * @return 函数返回值。
+ */
 static int parse_object_type(JsonParser* parser, LoadedObjectData* data)
 {
     if (!json_expect(parser, JSON_TOKEN_STRING)) {
@@ -778,7 +875,12 @@ static int parse_object_type(JsonParser* parser, LoadedObjectData* data)
     return 1;
 }
 
-/** Build runtime object from parsed staged fields; returns `NULL` on missing required data. */
+/**
+ * @brief build_loaded_object 函数。
+ *
+ * @param data 参数 `data`。
+ * @return 函数返回值。
+ */
 static GraphicObject* build_loaded_object(const LoadedObjectData* data)
 {
     if (!data || !data->has_id || !data->has_type ||
@@ -837,6 +939,16 @@ static GraphicObject* build_loaded_object(const LoadedObjectData* data)
 
 /**
  * @brief Parse one object entry and append it to document.
+ * @param parser [in,out] JSON 解析器。
+ * @param document [in,out] 目标文档。
+ * @return 解析并追加成功返回 `1`，否则返回 `0`。
+ *
+ * 算法步骤：
+ * 1. 读取对象字段（`id/type/stroke/geometry`）；
+ * 2. 未识别字段统一跳过值；
+ * 3. 校验后构建运行时对象；
+ * 4. 以指定 ID 追加进文档。
+ *
  * Risk note:
  * - On append failure, allocated object is destroyed immediately to prevent leaks.
  */
@@ -927,7 +1039,14 @@ static int parse_object_entry(JsonParser* parser, Document* document)
     return 1;
 }
 
-/** Parse selection ID array (extra IDs beyond max are safely ignored). */
+/**
+ * @brief parse_selection_array 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @param selection_ids 参数 `selection_ids`。
+ * @param selection_count 参数 `selection_count`。
+ * @return 函数返回值。
+ */
 static int parse_selection_array(JsonParser* parser, ObjectId* selection_ids, int* selection_count)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACKET)) {
@@ -965,7 +1084,13 @@ static int parse_selection_array(JsonParser* parser, ObjectId* selection_ids, in
     }
 }
 
-/** Parse objects array and append all parsed entries to document. */
+/**
+ * @brief parse_objects_array 函数。
+ *
+ * @param parser 参数 `parser`。
+ * @param document 参数 `document`。
+ * @return 函数返回值。
+ */
 static int parse_objects_array(JsonParser* parser, Document* document)
 {
     if (!json_expect(parser, JSON_TOKEN_LBRACKET)) {
@@ -997,7 +1122,11 @@ static int parse_objects_array(JsonParser* parser, Document* document)
 
 /**
  * @brief Parse top-level document JSON object.
+ * @param parser [in,out] JSON 解析器。
+ * @param document [in,out] 目标文档。
  * @return `1` on valid schema/content, `0` on parse/schema mismatch.
+ *
+ * @note 该函数只接受受支持的 schema，并严格校验 `format/version`。
  */
 static int parse_document_root(JsonParser* parser, Document* document)
 {
@@ -1106,6 +1235,14 @@ static int parse_document_root(JsonParser* parser, Document* document)
  * @brief Save document to JSON path using temp-file replacement.
  * @return `1` on success, `0` on allocation/I/O/serialization failure.
  */
+
+/**
+ * @brief document_save_json 函数。
+ *
+ * @param document 参数 `document`。
+ * @param path 参数 `path`。
+ * @return 函数返回值。
+ */
 int document_save_json(const Document* document, const char* path)
 {
     FILE* file = NULL;
@@ -1161,6 +1298,8 @@ int document_save_json(const Document* document, const char* path)
 
 /**
  * @brief Load document from JSON file into runtime model.
+ * @param document [in,out] 目标文档。
+ * @param path [in] JSON 文件路径。
  * @return `1` on success, `0` on I/O/parse/validation failure.
  *
  * Why staged load:

--- a/src/document/persistence.c
+++ b/src/document/persistence.c
@@ -86,10 +86,9 @@ typedef struct {
 } LoadedObjectData;
 
 /**
- * @brief read_text_file 函数。
- *
- * @param path 参数 `path`。
- * @return 函数返回值。
+ * @brief Reads a text file.
+ * @param path File path.
+ * @return File contents or NULL.
  */
 static char* read_text_file(const char* path)
 {
@@ -131,11 +130,10 @@ static char* read_text_file(const char* path)
 }
 
 /**
- * @brief duplicate_path_with_suffix 函数。
- *
- * @param path 参数 `path`。
- * @param suffix 参数 `suffix`。
- * @return 函数返回值。
+ * @brief Duplicates a path with a suffix appended.
+ * @param path Original path.
+ * @param suffix Suffix to append.
+ * @return Duplicated path or NULL.
  */
 static char* duplicate_path_with_suffix(const char* path, const char* suffix)
 {
@@ -161,10 +159,9 @@ static char* duplicate_path_with_suffix(const char* path, const char* suffix)
 }
 
 /**
- * @brief file_exists_at_path 函数。
- *
- * @param path 参数 `path`。
- * @return 函数返回值。
+ * @brief Checks if a file exists at path.
+ * @param path File path.
+ * @return 1 if exists, 0 otherwise.
  */
 static int file_exists_at_path(const char* path)
 {
@@ -184,10 +181,9 @@ static int file_exists_at_path(const char* path)
 }
 
 /**
- * @brief object_type_tag 函数。
- *
- * @param type 参数 `type`。
- * @return 函数返回值。
+ * @brief Gets the type tag string for an object.
+ * @param type Object type.
+ * @return Type tag string.
  */
 static const char* object_type_tag(GraphicObjectType type)
 {
@@ -204,11 +200,10 @@ static const char* object_type_tag(GraphicObjectType type)
 }
 
 /**
- * @brief replace_file_with_temp 函数。
- *
- * @param temp_path 参数 `temp_path`。
- * @param target_path 参数 `target_path`。
- * @return 函数返回值。
+ * @brief Replaces target file with temp file atomically.
+ * @param temp_path Temp file path.
+ * @param target_path Target file path.
+ * @return 1 on success, 0 on failure.
  */
 static int replace_file_with_temp(const char* temp_path, const char* target_path)
 {
@@ -238,12 +233,12 @@ static int replace_file_with_temp(const char* temp_path, const char* target_path
 }
 
 /**
- * @brief 将文档序列化为 JSON 并写入已打开文件。
- * @param file [in,out] 目标文件句柄。
- * @param document [in] 待序列化文档。
- * @return 写入成功返回 `1`，失败返回 `0`。
+ * @brief Serializes document to JSON and writes to open file.
+ * @param file [in,out] Target file handle.
+ * @param document [in] Document to serialize.
+ * @return 1 on success, 0 on failure.
  *
- * @note 使用 `ferror(file)` 作为整体写入失败检测。
+ * @note Uses ferror(file) for overall write failure detection.
  */
 static int write_document_json(FILE* file, const Document* document)
 {
@@ -306,11 +301,10 @@ static int write_document_json(FILE* file, const Document* document)
 }
 
 /**
- * @brief json_match_keyword 函数。
- *
- * @param parser 参数 `parser`。
- * @param keyword 参数 `keyword`。
- * @return 函数返回值。
+ * @brief Checks if parser matches a keyword at current position.
+ * @param parser JSON parser.
+ * @param keyword Keyword to match.
+ * @return 1 if matched, 0 otherwise.
  */
 static int json_match_keyword(const JsonParser* parser, const char* keyword)
 {
@@ -339,10 +333,9 @@ static int json_match_keyword(const JsonParser* parser, const char* keyword)
 }
 
 /**
- * @brief json_parser_skip_ws 函数。
- *
- * @param parser 参数 `parser`。
- * @return 无。
+ * @brief Skips whitespace in JSON parser.
+ * @param parser JSON parser.
+ * @return None.
  */
 static void json_parser_skip_ws(JsonParser* parser)
 {
@@ -353,9 +346,9 @@ static void json_parser_skip_ws(JsonParser* parser)
 }
 
 /**
- * @brief Advance parser to next token.
- * @param parser [in,out] JSON 解析器状态。
- * @return 无。
+ * @brief Advances parser to next token.
+ * @param parser [in,out] JSON parser state.
+ * @return None.
  *
  * Risk note:
  * - Keeps implementation intentionally strict; malformed escape/number forms
@@ -467,11 +460,10 @@ static void json_parser_next(JsonParser* parser)
 }
 
 /**
- * @brief json_token_is_string 函数。
- *
- * @param parser 参数 `parser`。
- * @param literal 参数 `literal`。
- * @return 函数返回值。
+ * @brief Checks if current token is a specific string literal.
+ * @param parser JSON parser.
+ * @param literal String literal to match.
+ * @return 1 if matches, 0 otherwise.
  */
 static int json_token_is_string(const JsonParser* parser, const char* literal)
 {
@@ -487,11 +479,10 @@ static int json_token_is_string(const JsonParser* parser, const char* literal)
 }
 
 /**
- * @brief json_expect 函数。
- *
- * @param parser 参数 `parser`。
- * @param type 参数 `type`。
- * @return 函数返回值。
+ * @brief Expects a specific token type.
+ * @param parser JSON parser.
+ * @param type Expected token type.
+ * @return 1 if matches, 0 otherwise.
  */
 static int json_expect(JsonParser* parser, JsonTokenType type)
 {
@@ -499,11 +490,10 @@ static int json_expect(JsonParser* parser, JsonTokenType type)
 }
 
 /**
- * @brief json_parse_u32 函数。
- *
- * @param parser 参数 `parser`。
- * @param out_value 参数 `out_value`。
- * @return 函数返回值。
+ * @brief Parses an unsigned 32-bit integer.
+ * @param parser JSON parser.
+ * @param out_value Output value pointer.
+ * @return 1 on success, 0 on failure.
  */
 static int json_parse_u32(JsonParser* parser, unsigned int* out_value)
 {
@@ -525,11 +515,10 @@ static int json_parse_u32(JsonParser* parser, unsigned int* out_value)
 }
 
 /**
- * @brief json_parse_float 函数。
- *
- * @param parser 参数 `parser`。
- * @param out_value 参数 `out_value`。
- * @return 函数返回值。
+ * @brief Parses a float value.
+ * @param parser JSON parser.
+ * @param out_value Output value pointer.
+ * @return 1 on success, 0 on failure.
  */
 static int json_parse_float(JsonParser* parser, float* out_value)
 {
@@ -545,10 +534,9 @@ static int json_parse_float(JsonParser* parser, float* out_value)
 static int json_skip_value(JsonParser* parser);
 
 /**
- * @brief json_skip_object 函数。
- *
- * @param parser 参数 `parser`。
- * @return 函数返回值。
+ * @brief Skips a JSON object.
+ * @param parser JSON parser.
+ * @return 1 on success, 0 on failure.
  */
 static int json_skip_object(JsonParser* parser)
 {
@@ -587,10 +575,9 @@ static int json_skip_object(JsonParser* parser)
 }
 
 /**
- * @brief json_skip_array 函数。
- *
- * @param parser 参数 `parser`。
- * @return 函数返回值。
+ * @brief Skips a JSON array.
+ * @param parser JSON parser.
+ * @return 1 on success, 0 on failure.
  */
 static int json_skip_array(JsonParser* parser)
 {
@@ -621,10 +608,9 @@ static int json_skip_array(JsonParser* parser)
 }
 
 /**
- * @brief json_skip_value 函数。
- *
- * @param parser 参数 `parser`。
- * @return 函数返回值。
+ * @brief Skips any JSON value.
+ * @param parser JSON parser.
+ * @return 1 on success, 0 on failure.
  */
 static int json_skip_value(JsonParser* parser)
 {
@@ -646,11 +632,10 @@ static int json_skip_value(JsonParser* parser)
 }
 
 /**
- * @brief parse_stroke_object 函数。
- *
- * @param parser 参数 `parser`。
- * @param data 参数 `data`。
- * @return 函数返回值。
+ * @brief Parses a stroke object.
+ * @param parser JSON parser.
+ * @param data Loaded object data.
+ * @return 1 on success, 0 on failure.
  */
 static int parse_stroke_object(JsonParser* parser, LoadedObjectData* data)
 {
@@ -752,11 +737,10 @@ static int parse_stroke_object(JsonParser* parser, LoadedObjectData* data)
 }
 
 /**
- * @brief parse_geometry_object 函数。
- *
- * @param parser 参数 `parser`。
- * @param data 参数 `data`。
- * @return 函数返回值。
+ * @brief Parses a geometry object.
+ * @param parser JSON parser.
+ * @param data Loaded object data.
+ * @return 1 on success, 0 on failure.
  */
 static int parse_geometry_object(JsonParser* parser, LoadedObjectData* data)
 {
@@ -846,11 +830,10 @@ static int parse_geometry_object(JsonParser* parser, LoadedObjectData* data)
 }
 
 /**
- * @brief parse_object_type 函数。
- *
- * @param parser 参数 `parser`。
- * @param data 参数 `data`。
- * @return 函数返回值。
+ * @brief Parses an object type.
+ * @param parser JSON parser.
+ * @param data Loaded object data.
+ * @return 1 on success, 0 on failure.
  */
 static int parse_object_type(JsonParser* parser, LoadedObjectData* data)
 {
@@ -876,10 +859,9 @@ static int parse_object_type(JsonParser* parser, LoadedObjectData* data)
 }
 
 /**
- * @brief build_loaded_object 函数。
- *
- * @param data 参数 `data`。
- * @return 函数返回值。
+ * @brief Builds a graphic object from loaded data.
+ * @param data Loaded object data.
+ * @return New object or NULL.
  */
 static GraphicObject* build_loaded_object(const LoadedObjectData* data)
 {
@@ -939,15 +921,15 @@ static GraphicObject* build_loaded_object(const LoadedObjectData* data)
 
 /**
  * @brief Parse one object entry and append it to document.
- * @param parser [in,out] JSON 解析器。
- * @param document [in,out] 目标文档。
- * @return 解析并追加成功返回 `1`，否则返回 `0`。
+ * @param parser [in,out] JSON parser.
+ * @param document [in,out] Target document.
+ * @return 1 on success, 0 on failure.
  *
- * 算法步骤：
- * 1. 读取对象字段（`id/type/stroke/geometry`）；
- * 2. 未识别字段统一跳过值；
- * 3. 校验后构建运行时对象；
- * 4. 以指定 ID 追加进文档。
+ * Algorithm steps:
+ * 1. Reads object fields (id/type/stroke/geometry).
+ * 2. Skips unrecognized fields.
+ * 3. Validates and constructs runtime object.
+ * 4. Appends to document with specified ID.
  *
  * Risk note:
  * - On append failure, allocated object is destroyed immediately to prevent leaks.
@@ -1040,12 +1022,11 @@ static int parse_object_entry(JsonParser* parser, Document* document)
 }
 
 /**
- * @brief parse_selection_array 函数。
- *
- * @param parser 参数 `parser`。
- * @param selection_ids 参数 `selection_ids`。
- * @param selection_count 参数 `selection_count`。
- * @return 函数返回值。
+ * @brief Parses a selection array.
+ * @param parser JSON parser.
+ * @param selection_ids Output array for selection IDs.
+ * @param selection_count Output count pointer.
+ * @return 1 on success, 0 on failure.
  */
 static int parse_selection_array(JsonParser* parser, ObjectId* selection_ids, int* selection_count)
 {
@@ -1085,11 +1066,10 @@ static int parse_selection_array(JsonParser* parser, ObjectId* selection_ids, in
 }
 
 /**
- * @brief parse_objects_array 函数。
- *
- * @param parser 参数 `parser`。
- * @param document 参数 `document`。
- * @return 函数返回值。
+ * @brief Parses an objects array.
+ * @param parser JSON parser.
+ * @param document Target document.
+ * @return 1 on success, 0 on failure.
  */
 static int parse_objects_array(JsonParser* parser, Document* document)
 {
@@ -1122,11 +1102,11 @@ static int parse_objects_array(JsonParser* parser, Document* document)
 
 /**
  * @brief Parse top-level document JSON object.
- * @param parser [in,out] JSON 解析器。
- * @param document [in,out] 目标文档。
- * @return `1` on valid schema/content, `0` on parse/schema mismatch.
+ * @param parser [in,out] JSON parser.
+ * @param document [in,out] Target document.
+ * @return 1 on valid schema/content, 0 on parse/schema mismatch.
  *
- * @note 该函数只接受受支持的 schema，并严格校验 `format/version`。
+ * @note This function only accepts supported schema and strictly validates format/version.
  */
 static int parse_document_root(JsonParser* parser, Document* document)
 {
@@ -1237,11 +1217,10 @@ static int parse_document_root(JsonParser* parser, Document* document)
  */
 
 /**
- * @brief document_save_json 函数。
- *
- * @param document 参数 `document`。
- * @param path 参数 `path`。
- * @return 函数返回值。
+ * @brief Saves document to JSON file.
+ * @param document Document to save.
+ * @param path Output file path.
+ * @return 1 on success, 0 on failure.
  */
 int document_save_json(const Document* document, const char* path)
 {
@@ -1297,10 +1276,10 @@ int document_save_json(const Document* document, const char* path)
 }
 
 /**
- * @brief Load document from JSON file into runtime model.
- * @param document [in,out] 目标文档。
- * @param path [in] JSON 文件路径。
- * @return `1` on success, `0` on I/O/parse/validation failure.
+ * @brief Loads document from JSON file into runtime model.
+ * @param document [in,out] Target document.
+ * @param path [in] JSON file path.
+ * @return 1 on success, 0 on I/O/parse/validation failure.
  *
  * Why staged load:
  * - Parses into a temporary `loaded_document` first; current document is only

--- a/src/main.c
+++ b/src/main.c
@@ -19,10 +19,9 @@
  */
 
 /**
- * @brief main 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Program entry point.
+ * @param void No parameters.
+ * @return Application exit code.
  */
 int main(void)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,13 @@
  * Edge cases:
  * - Failures are handled inside `app_run()`.
  */
+
+/**
+ * @brief main 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 int main(void)
 {
     return app_run();

--- a/src/platform/window.c
+++ b/src/platform/window.c
@@ -100,10 +100,8 @@ void platform_window_shutdown(PlatformWindow* window)
 }
 
 /**
- * @brief platform_window_poll_events 函数。
- *
- * @param void 无参数。
- * @return 无。
+ * @brief Poll window events.
+ * @return No return value.
  */
 void platform_window_poll_events(void)
 {
@@ -111,10 +109,9 @@ void platform_window_poll_events(void)
 }
 
 /**
- * @brief platform_window_swap_buffers 函数。
- *
- * @param window 参数 `window`。
- * @return 无。
+ * @brief Swap the window front and back buffers.
+ * @param window Target window.
+ * @return No return value.
  */
 void platform_window_swap_buffers(PlatformWindow* window)
 {
@@ -124,10 +121,9 @@ void platform_window_swap_buffers(PlatformWindow* window)
 }
 
 /**
- * @brief platform_window_should_close 函数。
- *
- * @param window 参数 `window`。
- * @return 函数返回值。
+ * @brief Query whether the window should close.
+ * @param window Target window.
+ * @return Non-zero if the window should close, zero otherwise.
  */
 int platform_window_should_close(const PlatformWindow* window)
 {

--- a/src/platform/window.c
+++ b/src/platform/window.c
@@ -99,13 +99,23 @@ void platform_window_shutdown(PlatformWindow* window)
     }
 }
 
-/** Poll pending OS events. */
+/**
+ * @brief platform_window_poll_events 函数。
+ *
+ * @param void 无参数。
+ * @return 无。
+ */
 void platform_window_poll_events(void)
 {
     glfwPollEvents();
 }
 
-/** Swap front/back buffers for valid window handle. */
+/**
+ * @brief platform_window_swap_buffers 函数。
+ *
+ * @param window 参数 `window`。
+ * @return 无。
+ */
 void platform_window_swap_buffers(PlatformWindow* window)
 {
     if (window && window->handle) {
@@ -113,7 +123,12 @@ void platform_window_swap_buffers(PlatformWindow* window)
     }
 }
 
-/** Return close-state (treat invalid window as closed). */
+/**
+ * @brief platform_window_should_close 函数。
+ *
+ * @param window 参数 `window`。
+ * @return 函数返回值。
+ */
 int platform_window_should_close(const PlatformWindow* window)
 {
     if (!window || !window->handle) {

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -65,7 +65,12 @@ struct RenderSystem {
     unsigned int debug_frame_counter;
 };
 
-/** Log and drain all pending GL errors for a render stage marker. */
+/**
+ * @brief log_gl_error_if_any 函数。
+ *
+ * @param stage 参数 `stage`。
+ * @return 无。
+ */
 static void log_gl_error_if_any(const char* stage)
 {
     GLenum error_code = glGetError();
@@ -84,7 +89,18 @@ static void log_gl_error_if_any(const char* stage)
     }
 }
 
-/** KHR_debug callback used in debug builds for richer driver diagnostics. */
+/**
+ * @brief render_debug_callback 函数。
+ *
+ * @param source 参数 `source`。
+ * @param type 参数 `type`。
+ * @param id 参数 `id`。
+ * @param severity 参数 `severity`。
+ * @param length 参数 `length`。
+ * @param message 参数 `message`。
+ * @param user_param 参数 `user_param`。
+ * @return 函数返回值。
+ */
 static void APIENTRY render_debug_callback(GLenum source,
                                            GLenum type,
                                            GLuint id,
@@ -113,7 +129,12 @@ static void APIENTRY render_debug_callback(GLenum source,
 #endif
 }
 
-/** Debug-only lightweight frame stats log with throttling to avoid console spam. */
+/**
+ * @brief render_log_frame_stats 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @return 无。
+ */
 static void render_log_frame_stats(const RenderSystem* renderer)
 {
 #if !defined(NDEBUG)
@@ -136,7 +157,12 @@ static void render_log_frame_stats(const RenderSystem* renderer)
 #endif
 }
 
-/** Read shader source text file into heap buffer. */
+/**
+ * @brief read_text_file 函数。
+ *
+ * @param path 参数 `path`。
+ * @return 函数返回值。
+ */
 static char* read_text_file(const char* path)
 {
     FILE* file = fopen(path, "rb");
@@ -164,7 +190,14 @@ static char* read_text_file(const char* path)
     return buffer;
 }
 
-/** Compile one shader stage from source; returns 0 on compile failure. */
+/**
+ * @brief compile_shader 函数。
+ *
+ * @param type 参数 `type`。
+ * @param source 参数 `source`。
+ * @param label 参数 `label`。
+ * @return 函数返回值。
+ */
 static GLuint compile_shader(GLenum type, const char* source, const char* label)
 {
     GLuint shader = glCreateShader(type);
@@ -186,7 +219,13 @@ static GLuint compile_shader(GLenum type, const char* source, const char* label)
     return shader;
 }
 
-/** Load, compile, and link shader program; returns 0 on failure. */
+/**
+ * @brief load_program 函数。
+ *
+ * @param vertex_path 参数 `vertex_path`。
+ * @param fragment_path 参数 `fragment_path`。
+ * @return 函数返回值。
+ */
 static GLuint load_program(const char* vertex_path, const char* fragment_path)
 {
     char* vertex_source = read_text_file(vertex_path);
@@ -246,6 +285,14 @@ static GLuint load_program(const char* vertex_path, const char* fragment_path)
  * Risk note:
  * - Uses `realloc`; on failure old buffers remain valid and unchanged.
  */
+
+/**
+ * @brief ensure_screen_vertex_capacity 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @param vertex_count 参数 `vertex_count`。
+ * @return 函数返回值。
+ */
 static int ensure_screen_vertex_capacity(RenderSystem* renderer, size_t vertex_count)
 {
     size_t required_vertex_capacity = vertex_count * RENDER_VERTEX_STRIDE_FLOATS;
@@ -262,7 +309,13 @@ static int ensure_screen_vertex_capacity(RenderSystem* renderer, size_t vertex_c
     return 1;
 }
 
-/** Ensure world-space path buffer can store requested point count. */
+/**
+ * @brief ensure_path_capacity 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @param point_count 参数 `point_count`。
+ * @return 函数返回值。
+ */
 static int ensure_path_capacity(RenderSystem* renderer, size_t point_count)
 {
     if (point_count > renderer->path_buffer_capacity) {
@@ -277,7 +330,13 @@ static int ensure_path_capacity(RenderSystem* renderer, size_t point_count)
     return 1;
 }
 
-/** Ensure GPU vertex buffer can store the current batch without reallocation on every draw. */
+/**
+ * @brief ensure_gpu_vertex_capacity 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @param vertex_count 参数 `vertex_count`。
+ * @return 函数返回值。
+ */
 static int ensure_gpu_vertex_capacity(RenderSystem* renderer, size_t vertex_count)
 {
     size_t required_vertex_capacity = vertex_count * RENDER_VERTEX_STRIDE_FLOATS;
@@ -298,7 +357,14 @@ static int ensure_gpu_vertex_capacity(RenderSystem* renderer, size_t vertex_coun
     return 1;
 }
 
-/** Append one colored screen-space vertex into the CPU staging buffer. */
+/**
+ * @brief write_screen_vertex 函数。
+ *
+ * @param cursor 参数 `cursor`。
+ * @param screen 参数 `screen`。
+ * @param color 参数 `color`。
+ * @return 无。
+ */
 static void write_screen_vertex(float** cursor, Vec2 screen, Color color)
 {
     *(*cursor)++ = screen.x;
@@ -309,13 +375,24 @@ static void write_screen_vertex(float** cursor, Vec2 screen, Color color)
     *(*cursor)++ = color.a;
 }
 
-/** Normalize line-strip draws to line segments so multiple paths can share one batch. */
+/**
+ * @brief batch_primitive_for 函数。
+ *
+ * @param primitive 参数 `primitive`。
+ * @return 函数返回值。
+ */
 static GLenum batch_primitive_for(GLenum primitive)
 {
     return (primitive == GL_LINE_STRIP) ? GL_LINES : primitive;
 }
 
-/** Return the number of staged vertices needed for one batched line draw. */
+/**
+ * @brief batch_vertex_count_for 函数。
+ *
+ * @param primitive 参数 `primitive`。
+ * @param point_count 参数 `point_count`。
+ * @return 函数返回值。
+ */
 static int batch_vertex_count_for(GLenum primitive, int point_count)
 {
     if (point_count <= 0) {
@@ -329,7 +406,13 @@ static int batch_vertex_count_for(GLenum primitive, int point_count)
     return point_count;
 }
 
-/** Upload staged screen-space vertices into the dynamic VBO. */
+/**
+ * @brief upload_vertices 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @param vertex_count 参数 `vertex_count`。
+ * @return 函数返回值。
+ */
 static int upload_vertices(RenderSystem* renderer, int vertex_count)
 {
     if (!renderer || vertex_count <= 0) {
@@ -348,7 +431,12 @@ static int upload_vertices(RenderSystem* renderer, int vertex_count)
     return 1;
 }
 
-/** Reset frame-local batch state and counters. */
+/**
+ * @brief begin_frame_batch 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @return 无。
+ */
 static void begin_frame_batch(RenderSystem* renderer)
 {
     if (!renderer) {
@@ -362,7 +450,15 @@ static void begin_frame_batch(RenderSystem* renderer)
     renderer->frame_uploads = 0;
 }
 
-/** Return whether the requested line draw can be appended to the current frame batch. */
+/**
+ * @brief can_append_line_batch 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @param primitive 参数 `primitive`。
+ * @param line_width 参数 `line_width`。
+ * @param append_vertices 参数 `append_vertices`。
+ * @return 函数返回值。
+ */
 static int can_append_line_batch(RenderSystem* renderer,
                                  GLenum primitive,
                                  float line_width,
@@ -383,7 +479,13 @@ static int can_append_line_batch(RenderSystem* renderer,
            fabsf(renderer->current_line_width - effective_line_width) <= 0.01f;
 }
 
-/** Upload and draw the currently staged line batch, if any. */
+/**
+ * @brief 提交并绘制当前缓存批次。
+ * @param renderer [in,out] 渲染器。
+ * @return 无。
+ *
+ * @note 仅当 `batched_vertex_count > 0` 时触发上传与绘制，随后重置批次状态。
+ */
 static void flush_batch(RenderSystem* renderer)
 {
     if (!renderer || renderer->batched_vertex_count <= 0) {
@@ -402,7 +504,18 @@ static void flush_batch(RenderSystem* renderer)
     renderer->batched_vertex_count = 0;
 }
 
-/** Append line vertices into the current frame batch without drawing immediately. */
+/**
+ * @brief append_line_vertices 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @param canvas 参数 `canvas`。
+ * @param points 参数 `points`。
+ * @param count 参数 `count`。
+ * @param color 参数 `color`。
+ * @param primitive 参数 `primitive`。
+ * @param line_width 参数 `line_width`。
+ * @return 函数返回值。
+ */
 static int append_line_vertices(RenderSystem* renderer,
                                 const CanvasView* canvas,
                                 const Vec2* points,
@@ -449,13 +562,27 @@ static int append_line_vertices(RenderSystem* renderer,
     return 1;
 }
 
-/** Flush any remaining frame batch at the end of the render pass. */
+/**
+ * @brief end_frame_batch 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @return 无。
+ */
 static void end_frame_batch(RenderSystem* renderer)
 {
     flush_batch(renderer);
 }
 
-/** Draw one polyline path. */
+/**
+ * @brief 绘制一条折线/线带路径。
+ * @param renderer [in,out] 渲染器。
+ * @param canvas [in] 画布视图。
+ * @param points [in] 路径点数组。
+ * @param count [in] 点数量。
+ * @param color [in] 线颜色。
+ * @param line_width [in] 线宽。
+ * @return 无。
+ */
 static void draw_polyline(RenderSystem* renderer,
                           const CanvasView* canvas,
                           const Vec2* points,
@@ -476,7 +603,14 @@ static void draw_polyline(RenderSystem* renderer,
     append_line_vertices(renderer, canvas, points, count, color, GL_LINE_STRIP, line_width);
 }
 
-/** Count regularly spaced grid lines across one visible axis span. */
+/**
+ * @brief count_grid_lines 函数。
+ *
+ * @param start 参数 `start`。
+ * @param end 参数 `end`。
+ * @param spacing 参数 `spacing`。
+ * @return 函数返回值。
+ */
 static int count_grid_lines(float start, float end, float spacing)
 {
     int count = 0;
@@ -495,7 +629,18 @@ static int count_grid_lines(float start, float end, float spacing)
     return count;
 }
 
-/** Draw world grid and axis lines in currently visible world rectangle. */
+/**
+ * @brief 绘制当前可视区域的网格与坐标轴。
+ * @param renderer [in,out] 渲染器。
+ * @param canvas [in] 画布视图。
+ * @return 无。
+ *
+ * 算法步骤：
+ * 1. 计算可视世界矩形与网格起止坐标；
+ * 2. 批量生成垂直/水平网格线段端点；
+ * 3. 追加到 line batch；
+ * 4. 额外绘制 X/Y 轴高亮线。
+ */
 static void draw_grid(RenderSystem* renderer, const CanvasView* canvas)
 {
     RectF visible = canvas_view_visible_world_rect(canvas);
@@ -551,7 +696,15 @@ static void draw_grid(RenderSystem* renderer, const CanvasView* canvas)
     append_line_vertices(renderer, canvas, axis_points, 4, axis_color, GL_LINES, 1.5f);
 }
 
-/** Draw one object path with optional selection highlight underlay. */
+/**
+ * @brief draw_object 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @param canvas 参数 `canvas`。
+ * @param object 参数 `object`。
+ * @param selected 参数 `selected`。
+ * @return 无。
+ */
 static void draw_object(RenderSystem* renderer,
                         const CanvasView* canvas,
                         const GraphicObject* object,
@@ -574,6 +727,16 @@ static void draw_object(RenderSystem* renderer,
 /**
  * @brief Convert canvas viewport to GL scissor box.
  * @return `1` when resulting scissor area is valid and non-empty, else `0`.
+ */
+
+/**
+ * @brief render_canvas_scissor_box 函数。
+ *
+ * @param viewport 参数 `viewport`。
+ * @param framebuffer_width 参数 `framebuffer_width`。
+ * @param framebuffer_height 参数 `framebuffer_height`。
+ * @param out_scissor 参数 `out_scissor`。
+ * @return 函数返回值。
  */
 static int render_canvas_scissor_box(const RectF* viewport, int framebuffer_width, int framebuffer_height, GLint out_scissor[4])
 {
@@ -622,7 +785,12 @@ static int render_canvas_scissor_box(const RectF* viewport, int framebuffer_widt
     return 1;
 }
 
-/** Create renderer resources and configure OpenGL state. */
+/**
+ * @brief render_system_create 函数。
+ *
+ * @param window 参数 `window`。
+ * @return 函数返回值。
+ */
 RenderSystem* render_system_create(PlatformWindow* window)
 {
     RenderSystem* renderer = (RenderSystem*)calloc(1, sizeof(*renderer));
@@ -696,7 +864,12 @@ RenderSystem* render_system_create(PlatformWindow* window)
     return renderer;
 }
 
-/** Destroy renderer-owned GL objects and heap buffers. */
+/**
+ * @brief render_system_destroy 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @return 无。
+ */
 void render_system_destroy(RenderSystem* renderer)
 {
     if (!renderer) {
@@ -711,7 +884,14 @@ void render_system_destroy(RenderSystem* renderer)
     free(renderer);
 }
 
-/** Update viewport and shader uniform after framebuffer resize. */
+/**
+ * @brief render_system_resize 函数。
+ *
+ * @param renderer 参数 `renderer`。
+ * @param width 参数 `width`。
+ * @param height 参数 `height`。
+ * @return 无。
+ */
 void render_system_resize(RenderSystem* renderer, int width, int height)
 {
     if (!renderer) {
@@ -730,6 +910,11 @@ void render_system_resize(RenderSystem* renderer, int width, int height)
 
 /**
  * @brief Render full canvas frame.
+ * @param renderer [in,out] 渲染器。
+ * @param document [in] 文档对象集合。
+ * @param canvas [in] 画布视图。
+ * @param overlay_object [in] 工具叠加预览对象（可为 `NULL`）。
+ * @return 无。
  *
  * Why preserve scissor state:
  * - UI and renderer may share context state; previous scissor state is restored

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -66,10 +66,9 @@ struct RenderSystem {
 };
 
 /**
- * @brief log_gl_error_if_any 函数。
- *
- * @param stage 参数 `stage`。
- * @return 无。
+ * @brief Log any pending GL errors.
+ * @param stage Label describing the stage where the error check occurs.
+ * @return No return value.
  */
 static void log_gl_error_if_any(const char* stage)
 {
@@ -90,16 +89,15 @@ static void log_gl_error_if_any(const char* stage)
 }
 
 /**
- * @brief render_debug_callback 函数。
- *
- * @param source 参数 `source`。
- * @param type 参数 `type`。
- * @param id 参数 `id`。
- * @param severity 参数 `severity`。
- * @param length 参数 `length`。
- * @param message 参数 `message`。
- * @param user_param 参数 `user_param`。
- * @return 函数返回值。
+ * @brief GL debug message callback.
+ * @param source GL message source.
+ * @param type GL message type.
+ * @param id GL message ID.
+ * @param severity GL message severity.
+ * @param length Message length.
+ * @param message Message string.
+ * @param user_param User parameter.
+ * @return No return value.
  */
 static void APIENTRY render_debug_callback(GLenum source,
                                            GLenum type,
@@ -130,10 +128,9 @@ static void APIENTRY render_debug_callback(GLenum source,
 }
 
 /**
- * @brief render_log_frame_stats 函数。
- *
- * @param renderer 参数 `renderer`。
- * @return 无。
+ * @brief Log frame statistics every 120 frames (debug builds only).
+ * @param renderer Renderer instance.
+ * @return No return value.
  */
 static void render_log_frame_stats(const RenderSystem* renderer)
 {
@@ -158,10 +155,9 @@ static void render_log_frame_stats(const RenderSystem* renderer)
 }
 
 /**
- * @brief read_text_file 函数。
- *
- * @param path 参数 `path`。
- * @return 函数返回值。
+ * @brief Read a text file into a heap-allocated buffer.
+ * @param path File path.
+ * @return Newly allocated buffer on success, `NULL` on failure.
  */
 static char* read_text_file(const char* path)
 {
@@ -191,12 +187,11 @@ static char* read_text_file(const char* path)
 }
 
 /**
- * @brief compile_shader 函数。
- *
- * @param type 参数 `type`。
- * @param source 参数 `source`。
- * @param label 参数 `label`。
- * @return 函数返回值。
+ * @brief Compile a shader from source string.
+ * @param type Shader type (GL_VERTEX_SHADER or GL_FRAGMENT_SHADER).
+ * @param source Shader source code.
+ * @param label Human-readable label for error messages.
+ * @return Shader handle on success, `0` on failure.
  */
 static GLuint compile_shader(GLenum type, const char* source, const char* label)
 {
@@ -220,11 +215,10 @@ static GLuint compile_shader(GLenum type, const char* source, const char* label)
 }
 
 /**
- * @brief load_program 函数。
- *
- * @param vertex_path 参数 `vertex_path`。
- * @param fragment_path 参数 `fragment_path`。
- * @return 函数返回值。
+ * @brief Load a shader program from vertex and fragment source files.
+ * @param vertex_path Path to vertex shader file.
+ * @param fragment_path Path to fragment shader file.
+ * @return Program handle on success, `0` on failure.
  */
 static GLuint load_program(const char* vertex_path, const char* fragment_path)
 {
@@ -287,11 +281,13 @@ static GLuint load_program(const char* vertex_path, const char* fragment_path)
  */
 
 /**
- * @brief ensure_screen_vertex_capacity 函数。
+ * @brief Ensure CPU screen-vertex buffer can store requested vertex count.
+ * @param renderer Renderer instance.
+ * @param vertex_count Requested vertex count.
+ * @return `1` on success, `0` on allocation failure.
  *
- * @param renderer 参数 `renderer`。
- * @param vertex_count 参数 `vertex_count`。
- * @return 函数返回值。
+ * Risk note:
+ * - Uses `realloc`; on failure old buffers remain valid and unchanged.
  */
 static int ensure_screen_vertex_capacity(RenderSystem* renderer, size_t vertex_count)
 {
@@ -310,11 +306,10 @@ static int ensure_screen_vertex_capacity(RenderSystem* renderer, size_t vertex_c
 }
 
 /**
- * @brief ensure_path_capacity 函数。
- *
- * @param renderer 参数 `renderer`。
- * @param point_count 参数 `point_count`。
- * @return 函数返回值。
+ * @brief Ensure path buffer can store requested point count.
+ * @param renderer Renderer instance.
+ * @param point_count Requested point count.
+ * @return `1` on success, `0` on allocation failure.
  */
 static int ensure_path_capacity(RenderSystem* renderer, size_t point_count)
 {
@@ -331,11 +326,10 @@ static int ensure_path_capacity(RenderSystem* renderer, size_t point_count)
 }
 
 /**
- * @brief ensure_gpu_vertex_capacity 函数。
- *
- * @param renderer 参数 `renderer`。
- * @param vertex_count 参数 `vertex_count`。
- * @return 函数返回值。
+ * @brief Ensure GPU VBO can store requested vertex count.
+ * @param renderer Renderer instance.
+ * @param vertex_count Requested vertex count.
+ * @return `1` on success, `0` if renderer is `NULL`.
  */
 static int ensure_gpu_vertex_capacity(RenderSystem* renderer, size_t vertex_count)
 {
@@ -358,12 +352,11 @@ static int ensure_gpu_vertex_capacity(RenderSystem* renderer, size_t vertex_coun
 }
 
 /**
- * @brief write_screen_vertex 函数。
- *
- * @param cursor 参数 `cursor`。
- * @param screen 参数 `screen`。
- * @param color 参数 `color`。
- * @return 无。
+ * @brief Write a vertex into the CPU buffer at the cursor position.
+ * @param cursor [in,out] Write cursor pointer.
+ * @param screen Screen coordinate.
+ * @param color Vertex color.
+ * @return No return value.
  */
 static void write_screen_vertex(float** cursor, Vec2 screen, Color color)
 {
@@ -376,10 +369,9 @@ static void write_screen_vertex(float** cursor, Vec2 screen, Color color)
 }
 
 /**
- * @brief batch_primitive_for 函数。
- *
- * @param primitive 参数 `primitive`。
- * @return 函数返回值。
+ * @brief Normalize primitive type for batching.
+ * @param primitive GL primitive type.
+ * @return GL primitive type suitable for batching.
  */
 static GLenum batch_primitive_for(GLenum primitive)
 {
@@ -387,11 +379,10 @@ static GLenum batch_primitive_for(GLenum primitive)
 }
 
 /**
- * @brief batch_vertex_count_for 函数。
- *
- * @param primitive 参数 `primitive`。
- * @param point_count 参数 `point_count`。
- * @return 函数返回值。
+ * @brief Compute how many vertices a primitive type will add to the batch.
+ * @param primitive GL primitive type.
+ * @param point_count Number of points.
+ * @return Number of vertices that will be batched.
  */
 static int batch_vertex_count_for(GLenum primitive, int point_count)
 {
@@ -407,11 +398,10 @@ static int batch_vertex_count_for(GLenum primitive, int point_count)
 }
 
 /**
- * @brief upload_vertices 函数。
- *
- * @param renderer 参数 `renderer`。
- * @param vertex_count 参数 `vertex_count`。
- * @return 函数返回值。
+ * @brief Upload batched vertices to GPU.
+ * @param renderer Renderer instance.
+ * @param vertex_count Number of vertices to upload.
+ * @return `1` on success, `0` on failure.
  */
 static int upload_vertices(RenderSystem* renderer, int vertex_count)
 {
@@ -432,10 +422,9 @@ static int upload_vertices(RenderSystem* renderer, int vertex_count)
 }
 
 /**
- * @brief begin_frame_batch 函数。
- *
- * @param renderer 参数 `renderer`。
- * @return 无。
+ * @brief Begin a new frame batch, resetting batch state.
+ * @param renderer Renderer instance.
+ * @return No return value.
  */
 static void begin_frame_batch(RenderSystem* renderer)
 {
@@ -451,13 +440,12 @@ static void begin_frame_batch(RenderSystem* renderer)
 }
 
 /**
- * @brief can_append_line_batch 函数。
- *
- * @param renderer 参数 `renderer`。
- * @param primitive 参数 `primitive`。
- * @param line_width 参数 `line_width`。
- * @param append_vertices 参数 `append_vertices`。
- * @return 函数返回值。
+ * @brief Check whether a new batch can be appended to the current batch.
+ * @param renderer Renderer instance.
+ * @param primitive GL primitive type.
+ * @param line_width Line width.
+ * @param append_vertices Number of vertices to append.
+ * @return `1` if appendable, `0` otherwise.
  */
 static int can_append_line_batch(RenderSystem* renderer,
                                  GLenum primitive,
@@ -480,11 +468,11 @@ static int can_append_line_batch(RenderSystem* renderer,
 }
 
 /**
- * @brief 提交并绘制当前缓存批次。
- * @param renderer [in,out] 渲染器。
- * @return 无。
+ * @brief Submit and draw the current batched cache.
+ * @param renderer [in,out] Renderer.
+ * @return No return value.
  *
- * @note 仅当 `batched_vertex_count > 0` 时触发上传与绘制，随后重置批次状态。
+ * @note Only triggers upload and draw when `batched_vertex_count > 0`, then resets batch state.
  */
 static void flush_batch(RenderSystem* renderer)
 {
@@ -505,16 +493,15 @@ static void flush_batch(RenderSystem* renderer)
 }
 
 /**
- * @brief append_line_vertices 函数。
- *
- * @param renderer 参数 `renderer`。
- * @param canvas 参数 `canvas`。
- * @param points 参数 `points`。
- * @param count 参数 `count`。
- * @param color 参数 `color`。
- * @param primitive 参数 `primitive`。
- * @param line_width 参数 `line_width`。
- * @return 函数返回值。
+ * @brief Add line vertices to the current batch.
+ * @param renderer Renderer instance.
+ * @param canvas Canvas view.
+ * @param points Point array.
+ * @param count Point count.
+ * @param color Line color.
+ * @param primitive GL primitive type.
+ * @param line_width Line width.
+ * @return `1` on success, `0` on failure.
  */
 static int append_line_vertices(RenderSystem* renderer,
                                 const CanvasView* canvas,
@@ -563,10 +550,9 @@ static int append_line_vertices(RenderSystem* renderer,
 }
 
 /**
- * @brief end_frame_batch 函数。
- *
- * @param renderer 参数 `renderer`。
- * @return 无。
+ * @brief End the frame batch, flushing any remaining batched content.
+ * @param renderer Renderer instance.
+ * @return No return value.
  */
 static void end_frame_batch(RenderSystem* renderer)
 {
@@ -574,14 +560,14 @@ static void end_frame_batch(RenderSystem* renderer)
 }
 
 /**
- * @brief 绘制一条折线/线带路径。
- * @param renderer [in,out] 渲染器。
- * @param canvas [in] 画布视图。
- * @param points [in] 路径点数组。
- * @param count [in] 点数量。
- * @param color [in] 线颜色。
- * @param line_width [in] 线宽。
- * @return 无。
+ * @brief Draw a polyline/line-strip path.
+ * @param renderer [in,out] Renderer.
+ * @param canvas [in] Canvas view.
+ * @param points [in] Path point array.
+ * @param count [in] Point count.
+ * @param color [in] Line color.
+ * @param line_width [in] Line width.
+ * @return No return value.
  */
 static void draw_polyline(RenderSystem* renderer,
                           const CanvasView* canvas,
@@ -604,12 +590,11 @@ static void draw_polyline(RenderSystem* renderer,
 }
 
 /**
- * @brief count_grid_lines 函数。
- *
- * @param start 参数 `start`。
- * @param end 参数 `end`。
- * @param spacing 参数 `spacing`。
- * @return 函数返回值。
+ * @brief Count grid lines between start and end at the given spacing.
+ * @param start Start coordinate.
+ * @param end End coordinate.
+ * @param spacing Grid spacing.
+ * @return Number of grid lines.
  */
 static int count_grid_lines(float start, float end, float spacing)
 {
@@ -630,16 +615,16 @@ static int count_grid_lines(float start, float end, float spacing)
 }
 
 /**
- * @brief 绘制当前可视区域的网格与坐标轴。
- * @param renderer [in,out] 渲染器。
- * @param canvas [in] 画布视图。
- * @return 无。
+ * @brief Draw the grid and axes for the current visible area.
+ * @param renderer [in,out] Renderer.
+ * @param canvas [in] Canvas view.
+ * @return No return value.
  *
- * 算法步骤：
- * 1. 计算可视世界矩形与网格起止坐标；
- * 2. 批量生成垂直/水平网格线段端点；
- * 3. 追加到 line batch；
- * 4. 额外绘制 X/Y 轴高亮线。
+ * Algorithm:
+ * 1. Compute visible world rectangle and grid start/end coordinates;
+ * 2. Batch-generate vertical/horizontal grid line segment endpoints;
+ * 3. Append to line batch;
+ * 4. Also draw X/Y axis highlight lines.
  */
 static void draw_grid(RenderSystem* renderer, const CanvasView* canvas)
 {
@@ -697,13 +682,12 @@ static void draw_grid(RenderSystem* renderer, const CanvasView* canvas)
 }
 
 /**
- * @brief draw_object 函数。
- *
- * @param renderer 参数 `renderer`。
- * @param canvas 参数 `canvas`。
- * @param object 参数 `object`。
- * @param selected 参数 `selected`。
- * @return 无。
+ * @brief Draw a single graphic object.
+ * @param renderer Renderer instance.
+ * @param canvas Canvas view.
+ * @param object Object to draw.
+ * @param selected Whether the object is selected (adds highlight).
+ * @return No return value.
  */
 static void draw_object(RenderSystem* renderer,
                         const CanvasView* canvas,
@@ -730,13 +714,12 @@ static void draw_object(RenderSystem* renderer,
  */
 
 /**
- * @brief render_canvas_scissor_box 函数。
- *
- * @param viewport 参数 `viewport`。
- * @param framebuffer_width 参数 `framebuffer_width`。
- * @param framebuffer_height 参数 `framebuffer_height`。
- * @param out_scissor 参数 `out_scissor`。
- * @return 函数返回值。
+ * @brief Convert canvas viewport to GL scissor box.
+ * @param viewport Canvas viewport rectangle.
+ * @param framebuffer_width Framebuffer width.
+ * @param framebuffer_height Framebuffer height.
+ * @param out_scissor [out] Output scissor box (x, y, w, h).
+ * @return `1` when resulting scissor area is valid and non-empty, else `0`.
  */
 static int render_canvas_scissor_box(const RectF* viewport, int framebuffer_width, int framebuffer_height, GLint out_scissor[4])
 {
@@ -786,10 +769,9 @@ static int render_canvas_scissor_box(const RectF* viewport, int framebuffer_widt
 }
 
 /**
- * @brief render_system_create 函数。
- *
- * @param window 参数 `window`。
- * @return 函数返回值。
+ * @brief Create the rendering system and initialize GPU resources.
+ * @param window Already-initialized platform window.
+ * @return Renderer instance on success, `NULL` on failure.
  */
 RenderSystem* render_system_create(PlatformWindow* window)
 {
@@ -865,10 +847,9 @@ RenderSystem* render_system_create(PlatformWindow* window)
 }
 
 /**
- * @brief render_system_destroy 函数。
- *
- * @param renderer 参数 `renderer`。
- * @return 无。
+ * @brief Destroy the rendering system and release GPU/heap resources.
+ * @param renderer Renderer instance.
+ * @return No return value.
  */
 void render_system_destroy(RenderSystem* renderer)
 {
@@ -885,12 +866,11 @@ void render_system_destroy(RenderSystem* renderer)
 }
 
 /**
- * @brief render_system_resize 函数。
- *
- * @param renderer 参数 `renderer`。
- * @param width 参数 `width`。
- * @param height 参数 `height`。
- * @return 无。
+ * @brief Handle window resize events.
+ * @param renderer Renderer instance.
+ * @param width New width in pixels.
+ * @param height New height in pixels.
+ * @return No return value.
  */
 void render_system_resize(RenderSystem* renderer, int width, int height)
 {
@@ -910,11 +890,11 @@ void render_system_resize(RenderSystem* renderer, int width, int height)
 
 /**
  * @brief Render full canvas frame.
- * @param renderer [in,out] 渲染器。
- * @param document [in] 文档对象集合。
- * @param canvas [in] 画布视图。
- * @param overlay_object [in] 工具叠加预览对象（可为 `NULL`）。
- * @return 无。
+ * @param renderer [in,out] Renderer.
+ * @param document [in] Document object collection.
+ * @param canvas [in] Canvas view.
+ * @param overlay_object [in] Tool overlay preview object (may be `NULL`).
+ * @return No return value.
  *
  * Why preserve scissor state:
  * - UI and renderer may share context state; previous scissor state is restored

--- a/src/tools/tool_controller.c
+++ b/src/tools/tool_controller.c
@@ -48,10 +48,9 @@ typedef struct {
 } ShapeToolState;
 
 /**
- * @brief snapshot_reset 函数。
- *
- * @param snapshot 参数 `snapshot`。
- * @return 无。
+ * @brief Resets a snapshot.
+ * @param snapshot Snapshot to reset.
+ * @return None.
  */
 static void snapshot_reset(DocumentSnapshot* snapshot)
 {
@@ -60,10 +59,9 @@ static void snapshot_reset(DocumentSnapshot* snapshot)
 }
 
 /**
- * @brief destroy_overlay 函数。
- *
- * @param tool 参数 `tool`。
- * @return 无。
+ * @brief Destroys a tool's overlay object.
+ * @param tool Tool instance.
+ * @return None.
  */
 static void destroy_overlay(Tool* tool)
 {
@@ -74,11 +72,10 @@ static void destroy_overlay(Tool* tool)
 }
 
 /**
- * @brief rect_from_points 函数。
- *
- * @param a 参数 `a`。
- * @param b 参数 `b`。
- * @return 函数返回值。
+ * @brief Creates a rectangle from two points.
+ * @param a First point.
+ * @param b Second point.
+ * @return Rectangle bounds.
  */
 static RectF rect_from_points(Vec2 a, Vec2 b)
 {
@@ -91,13 +88,12 @@ static RectF rect_from_points(Vec2 a, Vec2 b)
 }
 
 /**
- * @brief build_shape_object 函数。
- *
- * @param kind 参数 `kind`。
- * @param anchor 参数 `anchor`。
- * @param current 参数 `current`。
- * @param style 参数 `style`。
- * @return 函数返回值。
+ * @brief Builds a shape object from tool kind.
+ * @param kind Shape tool kind.
+ * @param anchor Anchor point.
+ * @param current Current point.
+ * @param style Graphic style.
+ * @return New shape object or NULL.
  */
 static GraphicObject* build_shape_object(ToolKind kind, Vec2 anchor, Vec2 current, GraphicStyle style)
 {
@@ -114,11 +110,10 @@ static GraphicObject* build_shape_object(ToolKind kind, Vec2 anchor, Vec2 curren
 }
 
 /**
- * @brief selection_matches_snapshot 函数。
- *
- * @param document 参数 `document`。
- * @param snapshot 参数 `snapshot`。
- * @return 函数返回值。
+ * @brief Checks if selection matches a snapshot.
+ * @param document Document instance.
+ * @param snapshot Snapshot to compare.
+ * @return 1 if matches, 0 otherwise.
  */
 static int selection_matches_snapshot(const Document* document, const DocumentSnapshot* snapshot)
 {
@@ -142,10 +137,10 @@ static int selection_matches_snapshot(const Document* document, const DocumentSn
 }
 
 /**
- * @brief Push document edit to history and sync dirty flag.
- * @param context [in,out] 工具上下文。
- * @param before_snapshot [in,out] 编辑前快照（该函数会消费并重置）。
- * @return 无。
+ * @brief Pushes document edit to history and syncs dirty flag.
+ * @param context [in,out] Tool context.
+ * @param before_snapshot [in,out] Before snapshot (consumed and reset by this function).
+ * @return None.
  *
  * @remark Safely resets snapshot even when context/history is invalid.
  */
@@ -167,10 +162,9 @@ static void tool_commit_document_change(ToolContext* context, DocumentSnapshot* 
 }
 
 /**
- * @brief select_tool_label 函数。
- *
- * @param tool 参数 `tool`。
- * @return 函数返回值。
+ * @brief Gets the select tool label.
+ * @param tool Tool instance.
+ * @return Tool label string.
  */
 static const char* select_tool_label(const Tool* tool)
 {
@@ -179,11 +173,10 @@ static const char* select_tool_label(const Tool* tool)
 }
 
 /**
- * @brief select_tool_deactivate 函数。
- *
- * @param tool 参数 `tool`。
- * @param context 参数 `context`。
- * @return 无。
+ * @brief Deactivates the select tool.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @return None.
  */
 static void select_tool_deactivate(Tool* tool, ToolContext* context)
 {
@@ -197,11 +190,11 @@ static void select_tool_deactivate(Tool* tool, ToolContext* context)
 }
 
 /**
- * @brief Handle select tool pointer press.
- * @param tool [in,out] 选择工具实例。
- * @param context [in,out] 工具上下文。
- * @param event [in] 指针事件。
- * @return 无。
+ * @brief Handles select tool pointer press.
+ * @param tool [in,out] Select tool instance.
+ * @param context [in,out] Tool context.
+ * @param event [in] Pointer event.
+ * @return None.
  *
  * Why snapshot first:
  * - Captures "before" state before selection/drag mutations so history entry
@@ -286,11 +279,11 @@ static void select_tool_pointer_down(Tool* tool, ToolContext* context, const Too
 }
 
 /**
- * @brief 拖拽过程中按世界坐标增量移动选中对象。
- * @param tool [in,out] 选择工具实例。
- * @param context [in,out] 工具上下文。
- * @param event [in] 指针事件。
- * @return 无。
+ * @brief Moves selected objects by world coordinate delta during drag.
+ * @param tool [in,out] Select tool instance.
+ * @param context [in,out] Tool context.
+ * @param event [in] Pointer event.
+ * @return None.
  */
 static void select_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
@@ -321,13 +314,13 @@ static void select_tool_pointer_move(Tool* tool, ToolContext* context, const Too
 }
 
 /**
- * @brief 结束选择拖拽并按需写入平移历史。
- * @param tool [in,out] 选择工具实例。
- * @param context [in,out] 工具上下文。
- * @param event [in] 指针事件。
- * @return 无。
+ * @brief Ends selection drag and writes translate history if needed.
+ * @param tool [in,out] Select tool instance.
+ * @param context [in,out] Tool context.
+ * @param event [in] Pointer event.
+ * @return None.
  *
- * @note 仅当实际发生位移且对象集合非空时才写入 `translate` 历史条目。
+ * @note Only writes translate history entry when displacement actually occurred and object set is non-empty.
  */
 static void select_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
@@ -358,13 +351,12 @@ static void select_tool_pointer_up(Tool* tool, ToolContext* context, const ToolE
 }
 
 /**
- * @brief select_tool_key_down 函数。
- *
- * @param tool 参数 `tool`。
- * @param context 参数 `context`。
- * @param key 参数 `key`。
- * @param mods 参数 `mods`。
- * @return 无。
+ * @brief Handles key down for select tool.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param key Key code.
+ * @param mods Modifier flags.
+ * @return None.
  */
 static void select_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)
 {
@@ -396,10 +388,9 @@ static const ToolVTable g_select_tool_vtable = {
 };
 
 /**
- * @brief pan_tool_label 函数。
- *
- * @param tool 参数 `tool`。
- * @return 函数返回值。
+ * @brief Gets the pan tool label.
+ * @param tool Tool instance.
+ * @return Tool label string.
  */
 static const char* pan_tool_label(const Tool* tool)
 {
@@ -408,11 +399,10 @@ static const char* pan_tool_label(const Tool* tool)
 }
 
 /**
- * @brief pan_tool_deactivate 函数。
- *
- * @param tool 参数 `tool`。
- * @param context 参数 `context`。
- * @return 无。
+ * @brief Deactivates the pan tool.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @return None.
  */
 static void pan_tool_deactivate(Tool* tool, ToolContext* context)
 {
@@ -422,12 +412,11 @@ static void pan_tool_deactivate(Tool* tool, ToolContext* context)
 }
 
 /**
- * @brief pan_tool_pointer_down 函数。
- *
- * @param tool 参数 `tool`。
- * @param context 参数 `context`。
- * @param event 参数 `event`。
- * @return 无。
+ * @brief Handles pointer down for pan tool.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param event Pointer event.
+ * @return None.
  */
 static void pan_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
@@ -441,12 +430,11 @@ static void pan_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEv
 }
 
 /**
- * @brief pan_tool_pointer_move 函数。
- *
- * @param tool 参数 `tool`。
- * @param context 参数 `context`。
- * @param event 参数 `event`。
- * @return 无。
+ * @brief Handles pointer move for pan tool.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param event Pointer event.
+ * @return None.
  */
 static void pan_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
@@ -459,12 +447,11 @@ static void pan_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEv
 }
 
 /**
- * @brief pan_tool_pointer_up 函数。
- *
- * @param tool 参数 `tool`。
- * @param context 参数 `context`。
- * @param event 参数 `event`。
- * @return 无。
+ * @brief Handles pointer up for pan tool.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param event Pointer event.
+ * @return None.
  */
 static void pan_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
@@ -477,13 +464,12 @@ static void pan_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEven
 }
 
 /**
- * @brief pan_tool_key_down 函数。
- *
- * @param tool 参数 `tool`。
- * @param context 参数 `context`。
- * @param key 参数 `key`。
- * @param mods 参数 `mods`。
- * @return 无。
+ * @brief Handles key down for pan tool.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param key Key code.
+ * @param mods Modifier flags.
+ * @return None.
  */
 static void pan_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)
 {
@@ -506,10 +492,9 @@ static const ToolVTable g_pan_tool_vtable = {
 };
 
 /**
- * @brief shape_tool_label 函数。
- *
- * @param tool 参数 `tool`。
- * @return 函数返回值。
+ * @brief Gets the shape tool label.
+ * @param tool Tool instance.
+ * @return Tool label string.
  */
 static const char* shape_tool_label(const Tool* tool)
 {
@@ -526,11 +511,10 @@ static const char* shape_tool_label(const Tool* tool)
 }
 
 /**
- * @brief shape_tool_deactivate 函数。
- *
- * @param tool 参数 `tool`。
- * @param context 参数 `context`。
- * @return 无。
+ * @brief Deactivates the shape tool.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @return None.
  */
 static void shape_tool_deactivate(Tool* tool, ToolContext* context)
 {
@@ -541,11 +525,11 @@ static void shape_tool_deactivate(Tool* tool, ToolContext* context)
 }
 
 /**
- * @brief 开始图形绘制交互并创建半透明预览对象。
- * @param tool [in,out] 形状工具实例。
- * @param context [in,out] 工具上下文（当前未直接使用）。
- * @param event [in] 指针事件。
- * @return 无。
+ * @brief Begins shape drawing interaction and creates semi-transparent preview.
+ * @param tool [in,out] Shape tool instance.
+ * @param context [in,out] Tool context (currently unused).
+ * @param event [in] Pointer event.
+ * @return None.
  */
 static void shape_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
@@ -567,11 +551,11 @@ static void shape_tool_pointer_down(Tool* tool, ToolContext* context, const Tool
 }
 
 /**
- * @brief 指针移动时更新形状预览对象。
- * @param tool [in,out] 形状工具实例。
- * @param context [in,out] 工具上下文（当前未直接使用）。
- * @param event [in] 指针事件。
- * @return 无。
+ * @brief Updates shape preview object on pointer move.
+ * @param tool [in,out] Shape tool instance.
+ * @param context [in,out] Tool context (currently unused).
+ * @param event [in] Pointer event.
+ * @return None.
  */
 static void shape_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
@@ -590,17 +574,17 @@ static void shape_tool_pointer_move(Tool* tool, ToolContext* context, const Tool
 }
 
 /**
- * @brief Finalize shape creation on pointer release.
- * @param tool [in,out] 形状工具实例。
- * @param context [in,out] 工具上下文。
- * @param event [in] 指针事件。
- * @return 无。
+ * @brief Finalizes shape creation on pointer release.
+ * @param tool [in,out] Shape tool instance.
+ * @param context [in,out] Tool context.
+ * @param event [in] Pointer event.
+ * @return None.
  *
- * 算法步骤：
- * 1. 捕获编辑前快照；
- * 2. 依据锚点和当前点构建最终对象；
- * 3. 追加到文档并更新选择；
- * 4. 将本次变更提交到历史栈。
+ * Algorithm steps:
+ * 1. Captures before edit snapshot.
+ * 2. Builds final object from anchor and current points.
+ * 3. Appends to document and updates selection.
+ * 4. Commits change to history stack.
  *
  * Risk note:
  * - Captures history snapshot before append; allocation/add failures clean up
@@ -641,13 +625,12 @@ static void shape_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEv
 }
 
 /**
- * @brief shape_tool_key_down 函数。
- *
- * @param tool 参数 `tool`。
- * @param context 参数 `context`。
- * @param key 参数 `key`。
- * @param mods 参数 `mods`。
- * @return 无。
+ * @brief Handles key down for shape tool.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param key Key code.
+ * @param mods Modifier flags.
+ * @return None.
  */
 static void shape_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)
 {
@@ -668,13 +651,12 @@ static const ToolVTable g_shape_tool_vtable = {
 };
 
 /**
- * @brief tool_init_slot 函数。
- *
- * @param tool 参数 `tool`。
- * @param kind 参数 `kind`。
- * @param vtable 参数 `vtable`。
- * @param state_size 参数 `state_size`。
- * @return 无。
+ * @brief Initializes a tool slot.
+ * @param tool Tool to initialize.
+ * @param kind Tool kind.
+ * @param vtable Tool vtable.
+ * @param state_size Size of tool state.
+ * @return None.
  */
 static void tool_init_slot(Tool* tool, ToolKind kind, const ToolVTable* vtable, size_t state_size)
 {
@@ -687,10 +669,9 @@ static void tool_init_slot(Tool* tool, ToolKind kind, const ToolVTable* vtable, 
 }
 
 /**
- * @brief tool_controller_init 函数。
- *
- * @param controller 参数 `controller`。
- * @return 无。
+ * @brief Initializes the tool controller.
+ * @param controller Controller instance.
+ * @return None.
  */
 void tool_controller_init(ToolController* controller)
 {
@@ -708,10 +689,9 @@ void tool_controller_init(ToolController* controller)
 }
 
 /**
- * @brief tool_controller_shutdown 函数。
- *
- * @param controller 参数 `controller`。
- * @return 无。
+ * @brief Shuts down the tool controller.
+ * @param controller Controller instance.
+ * @return None.
  */
 void tool_controller_shutdown(ToolController* controller)
 {
@@ -729,10 +709,9 @@ void tool_controller_shutdown(ToolController* controller)
 }
 
 /**
- * @brief tool_controller_get_active 函数。
- *
- * @param controller 参数 `controller`。
- * @return 函数返回值。
+ * @brief Gets the active tool.
+ * @param controller Controller instance.
+ * @return Active tool pointer.
  */
 Tool* tool_controller_get_active(ToolController* controller)
 {
@@ -743,10 +722,9 @@ Tool* tool_controller_get_active(ToolController* controller)
 }
 
 /**
- * @brief tool_controller_active_label 函数。
- *
- * @param controller 参数 `controller`。
- * @return 函数返回值。
+ * @brief Gets the active tool label.
+ * @param controller Controller instance.
+ * @return Active tool label string.
  */
 const char* tool_controller_active_label(const ToolController* controller)
 {
@@ -759,10 +737,9 @@ const char* tool_controller_active_label(const ToolController* controller)
 }
 
 /**
- * @brief tool_controller_overlay_object 函数。
- *
- * @param controller 参数 `controller`。
- * @return 函数返回值。
+ * @brief Gets the overlay object of the active tool.
+ * @param controller Controller instance.
+ * @return Overlay object or NULL.
  */
 GraphicObject* tool_controller_overlay_object(const ToolController* controller)
 {
@@ -773,12 +750,11 @@ GraphicObject* tool_controller_overlay_object(const ToolController* controller)
 }
 
 /**
- * @brief tool_controller_set_active 函数。
- *
- * @param controller 参数 `controller`。
- * @param context 参数 `context`。
- * @param kind 参数 `kind`。
- * @return 无。
+ * @brief Sets the active tool.
+ * @param controller Controller instance.
+ * @param context Tool context.
+ * @param kind Tool kind to activate.
+ * @return None.
  */
 void tool_controller_set_active(ToolController* controller, ToolContext* context, ToolKind kind)
 {
@@ -802,11 +778,11 @@ void tool_controller_set_active(ToolController* controller, ToolContext* context
 }
 
 /**
- * @brief 分发按下事件并开启指针捕获。
- * @param controller [in,out] 工具控制器。
- * @param context [in,out] 工具上下文。
- * @param event [in] 指针事件。
- * @return 无。
+ * @brief Dispatches pointer press event and starts pointer capture.
+ * @param controller [in,out] Tool controller.
+ * @param context [in,out] Tool context.
+ * @param event [in] Pointer event.
+ * @return None.
  */
 void tool_controller_pointer_down(ToolController* controller, ToolContext* context, const ToolEvent* event)
 {
@@ -821,11 +797,11 @@ void tool_controller_pointer_down(ToolController* controller, ToolContext* conte
 }
 
 /**
- * @brief 分发移动事件到当前激活工具。
- * @param controller [in,out] 工具控制器。
- * @param context [in,out] 工具上下文。
- * @param event [in] 指针事件。
- * @return 无。
+ * @brief Dispatches move event to currently active tool.
+ * @param controller [in,out] Tool controller.
+ * @param context [in,out] Tool context.
+ * @param event [in] Pointer event.
+ * @return None.
  */
 void tool_controller_pointer_move(ToolController* controller, ToolContext* context, const ToolEvent* event)
 {
@@ -839,11 +815,11 @@ void tool_controller_pointer_move(ToolController* controller, ToolContext* conte
 }
 
 /**
- * @brief 分发释放事件并结束指针捕获。
- * @param controller [in,out] 工具控制器。
- * @param context [in,out] 工具上下文。
- * @param event [in] 指针事件。
- * @return 无。
+ * @brief Dispatches release event and ends pointer capture.
+ * @param controller [in,out] Tool controller.
+ * @param context [in,out] Tool context.
+ * @param event [in] Pointer event.
+ * @return None.
  */
 void tool_controller_pointer_up(ToolController* controller, ToolContext* context, const ToolEvent* event)
 {
@@ -858,13 +834,12 @@ void tool_controller_pointer_up(ToolController* controller, ToolContext* context
 }
 
 /**
- * @brief tool_controller_key_down 函数。
- *
- * @param controller 参数 `controller`。
- * @param context 参数 `context`。
- * @param key 参数 `key`。
- * @param mods 参数 `mods`。
- * @return 无。
+ * @brief Handles key down for tool controller.
+ * @param controller Controller instance.
+ * @param context Tool context.
+ * @param key Key code.
+ * @param mods Modifier flags.
+ * @return None.
  */
 void tool_controller_key_down(ToolController* controller, ToolContext* context, int key, int mods)
 {
@@ -936,13 +911,12 @@ void tool_controller_key_down(ToolController* controller, ToolContext* context, 
 }
 
 /**
- * @brief tool_controller_scroll 函数。
- *
- * @param controller 参数 `controller`。
- * @param context 参数 `context`。
- * @param screen_pos 参数 `screen_pos`。
- * @param yoffset 参数 `yoffset`。
- * @return 无。
+ * @brief Handles scroll event for tool controller.
+ * @param controller Controller instance.
+ * @param context Tool context.
+ * @param screen_pos Screen position.
+ * @param yoffset Vertical scroll offset.
+ * @return None.
  */
 void tool_controller_scroll(ToolController* controller, ToolContext* context, Vec2 screen_pos, float yoffset)
 {

--- a/src/tools/tool_controller.c
+++ b/src/tools/tool_controller.c
@@ -47,14 +47,24 @@ typedef struct {
     Vec2 current;
 } ShapeToolState;
 
-/** Free and re-init snapshot for reuse. */
+/**
+ * @brief snapshot_reset 函数。
+ *
+ * @param snapshot 参数 `snapshot`。
+ * @return 无。
+ */
 static void snapshot_reset(DocumentSnapshot* snapshot)
 {
     document_snapshot_free(snapshot);
     document_snapshot_init(snapshot);
 }
 
-/** Destroy active overlay object preview if present. */
+/**
+ * @brief destroy_overlay 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @return 无。
+ */
 static void destroy_overlay(Tool* tool)
 {
     if (tool && tool->overlay_object) {
@@ -63,7 +73,13 @@ static void destroy_overlay(Tool* tool)
     }
 }
 
-/** Build axis-aligned rect from two arbitrary points. */
+/**
+ * @brief rect_from_points 函数。
+ *
+ * @param a 参数 `a`。
+ * @param b 参数 `b`。
+ * @return 函数返回值。
+ */
 static RectF rect_from_points(Vec2 a, Vec2 b)
 {
     RectF rect;
@@ -74,7 +90,15 @@ static RectF rect_from_points(Vec2 a, Vec2 b)
     return rect;
 }
 
-/** Create shape object for current shape tool kind. */
+/**
+ * @brief build_shape_object 函数。
+ *
+ * @param kind 参数 `kind`。
+ * @param anchor 参数 `anchor`。
+ * @param current 参数 `current`。
+ * @param style 参数 `style`。
+ * @return 函数返回值。
+ */
 static GraphicObject* build_shape_object(ToolKind kind, Vec2 anchor, Vec2 current, GraphicStyle style)
 {
     if (kind == TOOL_KIND_LINE) {
@@ -89,7 +113,13 @@ static GraphicObject* build_shape_object(ToolKind kind, Vec2 anchor, Vec2 curren
     return NULL;
 }
 
-/** Compare document selection against snapshot selection (order-sensitive). */
+/**
+ * @brief selection_matches_snapshot 函数。
+ *
+ * @param document 参数 `document`。
+ * @param snapshot 参数 `snapshot`。
+ * @return 函数返回值。
+ */
 static int selection_matches_snapshot(const Document* document, const DocumentSnapshot* snapshot)
 {
     int i = 0;
@@ -113,6 +143,10 @@ static int selection_matches_snapshot(const Document* document, const DocumentSn
 
 /**
  * @brief Push document edit to history and sync dirty flag.
+ * @param context [in,out] 工具上下文。
+ * @param before_snapshot [in,out] 编辑前快照（该函数会消费并重置）。
+ * @return 无。
+ *
  * @remark Safely resets snapshot even when context/history is invalid.
  */
 static void tool_commit_document_change(ToolContext* context, DocumentSnapshot* before_snapshot)
@@ -132,14 +166,25 @@ static void tool_commit_document_change(ToolContext* context, DocumentSnapshot* 
     workspace_sync_document_dirty(context->workspace);
 }
 
-/** Select tool UI label. */
+/**
+ * @brief select_tool_label 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @return 函数返回值。
+ */
 static const char* select_tool_label(const Tool* tool)
 {
     (void)tool;
     return "Select";
 }
 
-/** Deactivate select tool and clear transient state. */
+/**
+ * @brief select_tool_deactivate 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @param context 参数 `context`。
+ * @return 无。
+ */
 static void select_tool_deactivate(Tool* tool, ToolContext* context)
 {
     SelectToolState* state = (SelectToolState*)tool->state;
@@ -153,6 +198,10 @@ static void select_tool_deactivate(Tool* tool, ToolContext* context)
 
 /**
  * @brief Handle select tool pointer press.
+ * @param tool [in,out] 选择工具实例。
+ * @param context [in,out] 工具上下文。
+ * @param event [in] 指针事件。
+ * @return 无。
  *
  * Why snapshot first:
  * - Captures "before" state before selection/drag mutations so history entry
@@ -236,7 +285,13 @@ static void select_tool_pointer_down(Tool* tool, ToolContext* context, const Too
     state->drag_revision_before = context->document->revision;
 }
 
-/** Move all selected objects by world delta while dragging. */
+/**
+ * @brief 拖拽过程中按世界坐标增量移动选中对象。
+ * @param tool [in,out] 选择工具实例。
+ * @param context [in,out] 工具上下文。
+ * @param event [in] 指针事件。
+ * @return 无。
+ */
 static void select_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     SelectToolState* state = (SelectToolState*)tool->state;
@@ -265,7 +320,15 @@ static void select_tool_pointer_move(Tool* tool, ToolContext* context, const Too
     document_touch(context->document);
 }
 
-/** Finalize select drag/selection change and commit history when needed. */
+/**
+ * @brief 结束选择拖拽并按需写入平移历史。
+ * @param tool [in,out] 选择工具实例。
+ * @param context [in,out] 工具上下文。
+ * @param event [in] 指针事件。
+ * @return 无。
+ *
+ * @note 仅当实际发生位移且对象集合非空时才写入 `translate` 历史条目。
+ */
 static void select_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     SelectToolState* state = (SelectToolState*)tool->state;
@@ -294,7 +357,15 @@ static void select_tool_pointer_up(Tool* tool, ToolContext* context, const ToolE
     state->drag_revision_before = 0u;
 }
 
-/** Handle select tool keyboard input (Escape clears selection). */
+/**
+ * @brief select_tool_key_down 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @param context 参数 `context`。
+ * @param key 参数 `key`。
+ * @param mods 参数 `mods`。
+ * @return 无。
+ */
 static void select_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)
 {
     (void)tool;
@@ -324,14 +395,25 @@ static const ToolVTable g_select_tool_vtable = {
     select_tool_key_down
 };
 
-/** Pan tool label. */
+/**
+ * @brief pan_tool_label 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @return 函数返回值。
+ */
 static const char* pan_tool_label(const Tool* tool)
 {
     (void)tool;
     return "Hand";
 }
 
-/** Stop panning when tool deactivates. */
+/**
+ * @brief pan_tool_deactivate 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @param context 参数 `context`。
+ * @return 无。
+ */
 static void pan_tool_deactivate(Tool* tool, ToolContext* context)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -339,7 +421,14 @@ static void pan_tool_deactivate(Tool* tool, ToolContext* context)
     state->panning = 0;
 }
 
-/** Start panning on left press. */
+/**
+ * @brief pan_tool_pointer_down 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @param context 参数 `context`。
+ * @param event 参数 `event`。
+ * @return 无。
+ */
 static void pan_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -351,7 +440,14 @@ static void pan_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEv
     state->panning = 1;
 }
 
-/** Apply screen delta pan while active. */
+/**
+ * @brief pan_tool_pointer_move 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @param context 参数 `context`。
+ * @param event 参数 `event`。
+ * @return 无。
+ */
 static void pan_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -362,7 +458,14 @@ static void pan_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEv
     canvas_view_pan_screen_delta(context->canvas, event->delta_screen);
 }
 
-/** End panning on release. */
+/**
+ * @brief pan_tool_pointer_up 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @param context 参数 `context`。
+ * @param event 参数 `event`。
+ * @return 无。
+ */
 static void pan_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -373,7 +476,15 @@ static void pan_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEven
     }
 }
 
-/** Handle pan tool keyboard input (Escape cancels panning). */
+/**
+ * @brief pan_tool_key_down 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @param context 参数 `context`。
+ * @param key 参数 `key`。
+ * @param mods 参数 `mods`。
+ * @return 无。
+ */
 static void pan_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -394,7 +505,12 @@ static const ToolVTable g_pan_tool_vtable = {
     pan_tool_key_down
 };
 
-/** Return label by shape kind. */
+/**
+ * @brief shape_tool_label 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @return 函数返回值。
+ */
 static const char* shape_tool_label(const Tool* tool)
 {
     switch (tool->kind) {
@@ -409,7 +525,13 @@ static const char* shape_tool_label(const Tool* tool)
     }
 }
 
-/** Cancel shape drawing and clear overlay when tool deactivates. */
+/**
+ * @brief shape_tool_deactivate 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @param context 参数 `context`。
+ * @return 无。
+ */
 static void shape_tool_deactivate(Tool* tool, ToolContext* context)
 {
     ShapeToolState* state = (ShapeToolState*)tool->state;
@@ -418,7 +540,13 @@ static void shape_tool_deactivate(Tool* tool, ToolContext* context)
     destroy_overlay(tool);
 }
 
-/** Start shape draw interaction and create translucent overlay preview. */
+/**
+ * @brief 开始图形绘制交互并创建半透明预览对象。
+ * @param tool [in,out] 形状工具实例。
+ * @param context [in,out] 工具上下文（当前未直接使用）。
+ * @param event [in] 指针事件。
+ * @return 无。
+ */
 static void shape_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     ShapeToolState* state = (ShapeToolState*)tool->state;
@@ -438,7 +566,13 @@ static void shape_tool_pointer_down(Tool* tool, ToolContext* context, const Tool
     tool->overlay_object = build_shape_object(tool->kind, state->anchor, state->current, style);
 }
 
-/** Update shape overlay as pointer moves. */
+/**
+ * @brief 指针移动时更新形状预览对象。
+ * @param tool [in,out] 形状工具实例。
+ * @param context [in,out] 工具上下文（当前未直接使用）。
+ * @param event [in] 指针事件。
+ * @return 无。
+ */
 static void shape_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     ShapeToolState* state = (ShapeToolState*)tool->state;
@@ -457,6 +591,17 @@ static void shape_tool_pointer_move(Tool* tool, ToolContext* context, const Tool
 
 /**
  * @brief Finalize shape creation on pointer release.
+ * @param tool [in,out] 形状工具实例。
+ * @param context [in,out] 工具上下文。
+ * @param event [in] 指针事件。
+ * @return 无。
+ *
+ * 算法步骤：
+ * 1. 捕获编辑前快照；
+ * 2. 依据锚点和当前点构建最终对象；
+ * 3. 追加到文档并更新选择；
+ * 4. 将本次变更提交到历史栈。
+ *
  * Risk note:
  * - Captures history snapshot before append; allocation/add failures clean up
  *   object/snapshot to avoid leaks and partial commits.
@@ -495,7 +640,15 @@ static void shape_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEv
     tool_commit_document_change(context, &before_snapshot);
 }
 
-/** Escape cancels in-progress shape drawing. */
+/**
+ * @brief shape_tool_key_down 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @param context 参数 `context`。
+ * @param key 参数 `key`。
+ * @param mods 参数 `mods`。
+ * @return 无。
+ */
 static void shape_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)
 {
     (void)mods;
@@ -514,7 +667,15 @@ static const ToolVTable g_shape_tool_vtable = {
     shape_tool_key_down
 };
 
-/** Initialize one tool slot and allocate optional state block. */
+/**
+ * @brief tool_init_slot 函数。
+ *
+ * @param tool 参数 `tool`。
+ * @param kind 参数 `kind`。
+ * @param vtable 参数 `vtable`。
+ * @param state_size 参数 `state_size`。
+ * @return 无。
+ */
 static void tool_init_slot(Tool* tool, ToolKind kind, const ToolVTable* vtable, size_t state_size)
 {
     memset(tool, 0, sizeof(*tool));
@@ -525,7 +686,12 @@ static void tool_init_slot(Tool* tool, ToolKind kind, const ToolVTable* vtable, 
     }
 }
 
-/** Initialize all built-in tools and default active tool. */
+/**
+ * @brief tool_controller_init 函数。
+ *
+ * @param controller 参数 `controller`。
+ * @return 无。
+ */
 void tool_controller_init(ToolController* controller)
 {
     if (!controller) {
@@ -541,7 +707,12 @@ void tool_controller_init(ToolController* controller)
     controller->active_kind = TOOL_KIND_SELECT;
 }
 
-/** Shutdown all tool states and overlays. */
+/**
+ * @brief tool_controller_shutdown 函数。
+ *
+ * @param controller 参数 `controller`。
+ * @return 无。
+ */
 void tool_controller_shutdown(ToolController* controller)
 {
     int i = 0;
@@ -557,7 +728,12 @@ void tool_controller_shutdown(ToolController* controller)
     }
 }
 
-/** Return active tool pointer. */
+/**
+ * @brief tool_controller_get_active 函数。
+ *
+ * @param controller 参数 `controller`。
+ * @return 函数返回值。
+ */
 Tool* tool_controller_get_active(ToolController* controller)
 {
     if (!controller) {
@@ -566,7 +742,12 @@ Tool* tool_controller_get_active(ToolController* controller)
     return &controller->tools[controller->active_kind];
 }
 
-/** Return active tool label. */
+/**
+ * @brief tool_controller_active_label 函数。
+ *
+ * @param controller 参数 `controller`。
+ * @return 函数返回值。
+ */
 const char* tool_controller_active_label(const ToolController* controller)
 {
     const Tool* tool = NULL;
@@ -577,7 +758,12 @@ const char* tool_controller_active_label(const ToolController* controller)
     return tool->vtable->label(tool);
 }
 
-/** Return active tool overlay object if any. */
+/**
+ * @brief tool_controller_overlay_object 函数。
+ *
+ * @param controller 参数 `controller`。
+ * @return 函数返回值。
+ */
 GraphicObject* tool_controller_overlay_object(const ToolController* controller)
 {
     if (!controller) {
@@ -586,7 +772,14 @@ GraphicObject* tool_controller_overlay_object(const ToolController* controller)
     return controller->tools[controller->active_kind].overlay_object;
 }
 
-/** Switch active tool with proper deactivate/activate callbacks. */
+/**
+ * @brief tool_controller_set_active 函数。
+ *
+ * @param controller 参数 `controller`。
+ * @param context 参数 `context`。
+ * @param kind 参数 `kind`。
+ * @return 无。
+ */
 void tool_controller_set_active(ToolController* controller, ToolContext* context, ToolKind kind)
 {
     Tool* current = NULL;
@@ -608,7 +801,13 @@ void tool_controller_set_active(ToolController* controller, ToolContext* context
     }
 }
 
-/** Dispatch pointer-down and capture pointer. */
+/**
+ * @brief 分发按下事件并开启指针捕获。
+ * @param controller [in,out] 工具控制器。
+ * @param context [in,out] 工具上下文。
+ * @param event [in] 指针事件。
+ * @return 无。
+ */
 void tool_controller_pointer_down(ToolController* controller, ToolContext* context, const ToolEvent* event)
 {
     Tool* tool = tool_controller_get_active(controller);
@@ -621,7 +820,13 @@ void tool_controller_pointer_down(ToolController* controller, ToolContext* conte
     tool->vtable->pointer_down(tool, context, event);
 }
 
-/** Dispatch pointer-move to active tool. */
+/**
+ * @brief 分发移动事件到当前激活工具。
+ * @param controller [in,out] 工具控制器。
+ * @param context [in,out] 工具上下文。
+ * @param event [in] 指针事件。
+ * @return 无。
+ */
 void tool_controller_pointer_move(ToolController* controller, ToolContext* context, const ToolEvent* event)
 {
     Tool* tool = tool_controller_get_active(controller);
@@ -633,7 +838,13 @@ void tool_controller_pointer_move(ToolController* controller, ToolContext* conte
     tool->vtable->pointer_move(tool, context, event);
 }
 
-/** Dispatch pointer-up and release pointer capture. */
+/**
+ * @brief 分发释放事件并结束指针捕获。
+ * @param controller [in,out] 工具控制器。
+ * @param context [in,out] 工具上下文。
+ * @param event [in] 指针事件。
+ * @return 无。
+ */
 void tool_controller_pointer_up(ToolController* controller, ToolContext* context, const ToolEvent* event)
 {
     Tool* tool = tool_controller_get_active(controller);
@@ -647,9 +858,13 @@ void tool_controller_pointer_up(ToolController* controller, ToolContext* context
 }
 
 /**
- * @brief Dispatch key-down to global shortcuts or active tool.
- * Why global-first:
- * - Undo/redo/delete/tool-switch shortcuts must be deterministic regardless of tool.
+ * @brief tool_controller_key_down 函数。
+ *
+ * @param controller 参数 `controller`。
+ * @param context 参数 `context`。
+ * @param key 参数 `key`。
+ * @param mods 参数 `mods`。
+ * @return 无。
  */
 void tool_controller_key_down(ToolController* controller, ToolContext* context, int key, int mods)
 {
@@ -720,7 +935,15 @@ void tool_controller_key_down(ToolController* controller, ToolContext* context, 
     }
 }
 
-/** Apply wheel zoom around current cursor screen point. */
+/**
+ * @brief tool_controller_scroll 函数。
+ *
+ * @param controller 参数 `controller`。
+ * @param context 参数 `context`。
+ * @param screen_pos 参数 `screen_pos`。
+ * @param yoffset 参数 `yoffset`。
+ * @return 无。
+ */
 void tool_controller_scroll(ToolController* controller, ToolContext* context, Vec2 screen_pos, float yoffset)
 {
     float factor = 1.0f;

--- a/src/ui/ui_menu_actions.c
+++ b/src/ui/ui_menu_actions.c
@@ -23,12 +23,12 @@
 #include <GLFW/glfw3.h>
 
 /**
- * @brief 创建新文档并重置相关状态。
+ * @brief Creates a new document and resets related state.
  *
- * @param workspace [in,out] 工作区对象。
- * @return 无。
+ * @param workspace [in,out] Workspace instance.
+ * @return None.
  *
- * @note 会重建历史栈并重置画布缩放/中心，确保“新建文档”状态一致。
+ * @note Rebuilds history stack and resets canvas zoom/center to ensure consistent “new document” state.
  */
 static void app_workspace_new(Workspace* workspace)
 {
@@ -56,16 +56,16 @@ static void app_workspace_new(Workspace* workspace)
 }
 
 /**
- * @brief 将视图缩放到包围全部对象的最佳范围。
+ * @brief Zooms view to optimal range enclosing all objects.
  *
- * 算法步骤：
- * 1. 遍历对象，计算整体包围盒；
- * 2. 对包围盒增加固定边距；
- * 3. 基于视口宽高计算 `zoom_x/zoom_y`；
- * 4. 取较小值作为新缩放并将中心置于包围盒中心。
+ * Algorithm steps:
+ * 1. Iterates objects to compute overall bounding box.
+ * 2. Adds fixed padding to bounding box.
+ * 3. Computes zoom_x/zoom_y based on viewport dimensions.
+ * 4. Takes smaller value as new zoom and centers on bounding box center.
  *
- * @param workspace [in,out] 工作区对象。
- * @return 无。
+ * @param workspace [in,out] Workspace instance.
+ * @return None.
  */
 static void app_zoom_to_fit(Workspace* workspace)
 {
@@ -132,9 +132,9 @@ static void app_zoom_to_fit(Workspace* workspace)
 }
 
 /**
- * @brief 切换画布网格显示。
- * @param workspace [in,out] 工作区对象。
- * @return 无。
+ * @brief Toggles canvas grid display.
+ * @param workspace [in,out] Workspace instance.
+ * @return None.
  */
 static void app_toggle_grid(Workspace* workspace)
 {
@@ -145,9 +145,9 @@ static void app_toggle_grid(Workspace* workspace)
 }
 
 /**
- * @brief 触发检查器显示切换动作（当前为日志占位）。
- * @param workspace [in,out] 工作区对象（当前未直接使用）。
- * @return 无。
+ * @brief Triggers inspector visibility toggle (currently logs placeholder).
+ * @param workspace [in,out] Workspace instance (currently unused).
+ * @return None.
  */
 static void app_toggle_inspector(Workspace* workspace)
 {
@@ -156,9 +156,9 @@ static void app_toggle_inspector(Workspace* workspace)
 }
 
 /**
- * @brief 触发快捷键帮助动作（当前为日志占位）。
- * @param workspace [in,out] 工作区对象（当前未直接使用）。
- * @return 无。
+ * @brief Triggers keyboard shortcuts help (currently logs placeholder).
+ * @param workspace [in,out] Workspace instance (currently unused).
+ * @return None.
  */
 static void app_show_shortcuts(Workspace* workspace)
 {
@@ -167,9 +167,9 @@ static void app_show_shortcuts(Workspace* workspace)
 }
 
 /**
- * @brief 触发关于对话框动作（当前为日志占位）。
- * @param workspace [in,out] 工作区对象（当前未直接使用）。
- * @return 无。
+ * @brief Triggers about dialog (currently logs placeholder).
+ * @param workspace [in,out] Workspace instance (currently unused).
+ * @return None.
  */
 static void app_show_about(Workspace* workspace)
 {
@@ -178,9 +178,9 @@ static void app_show_about(Workspace* workspace)
 }
 
 /**
- * @brief 执行“另存为”命令。
- * @param workspace [in,out] 工作区对象。
- * @return 保存成功返回非零，否则返回 0。
+ * @brief Executes “Save As” command.
+ * @param workspace [in,out] Workspace instance.
+ * @return Non-zero on success, 0 on failure.
  */
 static int app_save_as(Workspace* workspace)
 {
@@ -191,9 +191,9 @@ static int app_save_as(Workspace* workspace)
 }
 
 /**
- * @brief 执行 PNG 导出命令（待实现）。
- * @param workspace [in,out] 工作区对象（当前未直接使用）。
- * @return 当前固定返回 0。
+ * @brief Executes PNG export command (not yet implemented).
+ * @param workspace [in,out] Workspace instance (currently unused).
+ * @return Currently always returns 0.
  */
 static int app_export_png(Workspace* workspace)
 {
@@ -204,9 +204,9 @@ static int app_export_png(Workspace* workspace)
 }
 
 /**
- * @brief 判断菜单动作当前是否可用。
- * @param id [in] 菜单动作 ID。
- * @return 可用返回非零，不可用返回 0。
+ * @brief Checks if menu action is currently available.
+ * @param id [in] Menu action ID.
+ * @return Non-zero if available, 0 if unavailable.
  */
 int ui_menu_is_action_available(MenuId id)
 {
@@ -223,16 +223,16 @@ int ui_menu_is_action_available(MenuId id)
 }
 
 /**
- * @brief 执行菜单动作分发。
+ * @brief Executes menu action dispatch.
  *
- * 算法步骤：
- * 1. 依据 `id` 进入对应分支；
- * 2. 调用文档/画布/历史相关操作；
- * 3. 对撤销重做等会改变修订号的动作同步 dirty 标记。
+ * Algorithm steps:
+ * 1. Enters corresponding branch based on id.
+ * 2. Calls document/canvas/history related operations.
+ * 3. Syncs dirty flag for actions that change revision number (like undo/redo).
  *
- * @param workspace [in,out] 工作区对象。
- * @param id [in] 菜单动作 ID。
- * @return 无。
+ * @param workspace [in,out] Workspace instance.
+ * @param id [in] Menu action ID.
+ * @return None.
  */
 void ui_menu_execute(Workspace* workspace, MenuId id)
 {

--- a/src/ui/ui_menu_actions.c
+++ b/src/ui/ui_menu_actions.c
@@ -22,6 +22,14 @@
 
 #include <GLFW/glfw3.h>
 
+/**
+ * @brief 创建新文档并重置相关状态。
+ *
+ * @param workspace [in,out] 工作区对象。
+ * @return 无。
+ *
+ * @note 会重建历史栈并重置画布缩放/中心，确保“新建文档”状态一致。
+ */
 static void app_workspace_new(Workspace* workspace)
 {
     if (!workspace) {
@@ -47,6 +55,18 @@ static void app_workspace_new(Workspace* workspace)
     LOG_INFO("%s", "Created new document");
 }
 
+/**
+ * @brief 将视图缩放到包围全部对象的最佳范围。
+ *
+ * 算法步骤：
+ * 1. 遍历对象，计算整体包围盒；
+ * 2. 对包围盒增加固定边距；
+ * 3. 基于视口宽高计算 `zoom_x/zoom_y`；
+ * 4. 取较小值作为新缩放并将中心置于包围盒中心。
+ *
+ * @param workspace [in,out] 工作区对象。
+ * @return 无。
+ */
 static void app_zoom_to_fit(Workspace* workspace)
 {
     if (!workspace || !workspace->canvas.document) {
@@ -111,6 +131,11 @@ static void app_zoom_to_fit(Workspace* workspace)
                                 new_zoom);
 }
 
+/**
+ * @brief 切换画布网格显示。
+ * @param workspace [in,out] 工作区对象。
+ * @return 无。
+ */
 static void app_toggle_grid(Workspace* workspace)
 {
     if (!workspace) {
@@ -119,24 +144,44 @@ static void app_toggle_grid(Workspace* workspace)
     workspace->canvas.show_grid = !workspace->canvas.show_grid;
 }
 
+/**
+ * @brief 触发检查器显示切换动作（当前为日志占位）。
+ * @param workspace [in,out] 工作区对象（当前未直接使用）。
+ * @return 无。
+ */
 static void app_toggle_inspector(Workspace* workspace)
 {
     (void)workspace;
     LOG_INFO("%s", "Inspector panel toggled");
 }
 
+/**
+ * @brief 触发快捷键帮助动作（当前为日志占位）。
+ * @param workspace [in,out] 工作区对象（当前未直接使用）。
+ * @return 无。
+ */
 static void app_show_shortcuts(Workspace* workspace)
 {
     (void)workspace;
     LOG_INFO("%s", "Keyboard shortcuts dialog requested");
 }
 
+/**
+ * @brief 触发关于对话框动作（当前为日志占位）。
+ * @param workspace [in,out] 工作区对象（当前未直接使用）。
+ * @return 无。
+ */
 static void app_show_about(Workspace* workspace)
 {
     (void)workspace;
     LOG_INFO("%s", "About dialog requested");
 }
 
+/**
+ * @brief 执行“另存为”命令。
+ * @param workspace [in,out] 工作区对象。
+ * @return 保存成功返回非零，否则返回 0。
+ */
 static int app_save_as(Workspace* workspace)
 {
     if (workspace->save_document) {
@@ -145,14 +190,24 @@ static int app_save_as(Workspace* workspace)
     return 0;
 }
 
+/**
+ * @brief 执行 PNG 导出命令（待实现）。
+ * @param workspace [in,out] 工作区对象（当前未直接使用）。
+ * @return 当前固定返回 0。
+ */
 static int app_export_png(Workspace* workspace)
 {
     (void)workspace;
-    // TODO: Implement PNG export via framebuffer capture
+    /* TODO: Implement PNG export via framebuffer capture. */
     LOG_INFO("%s", "Export PNG requested");
     return 0;
 }
 
+/**
+ * @brief 判断菜单动作当前是否可用。
+ * @param id [in] 菜单动作 ID。
+ * @return 可用返回非零，不可用返回 0。
+ */
 int ui_menu_is_action_available(MenuId id)
 {
     switch (id) {
@@ -167,6 +222,18 @@ int ui_menu_is_action_available(MenuId id)
     }
 }
 
+/**
+ * @brief 执行菜单动作分发。
+ *
+ * 算法步骤：
+ * 1. 依据 `id` 进入对应分支；
+ * 2. 调用文档/画布/历史相关操作；
+ * 3. 对撤销重做等会改变修订号的动作同步 dirty 标记。
+ *
+ * @param workspace [in,out] 工作区对象。
+ * @param id [in] 菜单动作 ID。
+ * @return 无。
+ */
 void ui_menu_execute(Workspace* workspace, MenuId id)
 {
     if (!workspace) {
@@ -227,7 +294,7 @@ void ui_menu_execute(Workspace* workspace, MenuId id)
     case MENU_ID_EDIT_CUT:
     case MENU_ID_EDIT_COPY:
     case MENU_ID_EDIT_PASTE:
-        // TODO: cut/copy/paste/delete operations not yet implemented
+        /* TODO: cut/copy/paste/delete operations not yet implemented. */
         LOG_INFO("Menu action %d not yet implemented", id);
         break;
 

--- a/src/ui/ui_menu_actions.h
+++ b/src/ui/ui_menu_actions.h
@@ -1,3 +1,7 @@
+/**
+ * @file ui_menu_actions.h
+ * @brief 菜单动作分发接口。
+ */
 #ifndef GLDRAW_UI_UI_MENU_ACTIONS_H
 #define GLDRAW_UI_UI_MENU_ACTIONS_H
 
@@ -6,28 +10,17 @@
 struct Workspace;
 
 /**
- * @file ui_menu_actions.h
- * @brief Menu action handler interface.
- *
- * This module provides centralized menu action handling.
- * All menu item clicks are routed through `ui_menu_execute()`
- * which dispatches to the appropriate handler.
- */
-
-/**
- * @brief Execute a menu action.
- * @param workspace [in,out] The workspace to operate on.
- * @param id [in] The menu item ID to execute.
- *
- * Routes the menu ID to the appropriate handler function.
- * This is the single entry point for all menu actions.
+ * @brief 执行指定菜单动作。
+ * @param workspace 工作区对象。
+ * @param id 菜单动作 ID。
+ * @return 无。
  */
 void ui_menu_execute(struct Workspace* workspace, MenuId id);
 
 /**
- * @brief Check whether a menu action is currently implemented and available.
- * @param id [in] Menu item ID.
- * @return Non-zero if available, zero if it should be disabled in UI.
+ * @brief 判断菜单动作当前是否可用。
+ * @param id 菜单动作 ID。
+ * @return 可用返回非零，不可用返回 0。
  */
 int ui_menu_is_action_available(MenuId id);
 

--- a/src/ui/ui_menu_actions.h
+++ b/src/ui/ui_menu_actions.h
@@ -1,6 +1,6 @@
 /**
  * @file ui_menu_actions.h
- * @brief 菜单动作分发接口。
+ * @brief Menu action dispatch interface.
  */
 #ifndef GLDRAW_UI_UI_MENU_ACTIONS_H
 #define GLDRAW_UI_UI_MENU_ACTIONS_H
@@ -10,17 +10,17 @@
 struct Workspace;
 
 /**
- * @brief 执行指定菜单动作。
- * @param workspace 工作区对象。
- * @param id 菜单动作 ID。
- * @return 无。
+ * @brief Executes the specified menu action.
+ * @param workspace Workspace instance.
+ * @param id Menu action ID.
+ * @return None.
  */
 void ui_menu_execute(struct Workspace* workspace, MenuId id);
 
 /**
- * @brief 判断菜单动作当前是否可用。
- * @param id 菜单动作 ID。
- * @return 可用返回非零，不可用返回 0。
+ * @brief Checks if menu action is currently available.
+ * @param id Menu action ID.
+ * @return Non-zero if available, 0 if unavailable.
  */
 int ui_menu_is_action_available(MenuId id);
 

--- a/src/ui/ui_menu_def.c
+++ b/src/ui/ui_menu_def.c
@@ -78,6 +78,13 @@ static MenuItemDef g_menu_items[] = {
  * @brief Get the number of menu item definitions.
  * @return Total count of entries in the menu definition table.
  */
+
+/**
+ * @brief ui_menu_def_count 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 int ui_menu_def_count(void)
 {
     return (int)(sizeof(g_menu_items) / sizeof(g_menu_items[0]));
@@ -86,6 +93,13 @@ int ui_menu_def_count(void)
 /**
  * @brief Get the menu item definition table.
  * @return Pointer to the static menu item array.
+ */
+
+/**
+ * @brief ui_menu_def_items 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
  */
 const MenuItemDef* ui_menu_def_items(void)
 {

--- a/src/ui/ui_menu_def.c
+++ b/src/ui/ui_menu_def.c
@@ -80,10 +80,9 @@ static MenuItemDef g_menu_items[] = {
  */
 
 /**
- * @brief ui_menu_def_count 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Gets the number of menu item definitions.
+ * @param void No parameters.
+ * @return Menu definition count.
  */
 int ui_menu_def_count(void)
 {
@@ -96,10 +95,9 @@ int ui_menu_def_count(void)
  */
 
 /**
- * @brief ui_menu_def_items 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Gets the menu item definition table.
+ * @param void No parameters.
+ * @return Pointer to menu definition array.
  */
 const MenuItemDef* ui_menu_def_items(void)
 {

--- a/src/ui/ui_menu_def.h
+++ b/src/ui/ui_menu_def.h
@@ -1,13 +1,13 @@
 /**
  * @file ui_menu_def.h
- * @brief 菜单项静态定义与菜单 ID 枚举。
+ * @brief Menu item static definitions and menu ID enumeration.
  */
 #ifndef GLDRAW_UI_UI_MENU_DEF_H
 #define GLDRAW_UI_UI_MENU_DEF_H
 
 /**
  * @enum MenuItemType
- * @brief 菜单项类型。
+ * @brief Menu item type.
  */
 typedef enum MenuItemType {
     MENU_ITEM_ACTION,
@@ -17,9 +17,9 @@ typedef enum MenuItemType {
 
 /**
  * @enum MenuId
- * @brief 菜单动作 ID 枚举。
+ * @brief Menu action ID enumeration.
  *
- * 约定分段：
+ * Assigned ranges:
  * - 1~99: File
  * - 100~199: Edit
  * - 200~299: View
@@ -62,13 +62,13 @@ typedef enum MenuId {
 
 /**
  * @struct MenuItemDef
- * @brief 菜单项配置。
+ * @brief Menu item configuration.
  *
- * @member type 菜单项类型。
- * @member label 显示文本。
- * @member shortcut 快捷键文本。
- * @member id 菜单动作 ID。
- * @member parent_id 父级菜单 ID（顶层为 -1）。
+ * @member type Menu item type.
+ * @member label Display text.
+ * @member shortcut Keyboard shortcut text.
+ * @member id Menu action ID.
+ * @member parent_id Parent menu ID (-1 for top-level).
  */
 typedef struct MenuItemDef {
     MenuItemType  type;
@@ -79,14 +79,14 @@ typedef struct MenuItemDef {
 } MenuItemDef;
 
 /**
- * @brief 获取菜单定义项数量。
- * @return 菜单定义表项数量。
+ * @brief Gets the menu definition count.
+ * @return Number of menu definition entries.
  */
 int ui_menu_def_count(void);
 
 /**
- * @brief 获取菜单定义表。
- * @return 指向静态菜单定义数组的只读指针。
+ * @brief Gets the menu definition table.
+ * @return Pointer to static menu definition array.
  */
 const MenuItemDef* ui_menu_def_items(void);
 

--- a/src/ui/ui_menu_def.h
+++ b/src/ui/ui_menu_def.h
@@ -1,32 +1,29 @@
+/**
+ * @file ui_menu_def.h
+ * @brief 菜单项静态定义与菜单 ID 枚举。
+ */
 #ifndef GLDRAW_UI_UI_MENU_DEF_H
 #define GLDRAW_UI_UI_MENU_DEF_H
 
 /**
- * @file ui_menu_def.h
- * @brief Menu ID enumeration and menu item definitions.
- *
- * This file defines the configuration-driven menu system.
- * Menu items are defined as static data, making it easy to
- * add, remove, or modify menu entries without changing logic code.
- */
-
-/**
- * @brief Menu item types
+ * @enum MenuItemType
+ * @brief 菜单项类型。
  */
 typedef enum MenuItemType {
-    MENU_ITEM_ACTION,     /**< Normal action item */
-    MENU_ITEM_SEPARATOR,  /**< Separator line */
-    MENU_ITEM_SUBMENU,    /**< Submenu container */
+    MENU_ITEM_ACTION,
+    MENU_ITEM_SEPARATOR,
+    MENU_ITEM_SUBMENU,
 } MenuItemType;
 
 /**
- * @brief Menu ID enumeration
+ * @enum MenuId
+ * @brief 菜单动作 ID 枚举。
  *
- * IDs are grouped by menu:
- *   1-99:   File menu
- *   100-199: Edit menu
- *   200-299: View menu
- *   300-399: Help menu
+ * 约定分段：
+ * - 1~99: File
+ * - 100~199: Edit
+ * - 200~299: View
+ * - 300~399: Help
  */
 typedef enum MenuId {
     /* File menu (1-99) */
@@ -64,27 +61,32 @@ typedef enum MenuId {
 } MenuId;
 
 /**
- * @brief Menu item definition structure
+ * @struct MenuItemDef
+ * @brief 菜单项配置。
  *
- * Used to define menu items as static configuration data.
+ * @member type 菜单项类型。
+ * @member label 显示文本。
+ * @member shortcut 快捷键文本。
+ * @member id 菜单动作 ID。
+ * @member parent_id 父级菜单 ID（顶层为 -1）。
  */
 typedef struct MenuItemDef {
-    MenuItemType  type;       /**< Item type (action/separator/submenu) */
-    const char*   label;      /**< Display text */
-    const char*   shortcut;   /**< Keyboard shortcut description (e.g., "Ctrl+N") */
-    int           id;         /**< Unique identifier */
-    int           parent_id;  /**< Parent menu ID (-1 for top-level menus) */
+    MenuItemType  type;
+    const char*   label;
+    const char*   shortcut;
+    int           id;
+    int           parent_id;
 } MenuItemDef;
 
 /**
- * @brief Get the number of menu items
- * @return Number of items in the menu definition array
+ * @brief 获取菜单定义项数量。
+ * @return 菜单定义表项数量。
  */
 int ui_menu_def_count(void);
 
 /**
- * @brief Get the menu item definitions
- * @return Array of menu item definitions
+ * @brief 获取菜单定义表。
+ * @return 指向静态菜单定义数组的只读指针。
  */
 const MenuItemDef* ui_menu_def_items(void);
 

--- a/src/ui/ui_menubar.c
+++ b/src/ui/ui_menubar.c
@@ -71,6 +71,14 @@ static const UiQuickActionDef g_quick_actions[] = {
     { "Fit", MENU_ID_VIEW_ZOOM_FIT, 40.0f, "Zoom to fit (Ctrl+0)" },
 };
 
+/**
+ * @brief ui_build_menu_item_text 函数。
+ *
+ * @param out_text 参数 `out_text`。
+ * @param out_size 参数 `out_size`。
+ * @param item 参数 `item`。
+ * @return 无。
+ */
 static void ui_build_menu_item_text(char* out_text, size_t out_size, const MenuItemDef* item)
 {
     if (!out_text || out_size == 0 || !item || !item->label) {
@@ -295,6 +303,12 @@ static int ui_render_dropdown(struct nk_context* ctx, int parent_id)
     return clicked_id;
 }
 
+/**
+ * @brief ui_render_theme_dropdown 函数。
+ *
+ * @param menubar 参数 `menubar`。
+ * @return 函数返回值。
+ */
 static int ui_render_theme_dropdown(UiMenuBar* menubar)
 {
     struct nk_context* ctx = NULL;
@@ -333,6 +347,13 @@ static int ui_render_theme_dropdown(UiMenuBar* menubar)
     return -1;
 }
 
+/**
+ * @brief ui_render_top_menu 函数。
+ *
+ * @param menubar 参数 `menubar`。
+ * @param menu 参数 `menu`。
+ * @return 函数返回值。
+ */
 static int ui_render_top_menu(UiMenuBar* menubar, const UiTopMenuDef* menu)
 {
     struct nk_context* ctx = NULL;
@@ -362,6 +383,14 @@ static int ui_render_top_menu(UiMenuBar* menubar, const UiTopMenuDef* menu)
     return clicked_id;
 }
 
+/**
+ * @brief ui_dispatch_menu_action 函数。
+ *
+ * @param menubar 参数 `menubar`。
+ * @param workspace 参数 `workspace`。
+ * @param clicked_id 参数 `clicked_id`。
+ * @return 无。
+ */
 static void ui_dispatch_menu_action(UiMenuBar* menubar, Workspace* workspace, int clicked_id)
 {
     if (!menubar || !workspace || clicked_id == -1) {
@@ -376,6 +405,14 @@ static void ui_dispatch_menu_action(UiMenuBar* menubar, Workspace* workspace, in
     ui_menu_execute(workspace, (MenuId)clicked_id);
 }
 
+/**
+ * @brief ui_menubar_build 函数。
+ *
+ * @param menubar 参数 `menubar`。
+ * @param workspace 参数 `workspace`。
+ * @param window_width 参数 `window_width`。
+ * @return 无。
+ */
 void ui_menubar_build(UiMenuBar* menubar, Workspace* workspace, int window_width)
 {
     struct nk_context* ctx;

--- a/src/ui/ui_menubar.c
+++ b/src/ui/ui_menubar.c
@@ -72,12 +72,11 @@ static const UiQuickActionDef g_quick_actions[] = {
 };
 
 /**
- * @brief ui_build_menu_item_text 函数。
- *
- * @param out_text 参数 `out_text`。
- * @param out_size 参数 `out_size`。
- * @param item 参数 `item`。
- * @return 无。
+ * @brief Builds menu item text with shortcut.
+ * @param out_text Output text buffer.
+ * @param out_size Buffer size.
+ * @param item Menu item definition.
+ * @return None.
  */
 static void ui_build_menu_item_text(char* out_text, size_t out_size, const MenuItemDef* item)
 {
@@ -304,10 +303,9 @@ static int ui_render_dropdown(struct nk_context* ctx, int parent_id)
 }
 
 /**
- * @brief ui_render_theme_dropdown 函数。
- *
- * @param menubar 参数 `menubar`。
- * @return 函数返回值。
+ * @brief Renders the theme dropdown menu.
+ * @param menubar Menu bar instance.
+ * @return Selected theme index or -1.
  */
 static int ui_render_theme_dropdown(UiMenuBar* menubar)
 {
@@ -348,11 +346,10 @@ static int ui_render_theme_dropdown(UiMenuBar* menubar)
 }
 
 /**
- * @brief ui_render_top_menu 函数。
- *
- * @param menubar 参数 `menubar`。
- * @param menu 参数 `menu`。
- * @return 函数返回值。
+ * @brief Renders a top-level menu.
+ * @param menubar Menu bar instance.
+ * @param menu Top menu definition.
+ * @return Clicked menu item ID or -1.
  */
 static int ui_render_top_menu(UiMenuBar* menubar, const UiTopMenuDef* menu)
 {
@@ -384,12 +381,11 @@ static int ui_render_top_menu(UiMenuBar* menubar, const UiTopMenuDef* menu)
 }
 
 /**
- * @brief ui_dispatch_menu_action 函数。
- *
- * @param menubar 参数 `menubar`。
- * @param workspace 参数 `workspace`。
- * @param clicked_id 参数 `clicked_id`。
- * @return 无。
+ * @brief Dispatches a menu action.
+ * @param menubar Menu bar instance.
+ * @param workspace Workspace instance.
+ * @param clicked_id Clicked menu item ID.
+ * @return None.
  */
 static void ui_dispatch_menu_action(UiMenuBar* menubar, Workspace* workspace, int clicked_id)
 {
@@ -406,12 +402,11 @@ static void ui_dispatch_menu_action(UiMenuBar* menubar, Workspace* workspace, in
 }
 
 /**
- * @brief ui_menubar_build 函数。
- *
- * @param menubar 参数 `menubar`。
- * @param workspace 参数 `workspace`。
- * @param window_width 参数 `window_width`。
- * @return 无。
+ * @brief Builds the menu bar UI.
+ * @param menubar Menu bar instance.
+ * @param workspace Workspace instance.
+ * @param window_width Window width.
+ * @return None.
  */
 void ui_menubar_build(UiMenuBar* menubar, Workspace* workspace, int window_width)
 {

--- a/src/ui/ui_menubar.h
+++ b/src/ui/ui_menubar.h
@@ -1,3 +1,7 @@
+/**
+ * @file ui_menubar.h
+ * @brief 顶部菜单栏模块公开接口。
+ */
 #ifndef GLDRAW_UI_UI_MENUBAR_H
 #define GLDRAW_UI_UI_MENUBAR_H
 
@@ -10,102 +14,102 @@ struct UiThemeDescriptor;
 typedef struct UiThemeDescriptor UiThemeDescriptor;
 
 /**
- * @file ui_menubar.h
- * @brief Menu bar public interface.
+ * @struct UiMenuBar
+ * @brief 菜单栏运行时状态。
  *
- * The menu bar module handles rendering of the top-level
- * menu bar and dropdown menus using Nuklear.
- */
-
-/**
- * @brief Menu bar state structure.
- *
- * Owns Nuklear context reference, layout metrics, and pending theme request flags.
+ * @member ctx Nuklear 上下文（不拥有）。
+ * @member show_inspector 检查器面板可见性。
+ * @member menu_height 菜单栏高度。
+ * @member themes 主题描述符数组（不拥有）。
+ * @member theme_count 主题数量。
+ * @member active_theme_index 当前激活主题索引。
+ * @member requested_theme_index 待应用主题索引（-1 表示无请求）。
+ * @member requested_theme_reload 是否请求重载外部主题。
  */
 typedef struct UiMenuBar {
-    struct nk_context* ctx;              /**< Nuklear context (not owned) */
-    bool show_inspector;                /**< Inspector panel visibility */
-    float menu_height;                  /**< Height of the menu bar */
-    const UiThemeDescriptor* themes;     /**< Available theme registry (not owned) */
-    int theme_count;                    /**< Number of themes in registry */
-    int active_theme_index;             /**< Currently active theme index */
-    int requested_theme_index;          /**< Pending theme change request (-1 = none) */
-    int requested_theme_reload;         /**< Non-zero when theme reload is requested */
+    struct nk_context* ctx;
+    bool show_inspector;
+    float menu_height;
+    const UiThemeDescriptor* themes;
+    int theme_count;
+    int active_theme_index;
+    int requested_theme_index;
+    int requested_theme_reload;
 } UiMenuBar;
 
 /**
- * @brief Create a new menu bar instance.
- * @param ctx [in] Nuklear context pointer.
- * @return Newly allocated menu bar, or `NULL` on allocation failure.
+ * @brief 创建菜单栏实例。
+ * @param ctx Nuklear 上下文指针。
+ * @return 成功返回 `UiMenuBar*`，失败返回 `NULL`。
  */
 UiMenuBar* ui_menubar_create(void* ctx);
 
 /**
- * @brief Release menu bar resources.
- * @param menubar [in] Menu bar to destroy; no-op when `NULL`.
- * @return None.
+ * @brief 销毁菜单栏实例。
+ * @param menubar 菜单栏对象。
+ * @return 无。
  */
 void ui_menubar_destroy(UiMenuBar* menubar);
 
 /**
- * @brief Build and render the menu bar.
- * @param menubar [in,out] Menu bar instance; no-op when `NULL`.
- * @param workspace [in,out] Workspace to operate on; used for menu action dispatch.
- * @param window_width [in] Current window width in pixels.
- * @return None.
+ * @brief 构建并绘制菜单栏。
+ * @param menubar 菜单栏对象。
+ * @param workspace 工作区对象。
+ * @param window_width 当前窗口宽度。
+ * @return 无。
  */
 void ui_menubar_build(UiMenuBar* menubar, struct Workspace* workspace, int window_width);
 
 /**
- * @brief Query whether the inspector panel is visible.
- * @param menubar [in] Menu bar instance; defaults to `true` when `NULL`.
- * @return `true` if inspector is visible, `false` otherwise.
+ * @brief 查询检查器面板是否可见。
+ * @param menubar 菜单栏对象。
+ * @return 可见返回 `true`，不可见返回 `false`。
  */
 bool ui_menubar_inspector_visible(const UiMenuBar* menubar);
 
 /**
- * @brief Get the current menu bar height.
- * @param menubar [in] Menu bar instance; defaults to `MENU_BAR_HEIGHT` when `NULL`.
- * @return Menu bar height in pixels.
+ * @brief 获取菜单栏高度。
+ * @param menubar 菜单栏对象。
+ * @return 菜单栏高度（像素）。
  */
 float ui_menubar_height(const UiMenuBar* menubar);
 
 /**
- * @brief Set the menu bar height.
- * @param menubar [in,out] Menu bar instance; no-op when `NULL`.
- * @param height [in] New height in pixels; minimum enforced to `MENU_BAR_HEIGHT`.
- * @return None.
+ * @brief 设置菜单栏高度。
+ * @param menubar 菜单栏对象。
+ * @param height 新高度（像素）。
+ * @return 无。
  */
 void ui_menubar_set_height(UiMenuBar* menubar, float height);
 
 /**
- * @brief Assign the available theme registry to the menu bar.
- * @param menubar [in,out] Menu bar instance; no-op when `NULL`.
- * @param themes [in] Array of theme descriptors; may be `NULL` when `theme_count` is zero.
- * @param theme_count [in] Number of themes in `themes` array; treated as zero when negative.
- * @return None.
+ * @brief 设置菜单栏可用主题列表。
+ * @param menubar 菜单栏对象。
+ * @param themes 主题描述符数组。
+ * @param theme_count 数组长度。
+ * @return 无。
  */
 void ui_menubar_set_themes(UiMenuBar* menubar, const UiThemeDescriptor* themes, int theme_count);
 
 /**
- * @brief Set the active theme by index.
- * @param menubar [in,out] Menu bar instance; no-op when `NULL`.
- * @param theme_index [in] Theme index to activate; clamped to valid range.
- * @return None.
+ * @brief 设置当前激活主题索引。
+ * @param menubar 菜单栏对象。
+ * @param theme_index 目标主题索引。
+ * @return 无。
  */
 void ui_menubar_set_active_theme_index(UiMenuBar* menubar, int theme_index);
 
 /**
- * @brief Atomically consume any pending theme change request.
- * @param menubar [in,out] Menu bar instance; returns `-1` when `NULL`.
- * @return Requested theme index, or `-1` if no request is pending.
+ * @brief 取出并清空待应用主题请求。
+ * @param menubar 菜单栏对象。
+ * @return 请求的主题索引；无请求时返回 `-1`。
  */
 int ui_menubar_take_theme_request(UiMenuBar* menubar);
 
 /**
- * @brief Atomically consume any pending theme reload request.
- * @param menubar [in,out] Menu bar instance; returns `0` when `NULL`.
- * @return `1` if reload was requested, `0` otherwise.
+ * @brief 取出并清空主题重载请求标记。
+ * @param menubar 菜单栏对象。
+ * @return 有请求返回 `1`，无请求返回 `0`。
  */
 int ui_menubar_take_theme_reload_request(UiMenuBar* menubar);
 

--- a/src/ui/ui_menubar.h
+++ b/src/ui/ui_menubar.h
@@ -1,6 +1,6 @@
 /**
  * @file ui_menubar.h
- * @brief 顶部菜单栏模块公开接口。
+ * @brief Top menu bar module public interface.
  */
 #ifndef GLDRAW_UI_UI_MENUBAR_H
 #define GLDRAW_UI_UI_MENUBAR_H
@@ -15,16 +15,16 @@ typedef struct UiThemeDescriptor UiThemeDescriptor;
 
 /**
  * @struct UiMenuBar
- * @brief 菜单栏运行时状态。
+ * @brief Menu bar runtime state.
  *
- * @member ctx Nuklear 上下文（不拥有）。
- * @member show_inspector 检查器面板可见性。
- * @member menu_height 菜单栏高度。
- * @member themes 主题描述符数组（不拥有）。
- * @member theme_count 主题数量。
- * @member active_theme_index 当前激活主题索引。
- * @member requested_theme_index 待应用主题索引（-1 表示无请求）。
- * @member requested_theme_reload 是否请求重载外部主题。
+ * @member ctx Nuklear context (non-owning).
+ * @member show_inspector Inspector panel visibility.
+ * @member menu_height Menu bar height.
+ * @member themes Theme descriptor array (non-owning).
+ * @member theme_count Theme count.
+ * @member active_theme_index Currently active theme index.
+ * @member requested_theme_index Pending theme index to apply (-1 means no request).
+ * @member requested_theme_reload Whether a reload of external themes is requested.
  */
 typedef struct UiMenuBar {
     struct nk_context* ctx;
@@ -38,78 +38,78 @@ typedef struct UiMenuBar {
 } UiMenuBar;
 
 /**
- * @brief 创建菜单栏实例。
- * @param ctx Nuklear 上下文指针。
- * @return 成功返回 `UiMenuBar*`，失败返回 `NULL`。
+ * @brief Create a menu bar instance.
+ * @param ctx Nuklear context pointer.
+ * @return `UiMenuBar*` on success, `NULL` on failure.
  */
 UiMenuBar* ui_menubar_create(void* ctx);
 
 /**
- * @brief 销毁菜单栏实例。
- * @param menubar 菜单栏对象。
- * @return 无。
+ * @brief Destroy a menu bar instance.
+ * @param menubar Menu bar object.
+ * @return No return value.
  */
 void ui_menubar_destroy(UiMenuBar* menubar);
 
 /**
- * @brief 构建并绘制菜单栏。
- * @param menubar 菜单栏对象。
- * @param workspace 工作区对象。
- * @param window_width 当前窗口宽度。
- * @return 无。
+ * @brief Build and draw the menu bar.
+ * @param menubar Menu bar object.
+ * @param workspace Workspace object.
+ * @param window_width Current window width.
+ * @return No return value.
  */
 void ui_menubar_build(UiMenuBar* menubar, struct Workspace* workspace, int window_width);
 
 /**
- * @brief 查询检查器面板是否可见。
- * @param menubar 菜单栏对象。
- * @return 可见返回 `true`，不可见返回 `false`。
+ * @brief Query whether the inspector panel is visible.
+ * @param menubar Menu bar object.
+ * @return `true` if visible, `false` otherwise.
  */
 bool ui_menubar_inspector_visible(const UiMenuBar* menubar);
 
 /**
- * @brief 获取菜单栏高度。
- * @param menubar 菜单栏对象。
- * @return 菜单栏高度（像素）。
+ * @brief Get the menu bar height.
+ * @param menubar Menu bar object.
+ * @return Menu bar height in pixels.
  */
 float ui_menubar_height(const UiMenuBar* menubar);
 
 /**
- * @brief 设置菜单栏高度。
- * @param menubar 菜单栏对象。
- * @param height 新高度（像素）。
- * @return 无。
+ * @brief Set the menu bar height.
+ * @param menubar Menu bar object.
+ * @param height New height in pixels.
+ * @return No return value.
  */
 void ui_menubar_set_height(UiMenuBar* menubar, float height);
 
 /**
- * @brief 设置菜单栏可用主题列表。
- * @param menubar 菜单栏对象。
- * @param themes 主题描述符数组。
- * @param theme_count 数组长度。
- * @return 无。
+ * @brief Set the available theme list for the menu bar.
+ * @param menubar Menu bar object.
+ * @param themes Theme descriptor array.
+ * @param theme_count Array length.
+ * @return No return value.
  */
 void ui_menubar_set_themes(UiMenuBar* menubar, const UiThemeDescriptor* themes, int theme_count);
 
 /**
- * @brief 设置当前激活主题索引。
- * @param menubar 菜单栏对象。
- * @param theme_index 目标主题索引。
- * @return 无。
+ * @brief Set the currently active theme index.
+ * @param menubar Menu bar object.
+ * @param theme_index Target theme index.
+ * @return No return value.
  */
 void ui_menubar_set_active_theme_index(UiMenuBar* menubar, int theme_index);
 
 /**
- * @brief 取出并清空待应用主题请求。
- * @param menubar 菜单栏对象。
- * @return 请求的主题索引；无请求时返回 `-1`。
+ * @brief Take and clear the pending theme application request.
+ * @param menubar Menu bar object.
+ * @return Requested theme index; returns `-1` if no request is pending.
  */
 int ui_menubar_take_theme_request(UiMenuBar* menubar);
 
 /**
- * @brief 取出并清空主题重载请求标记。
- * @param menubar 菜单栏对象。
- * @return 有请求返回 `1`，无请求返回 `0`。
+ * @brief Take and clear the theme reload request flag.
+ * @param menubar Menu bar object.
+ * @return `1` if a request is pending, `0` otherwise.
  */
 int ui_menubar_take_theme_reload_request(UiMenuBar* menubar);
 

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -79,6 +79,14 @@ typedef enum UiThemeReloadReason {
     UI_THEME_RELOAD_REASON_MANUAL
 } UiThemeReloadReason;
 
+/**
+ * @brief ui_clampf 函数。
+ *
+ * @param value 参数 `value`。
+ * @param min_value 参数 `min_value`。
+ * @param max_value 参数 `max_value`。
+ * @return 函数返回值。
+ */
 static float ui_clampf(float value, float min_value, float max_value)
 {
     if (value < min_value) {
@@ -90,6 +98,12 @@ static float ui_clampf(float value, float min_value, float max_value)
     return value;
 }
 
+/**
+ * @brief ui_theme_reload_reason_label 函数。
+ *
+ * @param reason 参数 `reason`。
+ * @return 函数返回值。
+ */
 static const char* ui_theme_reload_reason_label(UiThemeReloadReason reason)
 {
     switch (reason) {
@@ -103,6 +117,12 @@ static const char* ui_theme_reload_reason_label(UiThemeReloadReason reason)
     }
 }
 
+/**
+ * @brief ui_system_sync_menubar_themes 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @return 无。
+ */
 static void ui_system_sync_menubar_themes(UiSystem* ui)
 {
     int theme_count = 0;
@@ -138,6 +158,14 @@ static void ui_system_sync_menubar_themes(UiSystem* ui)
     ui_menubar_set_active_theme_index(ui->menu_bar, active_theme_index);
 }
 
+/**
+ * @brief ui_system_set_theme 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @param theme_id 参数 `theme_id`。
+ * @param persist_selection 参数 `persist_selection`。
+ * @return 函数返回值。
+ */
 static int ui_system_set_theme(UiSystem* ui, const char* theme_id, int persist_selection)
 {
     int theme_index = -1;
@@ -176,6 +204,15 @@ static int ui_system_set_theme(UiSystem* ui, const char* theme_id, int persist_s
     return 1;
 }
 
+/**
+ * @brief ui_system_reload_themes 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @param workspace 参数 `workspace`。
+ * @param notify_status 参数 `notify_status`。
+ * @param reason 参数 `reason`。
+ * @return 无。
+ */
 static void ui_system_reload_themes(UiSystem* ui,
                                     Workspace* workspace,
                                     int notify_status,
@@ -227,6 +264,12 @@ static void ui_system_reload_themes(UiSystem* ui,
     }
 }
 
+/**
+ * @brief ui_system_load_theme_from_settings 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @return 无。
+ */
 static void ui_system_load_theme_from_settings(UiSystem* ui)
 {
     char loaded_theme_id[UI_THEME_ID_CAPACITY];
@@ -246,6 +289,14 @@ static void ui_system_load_theme_from_settings(UiSystem* ui)
     ui_system_set_theme(ui, ui_theme_default_id(), 0);
 }
 
+/**
+ * @brief ui_system_poll_theme_hot_reload 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @param workspace 参数 `workspace`。
+ * @param now_seconds 参数 `now_seconds`。
+ * @return 无。
+ */
 static void ui_system_poll_theme_hot_reload(UiSystem* ui, Workspace* workspace, double now_seconds)
 {
     unsigned long long signature = 0ull;
@@ -267,12 +318,25 @@ static void ui_system_poll_theme_hot_reload(UiSystem* ui, Workspace* workspace, 
     ui_system_reload_themes(ui, workspace, 1, UI_THEME_RELOAD_REASON_AUTO);
 }
 
+/**
+ * @brief ui_smoothstep 函数。
+ *
+ * @param t 参数 `t`。
+ * @return 函数返回值。
+ */
 static float ui_smoothstep(float t)
 {
     float clamped = ui_clampf(t, 0.0f, 1.0f);
     return clamped * clamped * (3.0f - 2.0f * clamped);
 }
 
+/**
+ * @brief ui_rectf_equals 函数。
+ *
+ * @param a 参数 `a`。
+ * @param b 参数 `b`。
+ * @return 函数返回值。
+ */
 static int ui_rectf_equals(RectF a, RectF b)
 {
     const float eps = 1e-3f;
@@ -282,6 +346,13 @@ static int ui_rectf_equals(RectF a, RectF b)
            fabsf(a.h - b.h) <= eps;
 }
 
+/**
+ * @brief ui_clamp_rect_to_window 函数。
+ *
+ * @param rect 参数 `rect`。
+ * @param window_bounds 参数 `window_bounds`。
+ * @return 函数返回值。
+ */
 static RectF ui_clamp_rect_to_window(RectF rect, RectF window_bounds)
 {
     float max_x = window_bounds.x + window_bounds.w;
@@ -323,6 +394,15 @@ static RectF ui_clamp_rect_to_window(RectF rect, RectF window_bounds)
     return rect;
 }
 
+/**
+ * @brief ui_publish_layout 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @param workspace 参数 `workspace`。
+ * @param width 参数 `width`。
+ * @param height 参数 `height`。
+ * @return 无。
+ */
 static void ui_publish_layout(UiSystem* ui, Workspace* workspace, int width, int height)
 {
     WorkspaceLayout next_layout;
@@ -361,6 +441,12 @@ static void ui_publish_layout(UiSystem* ui, Workspace* workspace, int width, int
     ui->layout_snapshot = workspace->layout;
 }
 
+/**
+ * @brief ui_tool_context 函数。
+ *
+ * @param workspace 参数 `workspace`。
+ * @return 函数返回值。
+ */
 static ToolContext ui_tool_context(Workspace* workspace)
 {
     ToolContext context;
@@ -371,6 +457,17 @@ static ToolContext ui_tool_context(Workspace* workspace)
     return context;
 }
 
+/**
+ * @brief 提交一次对象标量属性修改并写入历史。
+ * @param workspace [in,out] 工作区对象。
+ * @param object [in,out] 目标对象。
+ * @param key [in] 标量属性键名。
+ * @param before_value [in] 修改前值。
+ * @param after_value [in] 修改后值。
+ * @return 无。
+ *
+ * @note 若历史写入失败，当前编辑值仍保留，以避免 UI 交互回退抖动。
+ */
 static void ui_commit_scalar_edit(Workspace* workspace,
                                   GraphicObject* object,
                                   const char* key,
@@ -404,6 +501,14 @@ static void ui_commit_scalar_edit(Workspace* workspace,
     workspace_sync_document_dirty(workspace);
 }
 
+/**
+ * @brief ui_apply_stroke_color 函数。
+ *
+ * @param workspace 参数 `workspace`。
+ * @param object 参数 `object`。
+ * @param color 参数 `color`。
+ * @return 无。
+ */
 static void ui_apply_stroke_color(Workspace* workspace, GraphicObject* object, Color color)
 {
     Color before;
@@ -427,6 +532,14 @@ static void ui_apply_stroke_color(Workspace* workspace, GraphicObject* object, C
     }
 }
 
+/**
+ * @brief ui_apply_stroke_width 函数。
+ *
+ * @param workspace 参数 `workspace`。
+ * @param object 参数 `object`。
+ * @param stroke_width 参数 `stroke_width`。
+ * @return 无。
+ */
 static void ui_apply_stroke_width(Workspace* workspace, GraphicObject* object, float stroke_width)
 {
     float before = 0.0f;
@@ -439,6 +552,21 @@ static void ui_apply_stroke_width(Workspace* workspace, GraphicObject* object, f
     ui_commit_scalar_edit(workspace, object, "stroke_width", before, stroke_width);
 }
 
+/**
+ * @brief ui_property_apply_float 函数。
+ *
+ * @param ctx 参数 `ctx`。
+ * @param workspace 参数 `workspace`。
+ * @param object 参数 `object`。
+ * @param label 参数 `label`。
+ * @param key 参数 `key`。
+ * @param min_value 参数 `min_value`。
+ * @param value 参数 `value`。
+ * @param max_value 参数 `max_value`。
+ * @param step 参数 `step`。
+ * @param inc_per_pixel 参数 `inc_per_pixel`。
+ * @return 无。
+ */
 static void ui_property_apply_float(struct nk_context* ctx,
                                     Workspace* workspace,
                                     GraphicObject* object,
@@ -458,6 +586,15 @@ static void ui_property_apply_float(struct nk_context* ctx,
     }
 }
 
+/**
+ * @brief ui_tool_button 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @param label 参数 `label`。
+ * @param active 参数 `active`。
+ * @param tooltip 参数 `tooltip`。
+ * @return 函数返回值。
+ */
 static int ui_tool_button(UiSystem* ui, const char* label, int active, const char* tooltip)
 {
     struct nk_context* ctx = ui->ctx;
@@ -498,6 +635,14 @@ static int ui_tool_button(UiSystem* ui, const char* label, int active, const cha
     return pressed;
 }
 
+/**
+ * @brief ui_tool_rail 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @param workspace 参数 `workspace`。
+ * @param bounds 参数 `bounds`。
+ * @return 无。
+ */
 static void ui_tool_rail(UiSystem* ui, Workspace* workspace, RectF bounds)
 {
     struct nk_context* ctx = ui->ctx;
@@ -538,6 +683,12 @@ static void ui_tool_rail(UiSystem* ui, Workspace* workspace, RectF bounds)
     nk_end(ctx);
 }
 
+/**
+ * @brief ui_inspector_empty_hint 函数。
+ *
+ * @param ctx 参数 `ctx`。
+ * @return 无。
+ */
 static void ui_inspector_empty_hint(struct nk_context* ctx)
 {
     nk_label(ctx, "No selection", NK_TEXT_LEFT);
@@ -547,6 +698,14 @@ static void ui_inspector_empty_hint(struct nk_context* ctx)
     nk_label(ctx, "Delete removes selection", NK_TEXT_LEFT);
 }
 
+/**
+ * @brief ui_inspector_overview 函数。
+ *
+ * @param ctx 参数 `ctx`。
+ * @param document 参数 `document`。
+ * @param object 参数 `object`。
+ * @return 无。
+ */
 static void ui_inspector_overview(struct nk_context* ctx, const Document* document, const GraphicObject* object)
 {
     if (!ctx || !document || !object) {
@@ -558,6 +717,14 @@ static void ui_inspector_overview(struct nk_context* ctx, const Document* docume
     nk_labelf(ctx, NK_TEXT_LEFT, "Selected: %d", document->selection.count);
 }
 
+/**
+ * @brief ui_inspector_style 函数。
+ *
+ * @param ctx 参数 `ctx`。
+ * @param workspace 参数 `workspace`。
+ * @param object 参数 `object`。
+ * @return 无。
+ */
 static void ui_inspector_style(struct nk_context* ctx, Workspace* workspace, GraphicObject* object)
 {
     Color stroke;
@@ -585,6 +752,14 @@ static void ui_inspector_style(struct nk_context* ctx, Workspace* workspace, Gra
     if (nk_slider_float(ctx, 1.0f, &stroke_width, 12.0f, 0.1f)) ui_apply_stroke_width(workspace, object, stroke_width);
 }
 
+/**
+ * @brief ui_inspector_geometry 函数。
+ *
+ * @param ctx 参数 `ctx`。
+ * @param workspace 参数 `workspace`。
+ * @param object 参数 `object`。
+ * @return 无。
+ */
 static void ui_inspector_geometry(struct nk_context* ctx, Workspace* workspace, GraphicObject* object)
 {
     if (!ctx || !workspace || !object) {
@@ -620,6 +795,13 @@ static void ui_inspector_geometry(struct nk_context* ctx, Workspace* workspace, 
     }
 }
 
+/**
+ * @brief 构建并绘制右侧 Inspector 选择面板。
+ * @param ui [in,out] UI 系统。
+ * @param workspace [in,out] 工作区对象。
+ * @param bounds [in] 面板布局矩形。
+ * @return 无。
+ */
 static void ui_selection_panel(UiSystem* ui, Workspace* workspace, RectF bounds)
 {
     struct nk_context* ctx = ui->ctx;
@@ -646,6 +828,15 @@ static void ui_selection_panel(UiSystem* ui, Workspace* workspace, RectF bounds)
     nk_end(ctx);
 }
 
+/**
+ * @brief ui_status_bar 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @param workspace 参数 `workspace`。
+ * @param window_width 参数 `window_width`。
+ * @param window_height 参数 `window_height`。
+ * @return 无。
+ */
 static void ui_status_bar(UiSystem* ui, Workspace* workspace, int window_width, int window_height)
 {
     struct nk_context* ctx = ui->ctx;
@@ -686,6 +877,12 @@ static void ui_status_bar(UiSystem* ui, Workspace* workspace, int window_width, 
     nk_end(ctx);
 }
 
+/**
+ * @brief ui_system_create 函数。
+ *
+ * @param window 参数 `window`。
+ * @return 函数返回值。
+ */
 UiSystem* ui_system_create(PlatformWindow* window)
 {
     UiSystem* ui = (UiSystem*)calloc(1, sizeof(*ui));
@@ -727,6 +924,12 @@ UiSystem* ui_system_create(PlatformWindow* window)
     return ui;
 }
 
+/**
+ * @brief ui_system_destroy 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @return 无。
+ */
 void ui_system_destroy(UiSystem* ui)
 {
     if (!ui) {
@@ -740,6 +943,12 @@ void ui_system_destroy(UiSystem* ui)
     free(ui);
 }
 
+/**
+ * @brief ui_system_begin_frame 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @return 无。
+ */
 void ui_system_begin_frame(UiSystem* ui)
 {
     if (ui) {
@@ -747,6 +956,19 @@ void ui_system_begin_frame(UiSystem* ui)
     }
 }
 
+/**
+ * @brief 构建一帧完整 UI（菜单、工具栏、检查器、状态栏）。
+ * @param ui [in,out] UI 系统。
+ * @param workspace [in,out] 工作区对象。
+ * @return 无。
+ *
+ * 算法步骤：
+ * 1. 读取窗口尺寸并刷新主题热重载状态；
+ * 2. 构建菜单栏并处理主题切换请求；
+ * 3. 计算 appbar/rail/panel/content 布局；
+ * 4. 按动画状态绘制 inspector；
+ * 5. 绘制状态栏并发布布局快照给工作区。
+ */
 void ui_system_build(UiSystem* ui, Workspace* workspace)
 {
     int width = 0;
@@ -896,6 +1118,12 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
     ui_publish_layout(ui, workspace, width, height);
 }
 
+/**
+ * @brief ui_system_render 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @return 无。
+ */
 void ui_system_render(UiSystem* ui)
 {
     if (!ui) {
@@ -904,6 +1132,12 @@ void ui_system_render(UiSystem* ui)
     nk_glfw3_render(&ui->glfw, NK_ANTI_ALIASING_ON, UI_MAX_VERTEX_BUFFER, UI_MAX_ELEMENT_BUFFER);
 }
 
+/**
+ * @brief ui_system_has_active_interaction 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @return 函数返回值。
+ */
 int ui_system_has_active_interaction(const UiSystem* ui)
 {
     if (!ui || !ui->ctx) {
@@ -913,6 +1147,13 @@ int ui_system_has_active_interaction(const UiSystem* ui)
     return nk_item_is_any_active(ui->ctx);
 }
 
+/**
+ * @brief ui_system_blocks_pointer 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @param screen_pos 参数 `screen_pos`。
+ * @return 函数返回值。
+ */
 int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos)
 {
     if (!ui || !ui->ctx) {
@@ -929,6 +1170,12 @@ int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos)
            rectf_contains_point(&ui->layout_snapshot.status_bounds, screen_pos);
 }
 
+/**
+ * @brief ui_system_window_bounds 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @return 函数返回值。
+ */
 RectF ui_system_window_bounds(const UiSystem* ui)
 {
     RectF bounds = {0.0f, 0.0f, 1.0f, 1.0f};
@@ -947,6 +1194,12 @@ RectF ui_system_window_bounds(const UiSystem* ui)
     return bounds;
 }
 
+/**
+ * @brief ui_system_content_bounds 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @return 函数返回值。
+ */
 RectF ui_system_content_bounds(const UiSystem* ui)
 {
     RectF bounds = {0.0f, 0.0f, 0.0f, 0.0f};
@@ -958,6 +1211,13 @@ RectF ui_system_content_bounds(const UiSystem* ui)
     return ui->layout_snapshot.canvas_content_bounds;
 }
 
+/**
+ * @brief ui_system_point_in_canvas 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @param screen_pos 参数 `screen_pos`。
+ * @return 函数返回值。
+ */
 int ui_system_point_in_canvas(const UiSystem* ui, Vec2 screen_pos)
 {
     RectF canvas_bounds = ui_system_content_bounds(ui);
@@ -970,6 +1230,12 @@ int ui_system_point_in_canvas(const UiSystem* ui, Vec2 screen_pos)
     return rectf_contains_point(&canvas_bounds, screen_pos);
 }
 
+/**
+ * @brief ui_system_canvas_background 函数。
+ *
+ * @param ui 参数 `ui`。
+ * @return 函数返回值。
+ */
 Color ui_system_canvas_background(const UiSystem* ui)
 {
     Color background = {0.11f, 0.12f, 0.14f, 1.0f};

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -80,12 +80,11 @@ typedef enum UiThemeReloadReason {
 } UiThemeReloadReason;
 
 /**
- * @brief ui_clampf 函数。
- *
- * @param value 参数 `value`。
- * @param min_value 参数 `min_value`。
- * @param max_value 参数 `max_value`。
- * @return 函数返回值。
+ * @brief Clamps a float value.
+ * @param value Value to clamp.
+ * @param min_value Minimum value.
+ * @param max_value Maximum value.
+ * @return Clamped value.
  */
 static float ui_clampf(float value, float min_value, float max_value)
 {
@@ -99,10 +98,9 @@ static float ui_clampf(float value, float min_value, float max_value)
 }
 
 /**
- * @brief ui_theme_reload_reason_label 函数。
- *
- * @param reason 参数 `reason`。
- * @return 函数返回值。
+ * @brief Gets label for theme reload reason.
+ * @param reason Reload reason enum.
+ * @return Reason label string.
  */
 static const char* ui_theme_reload_reason_label(UiThemeReloadReason reason)
 {
@@ -118,10 +116,9 @@ static const char* ui_theme_reload_reason_label(UiThemeReloadReason reason)
 }
 
 /**
- * @brief ui_system_sync_menubar_themes 函数。
- *
- * @param ui 参数 `ui`。
- * @return 无。
+ * @brief Syncs theme registry with menu bar.
+ * @param ui UI system instance.
+ * @return None.
  */
 static void ui_system_sync_menubar_themes(UiSystem* ui)
 {
@@ -159,12 +156,11 @@ static void ui_system_sync_menubar_themes(UiSystem* ui)
 }
 
 /**
- * @brief ui_system_set_theme 函数。
- *
- * @param ui 参数 `ui`。
- * @param theme_id 参数 `theme_id`。
- * @param persist_selection 参数 `persist_selection`。
- * @return 函数返回值。
+ * @brief Sets the active theme.
+ * @param ui UI system instance.
+ * @param theme_id Theme ID to activate.
+ * @param persist_selection Whether to persist selection.
+ * @return 1 on success, 0 on failure.
  */
 static int ui_system_set_theme(UiSystem* ui, const char* theme_id, int persist_selection)
 {
@@ -205,13 +201,12 @@ static int ui_system_set_theme(UiSystem* ui, const char* theme_id, int persist_s
 }
 
 /**
- * @brief ui_system_reload_themes 函数。
- *
- * @param ui 参数 `ui`。
- * @param workspace 参数 `workspace`。
- * @param notify_status 参数 `notify_status`。
- * @param reason 参数 `reason`。
- * @return 无。
+ * @brief Reloads external themes.
+ * @param ui UI system instance.
+ * @param workspace Workspace instance.
+ * @param notify_status Whether to notify status bar.
+ * @param reason Reload reason.
+ * @return None.
  */
 static void ui_system_reload_themes(UiSystem* ui,
                                     Workspace* workspace,
@@ -265,10 +260,9 @@ static void ui_system_reload_themes(UiSystem* ui,
 }
 
 /**
- * @brief ui_system_load_theme_from_settings 函数。
- *
- * @param ui 参数 `ui`。
- * @return 无。
+ * @brief Loads theme selection from settings.
+ * @param ui UI system instance.
+ * @return None.
  */
 static void ui_system_load_theme_from_settings(UiSystem* ui)
 {
@@ -290,12 +284,11 @@ static void ui_system_load_theme_from_settings(UiSystem* ui)
 }
 
 /**
- * @brief ui_system_poll_theme_hot_reload 函数。
- *
- * @param ui 参数 `ui`。
- * @param workspace 参数 `workspace`。
- * @param now_seconds 参数 `now_seconds`。
- * @return 无。
+ * @brief Polls for theme hot reload.
+ * @param ui UI system instance.
+ * @param workspace Workspace instance.
+ * @param now_seconds Current time in seconds.
+ * @return None.
  */
 static void ui_system_poll_theme_hot_reload(UiSystem* ui, Workspace* workspace, double now_seconds)
 {
@@ -319,10 +312,9 @@ static void ui_system_poll_theme_hot_reload(UiSystem* ui, Workspace* workspace, 
 }
 
 /**
- * @brief ui_smoothstep 函数。
- *
- * @param t 参数 `t`。
- * @return 函数返回值。
+ * @brief Smoothstep interpolation.
+ * @param t Interpolation parameter.
+ * @return Smoothed value.
  */
 static float ui_smoothstep(float t)
 {
@@ -331,11 +323,10 @@ static float ui_smoothstep(float t)
 }
 
 /**
- * @brief ui_rectf_equals 函数。
- *
- * @param a 参数 `a`。
- * @param b 参数 `b`。
- * @return 函数返回值。
+ * @brief Checks if two rectangles are equal.
+ * @param a First rectangle.
+ * @param b Second rectangle.
+ * @return 1 if equal, 0 otherwise.
  */
 static int ui_rectf_equals(RectF a, RectF b)
 {
@@ -347,11 +338,10 @@ static int ui_rectf_equals(RectF a, RectF b)
 }
 
 /**
- * @brief ui_clamp_rect_to_window 函数。
- *
- * @param rect 参数 `rect`。
- * @param window_bounds 参数 `window_bounds`。
- * @return 函数返回值。
+ * @brief Clamps rectangle to window bounds.
+ * @param rect Rectangle to clamp.
+ * @param window_bounds Window bounds.
+ * @return Clamped rectangle.
  */
 static RectF ui_clamp_rect_to_window(RectF rect, RectF window_bounds)
 {
@@ -395,13 +385,12 @@ static RectF ui_clamp_rect_to_window(RectF rect, RectF window_bounds)
 }
 
 /**
- * @brief ui_publish_layout 函数。
- *
- * @param ui 参数 `ui`。
- * @param workspace 参数 `workspace`。
- * @param width 参数 `width`。
- * @param height 参数 `height`。
- * @return 无。
+ * @brief Publishes layout to workspace.
+ * @param ui UI system instance.
+ * @param workspace Workspace instance.
+ * @param width Window width.
+ * @param height Window height.
+ * @return None.
  */
 static void ui_publish_layout(UiSystem* ui, Workspace* workspace, int width, int height)
 {
@@ -442,10 +431,9 @@ static void ui_publish_layout(UiSystem* ui, Workspace* workspace, int width, int
 }
 
 /**
- * @brief ui_tool_context 函数。
- *
- * @param workspace 参数 `workspace`。
- * @return 函数返回值。
+ * @brief Creates a tool context from workspace.
+ * @param workspace Workspace instance.
+ * @return Tool context.
  */
 static ToolContext ui_tool_context(Workspace* workspace)
 {
@@ -458,15 +446,15 @@ static ToolContext ui_tool_context(Workspace* workspace)
 }
 
 /**
- * @brief 提交一次对象标量属性修改并写入历史。
- * @param workspace [in,out] 工作区对象。
- * @param object [in,out] 目标对象。
- * @param key [in] 标量属性键名。
- * @param before_value [in] 修改前值。
- * @param after_value [in] 修改后值。
- * @return 无。
+ * @brief Commits an object scalar property edit to history.
+ * @param workspace [in,out] Workspace instance.
+ * @param object [in,out] Target object.
+ * @param key [in] Scalar property key.
+ * @param before_value [in] Value before change.
+ * @param after_value [in] Value after change.
+ * @return None.
  *
- * @note 若历史写入失败，当前编辑值仍保留，以避免 UI 交互回退抖动。
+ * @note If history write fails, current edit value is kept to avoid UI interaction rollback jitter.
  */
 static void ui_commit_scalar_edit(Workspace* workspace,
                                   GraphicObject* object,
@@ -502,12 +490,11 @@ static void ui_commit_scalar_edit(Workspace* workspace,
 }
 
 /**
- * @brief ui_apply_stroke_color 函数。
- *
- * @param workspace 参数 `workspace`。
- * @param object 参数 `object`。
- * @param color 参数 `color`。
- * @return 无。
+ * @brief Applies stroke color to object.
+ * @param workspace Workspace instance.
+ * @param object Object to modify.
+ * @param color Stroke color to apply.
+ * @return None.
  */
 static void ui_apply_stroke_color(Workspace* workspace, GraphicObject* object, Color color)
 {
@@ -533,12 +520,11 @@ static void ui_apply_stroke_color(Workspace* workspace, GraphicObject* object, C
 }
 
 /**
- * @brief ui_apply_stroke_width 函数。
- *
- * @param workspace 参数 `workspace`。
- * @param object 参数 `object`。
- * @param stroke_width 参数 `stroke_width`。
- * @return 无。
+ * @brief Applies stroke width to object.
+ * @param workspace Workspace instance.
+ * @param object Object to modify.
+ * @param stroke_width Stroke width to apply.
+ * @return None.
  */
 static void ui_apply_stroke_width(Workspace* workspace, GraphicObject* object, float stroke_width)
 {
@@ -553,19 +539,18 @@ static void ui_apply_stroke_width(Workspace* workspace, GraphicObject* object, f
 }
 
 /**
- * @brief ui_property_apply_float 函数。
- *
- * @param ctx 参数 `ctx`。
- * @param workspace 参数 `workspace`。
- * @param object 参数 `object`。
- * @param label 参数 `label`。
- * @param key 参数 `key`。
- * @param min_value 参数 `min_value`。
- * @param value 参数 `value`。
- * @param max_value 参数 `max_value`。
- * @param step 参数 `step`。
- * @param inc_per_pixel 参数 `inc_per_pixel`。
- * @return 无。
+ * @brief Applies a float property change.
+ * @param ctx Nuklear context.
+ * @param workspace Workspace instance.
+ * @param object Object to modify.
+ * @param label Property label.
+ * @param key Property key.
+ * @param min_value Minimum value.
+ * @param value Current value pointer.
+ * @param max_value Maximum value.
+ * @param step Step value.
+ * @param inc_per_pixel Increment per pixel.
+ * @return None.
  */
 static void ui_property_apply_float(struct nk_context* ctx,
                                     Workspace* workspace,
@@ -587,13 +572,12 @@ static void ui_property_apply_float(struct nk_context* ctx,
 }
 
 /**
- * @brief ui_tool_button 函数。
- *
- * @param ui 参数 `ui`。
- * @param label 参数 `label`。
- * @param active 参数 `active`。
- * @param tooltip 参数 `tooltip`。
- * @return 函数返回值。
+ * @brief Renders a tool button.
+ * @param ui UI system instance.
+ * @param label Button label.
+ * @param active Whether button is active.
+ * @param tooltip Tooltip text.
+ * @return 1 if pressed, 0 otherwise.
  */
 static int ui_tool_button(UiSystem* ui, const char* label, int active, const char* tooltip)
 {
@@ -636,12 +620,11 @@ static int ui_tool_button(UiSystem* ui, const char* label, int active, const cha
 }
 
 /**
- * @brief ui_tool_rail 函数。
- *
- * @param ui 参数 `ui`。
- * @param workspace 参数 `workspace`。
- * @param bounds 参数 `bounds`。
- * @return 无。
+ * @brief Renders the tool rail panel.
+ * @param ui UI system instance.
+ * @param workspace Workspace instance.
+ * @param bounds Panel bounds.
+ * @return None.
  */
 static void ui_tool_rail(UiSystem* ui, Workspace* workspace, RectF bounds)
 {
@@ -684,10 +667,9 @@ static void ui_tool_rail(UiSystem* ui, Workspace* workspace, RectF bounds)
 }
 
 /**
- * @brief ui_inspector_empty_hint 函数。
- *
- * @param ctx 参数 `ctx`。
- * @return 无。
+ * @brief Shows empty inspector hint text.
+ * @param ctx Nuklear context.
+ * @return None.
  */
 static void ui_inspector_empty_hint(struct nk_context* ctx)
 {
@@ -699,12 +681,11 @@ static void ui_inspector_empty_hint(struct nk_context* ctx)
 }
 
 /**
- * @brief ui_inspector_overview 函数。
- *
- * @param ctx 参数 `ctx`。
- * @param document 参数 `document`。
- * @param object 参数 `object`。
- * @return 无。
+ * @brief Renders inspector overview section.
+ * @param ctx Nuklear context.
+ * @param document Document instance.
+ * @param object Selected object.
+ * @return None.
  */
 static void ui_inspector_overview(struct nk_context* ctx, const Document* document, const GraphicObject* object)
 {
@@ -718,12 +699,11 @@ static void ui_inspector_overview(struct nk_context* ctx, const Document* docume
 }
 
 /**
- * @brief ui_inspector_style 函数。
- *
- * @param ctx 参数 `ctx`。
- * @param workspace 参数 `workspace`。
- * @param object 参数 `object`。
- * @return 无。
+ * @brief Renders inspector style section.
+ * @param ctx Nuklear context.
+ * @param workspace Workspace instance.
+ * @param object Selected object.
+ * @return None.
  */
 static void ui_inspector_style(struct nk_context* ctx, Workspace* workspace, GraphicObject* object)
 {
@@ -753,12 +733,11 @@ static void ui_inspector_style(struct nk_context* ctx, Workspace* workspace, Gra
 }
 
 /**
- * @brief ui_inspector_geometry 函数。
- *
- * @param ctx 参数 `ctx`。
- * @param workspace 参数 `workspace`。
- * @param object 参数 `object`。
- * @return 无。
+ * @brief Renders inspector geometry section.
+ * @param ctx Nuklear context.
+ * @param workspace Workspace instance.
+ * @param object Selected object.
+ * @return None.
  */
 static void ui_inspector_geometry(struct nk_context* ctx, Workspace* workspace, GraphicObject* object)
 {
@@ -796,11 +775,11 @@ static void ui_inspector_geometry(struct nk_context* ctx, Workspace* workspace, 
 }
 
 /**
- * @brief 构建并绘制右侧 Inspector 选择面板。
- * @param ui [in,out] UI 系统。
- * @param workspace [in,out] 工作区对象。
- * @param bounds [in] 面板布局矩形。
- * @return 无。
+ * @brief Builds and renders the right-side Inspector selection panel.
+ * @param ui [in,out] UI system.
+ * @param workspace [in,out] Workspace instance.
+ * @param bounds [in] Panel layout rectangle.
+ * @return None.
  */
 static void ui_selection_panel(UiSystem* ui, Workspace* workspace, RectF bounds)
 {
@@ -829,13 +808,12 @@ static void ui_selection_panel(UiSystem* ui, Workspace* workspace, RectF bounds)
 }
 
 /**
- * @brief ui_status_bar 函数。
- *
- * @param ui 参数 `ui`。
- * @param workspace 参数 `workspace`。
- * @param window_width 参数 `window_width`。
- * @param window_height 参数 `window_height`。
- * @return 无。
+ * @brief Renders the status bar.
+ * @param ui UI system instance.
+ * @param workspace Workspace instance.
+ * @param window_width Window width.
+ * @param window_height Window height.
+ * @return None.
  */
 static void ui_status_bar(UiSystem* ui, Workspace* workspace, int window_width, int window_height)
 {
@@ -878,10 +856,9 @@ static void ui_status_bar(UiSystem* ui, Workspace* workspace, int window_width, 
 }
 
 /**
- * @brief ui_system_create 函数。
- *
- * @param window 参数 `window`。
- * @return 函数返回值。
+ * @brief Creates a UI system instance.
+ * @param window Platform window.
+ * @return UI system instance or NULL.
  */
 UiSystem* ui_system_create(PlatformWindow* window)
 {
@@ -925,10 +902,9 @@ UiSystem* ui_system_create(PlatformWindow* window)
 }
 
 /**
- * @brief ui_system_destroy 函数。
- *
- * @param ui 参数 `ui`。
- * @return 无。
+ * @brief Destroys a UI system instance.
+ * @param ui UI system instance.
+ * @return None.
  */
 void ui_system_destroy(UiSystem* ui)
 {
@@ -944,10 +920,9 @@ void ui_system_destroy(UiSystem* ui)
 }
 
 /**
- * @brief ui_system_begin_frame 函数。
- *
- * @param ui 参数 `ui`。
- * @return 无。
+ * @brief Begins a UI frame.
+ * @param ui UI system instance.
+ * @return None.
  */
 void ui_system_begin_frame(UiSystem* ui)
 {
@@ -957,17 +932,17 @@ void ui_system_begin_frame(UiSystem* ui)
 }
 
 /**
- * @brief 构建一帧完整 UI（菜单、工具栏、检查器、状态栏）。
- * @param ui [in,out] UI 系统。
- * @param workspace [in,out] 工作区对象。
- * @return 无。
+ * @brief Builds a complete UI frame (menu, toolbar, inspector, status bar).
+ * @param ui [in,out] UI system.
+ * @param workspace [in,out] Workspace instance.
+ * @return None.
  *
- * 算法步骤：
- * 1. 读取窗口尺寸并刷新主题热重载状态；
- * 2. 构建菜单栏并处理主题切换请求；
- * 3. 计算 appbar/rail/panel/content 布局；
- * 4. 按动画状态绘制 inspector；
- * 5. 绘制状态栏并发布布局快照给工作区。
+ * Algorithm steps:
+ * 1. Reads window size and refreshes theme hot-reload state.
+ * 2. Builds menu bar and handles theme switch requests.
+ * 3. Computes appbar/rail/panel/content layout.
+ * 4. Draws inspector based on animation state.
+ * 5. Draws status bar and publishes layout snapshot to workspace.
  */
 void ui_system_build(UiSystem* ui, Workspace* workspace)
 {
@@ -1119,10 +1094,9 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
 }
 
 /**
- * @brief ui_system_render 函数。
- *
- * @param ui 参数 `ui`。
- * @return 无。
+ * @brief Renders the UI.
+ * @param ui UI system instance.
+ * @return None.
  */
 void ui_system_render(UiSystem* ui)
 {
@@ -1133,10 +1107,9 @@ void ui_system_render(UiSystem* ui)
 }
 
 /**
- * @brief ui_system_has_active_interaction 函数。
- *
- * @param ui 参数 `ui`。
- * @return 函数返回值。
+ * @brief Checks if UI has an active interaction.
+ * @param ui UI system instance.
+ * @return 1 if active interaction, 0 otherwise.
  */
 int ui_system_has_active_interaction(const UiSystem* ui)
 {
@@ -1148,11 +1121,10 @@ int ui_system_has_active_interaction(const UiSystem* ui)
 }
 
 /**
- * @brief ui_system_blocks_pointer 函数。
- *
- * @param ui 参数 `ui`。
- * @param screen_pos 参数 `screen_pos`。
- * @return 函数返回值。
+ * @brief Checks if UI blocks pointer at position.
+ * @param ui UI system instance.
+ * @param screen_pos Screen position.
+ * @return 1 if pointer is blocked, 0 otherwise.
  */
 int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos)
 {
@@ -1171,10 +1143,9 @@ int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos)
 }
 
 /**
- * @brief ui_system_window_bounds 函数。
- *
- * @param ui 参数 `ui`。
- * @return 函数返回值。
+ * @brief Gets the window bounds.
+ * @param ui UI system instance.
+ * @return Window bounds rectangle.
  */
 RectF ui_system_window_bounds(const UiSystem* ui)
 {
@@ -1195,10 +1166,9 @@ RectF ui_system_window_bounds(const UiSystem* ui)
 }
 
 /**
- * @brief ui_system_content_bounds 函数。
- *
- * @param ui 参数 `ui`。
- * @return 函数返回值。
+ * @brief Gets the content bounds.
+ * @param ui UI system instance.
+ * @return Content bounds rectangle.
  */
 RectF ui_system_content_bounds(const UiSystem* ui)
 {
@@ -1212,11 +1182,10 @@ RectF ui_system_content_bounds(const UiSystem* ui)
 }
 
 /**
- * @brief ui_system_point_in_canvas 函数。
- *
- * @param ui 参数 `ui`。
- * @param screen_pos 参数 `screen_pos`。
- * @return 函数返回值。
+ * @brief Checks if point is in canvas area.
+ * @param ui UI system instance.
+ * @param screen_pos Screen position.
+ * @return 1 if in canvas, 0 otherwise.
  */
 int ui_system_point_in_canvas(const UiSystem* ui, Vec2 screen_pos)
 {
@@ -1231,10 +1200,9 @@ int ui_system_point_in_canvas(const UiSystem* ui, Vec2 screen_pos)
 }
 
 /**
- * @brief ui_system_canvas_background 函数。
- *
- * @param ui 参数 `ui`。
- * @return 函数返回值。
+ * @brief Gets the canvas background color.
+ * @param ui UI system instance.
+ * @return Background color.
  */
 Color ui_system_canvas_background(const UiSystem* ui)
 {

--- a/src/ui/ui_theme.c
+++ b/src/ui/ui_theme.c
@@ -64,6 +64,14 @@ static UiThemeTokens ui_theme_dark_plus_tokens(void);
 static UiThemeTokens ui_theme_high_contrast_tokens(void);
 static int ui_theme_builtin_count(void);
 
+/**
+ * @brief ui_theme_mix_channel 函数。
+ *
+ * @param a 参数 `a`。
+ * @param b 参数 `b`。
+ * @param t 参数 `t`。
+ * @return 函数返回值。
+ */
 static struct nk_color ui_theme_mix_channel(struct nk_color a, struct nk_color b, float t)
 {
     struct nk_color out;
@@ -82,6 +90,12 @@ static struct nk_color ui_theme_mix_channel(struct nk_color a, struct nk_color b
     return out;
 }
 
+/**
+ * @brief ui_theme_light_tokens 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 static UiThemeTokens ui_theme_light_tokens(void)
 {
     UiThemeTokens tokens;
@@ -123,6 +137,12 @@ static UiThemeTokens ui_theme_light_tokens(void)
     return tokens;
 }
 
+/**
+ * @brief ui_theme_dark_plus_tokens 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 static UiThemeTokens ui_theme_dark_plus_tokens(void)
 {
     UiThemeTokens tokens;
@@ -164,6 +184,12 @@ static UiThemeTokens ui_theme_dark_plus_tokens(void)
     return tokens;
 }
 
+/**
+ * @brief ui_theme_high_contrast_tokens 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 static UiThemeTokens ui_theme_high_contrast_tokens(void)
 {
     UiThemeTokens tokens;
@@ -205,16 +231,34 @@ static UiThemeTokens ui_theme_high_contrast_tokens(void)
     return tokens;
 }
 
+/**
+ * @brief ui_theme_default_tokens 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 UiThemeTokens ui_theme_default_tokens(void)
 {
     return ui_theme_light_tokens();
 }
 
+/**
+ * @brief ui_theme_builtin_count 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 static int ui_theme_builtin_count(void)
 {
     return (int)(sizeof(g_builtin_theme_descriptors) / sizeof(g_builtin_theme_descriptors[0]));
 }
 
+/**
+ * @brief ui_theme_builtin_descriptor_at 函数。
+ *
+ * @param index 参数 `index`。
+ * @return 函数返回值。
+ */
 static const UiThemeDescriptor* ui_theme_builtin_descriptor_at(int index)
 {
     if (index < 0 || index >= ui_theme_builtin_count()) {
@@ -223,6 +267,12 @@ static const UiThemeDescriptor* ui_theme_builtin_descriptor_at(int index)
     return &g_builtin_theme_descriptors[index];
 }
 
+/**
+ * @brief ui_theme_builtin_tokens_at 函数。
+ *
+ * @param index 参数 `index`。
+ * @return 函数返回值。
+ */
 static UiThemeTokens ui_theme_builtin_tokens_at(int index)
 {
     switch (index) {
@@ -236,6 +286,12 @@ static UiThemeTokens ui_theme_builtin_tokens_at(int index)
     }
 }
 
+/**
+ * @brief ui_theme_custom_index_of_id 函数。
+ *
+ * @param theme_id 参数 `theme_id`。
+ * @return 函数返回值。
+ */
 static int ui_theme_custom_index_of_id(const char* theme_id)
 {
     if (!theme_id || theme_id[0] == '\0') {
@@ -250,11 +306,23 @@ static int ui_theme_custom_index_of_id(const char* theme_id)
     return -1;
 }
 
+/**
+ * @brief ui_theme_count 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 int ui_theme_count(void)
 {
     return ui_theme_builtin_count() + g_custom_theme_count;
 }
 
+/**
+ * @brief ui_theme_descriptor_at 函数。
+ *
+ * @param index 参数 `index`。
+ * @return 函数返回值。
+ */
 const UiThemeDescriptor* ui_theme_descriptor_at(int index)
 {
     int builtin_count = ui_theme_builtin_count();
@@ -269,6 +337,12 @@ const UiThemeDescriptor* ui_theme_descriptor_at(int index)
     return &g_custom_theme_entries[custom_index].descriptor;
 }
 
+/**
+ * @brief ui_theme_index_of_id 函数。
+ *
+ * @param theme_id 参数 `theme_id`。
+ * @return 函数返回值。
+ */
 int ui_theme_index_of_id(const char* theme_id)
 {
     int builtin_count = ui_theme_builtin_count();
@@ -292,11 +366,23 @@ int ui_theme_index_of_id(const char* theme_id)
     return -1;
 }
 
+/**
+ * @brief ui_theme_default_id 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 const char* ui_theme_default_id(void)
 {
     return g_builtin_theme_descriptors[UI_THEME_LIGHT_INDEX].id;
 }
 
+/**
+ * @brief ui_theme_tokens_for_id 函数。
+ *
+ * @param theme_id 参数 `theme_id`。
+ * @return 函数返回值。
+ */
 UiThemeTokens ui_theme_tokens_for_id(const char* theme_id)
 {
     int theme_index = ui_theme_index_of_id(theme_id);
@@ -311,6 +397,12 @@ UiThemeTokens ui_theme_tokens_for_id(const char* theme_id)
     return g_custom_theme_entries[theme_index - builtin_count].tokens;
 }
 
+/**
+ * @brief ui_read_text_file 函数。
+ *
+ * @param path 参数 `path`。
+ * @return 函数返回值。
+ */
 static char* ui_read_text_file(const char* path)
 {
     FILE* file = NULL;
@@ -354,6 +446,15 @@ static char* ui_read_text_file(const char* path)
     return buffer;
 }
 
+/**
+ * @brief ui_extract_json_string_value 函数。
+ *
+ * @param text 参数 `text`。
+ * @param key 参数 `key`。
+ * @param out_value 参数 `out_value`。
+ * @param out_value_size 参数 `out_value_size`。
+ * @return 函数返回值。
+ */
 static int ui_extract_json_string_value(const char* text,
                                         const char* key,
                                         char* out_value,
@@ -419,6 +520,14 @@ static int ui_extract_json_string_value(const char* text,
     return 0;
 }
 
+/**
+ * @brief ui_extract_json_number_value 函数。
+ *
+ * @param text 参数 `text`。
+ * @param key 参数 `key`。
+ * @param out_value 参数 `out_value`。
+ * @return 函数返回值。
+ */
 static int ui_extract_json_number_value(const char* text, const char* key, float* out_value)
 {
     char key_pattern[96];
@@ -463,6 +572,14 @@ static int ui_extract_json_number_value(const char* text, const char* key, float
     return 1;
 }
 
+/**
+ * @brief ui_extract_json_bool_value 函数。
+ *
+ * @param text 参数 `text`。
+ * @param key 参数 `key`。
+ * @param out_value 参数 `out_value`。
+ * @return 函数返回值。
+ */
 static int ui_extract_json_bool_value(const char* text, const char* key, int* out_value)
 {
     char key_pattern[96];
@@ -507,6 +624,13 @@ static int ui_extract_json_bool_value(const char* text, const char* key, int* ou
     return 0;
 }
 
+/**
+ * @brief ui_json_key_exists 函数。
+ *
+ * @param text 参数 `text`。
+ * @param key 参数 `key`。
+ * @return 函数返回值。
+ */
 static int ui_json_key_exists(const char* text, const char* key)
 {
     char key_pattern[96];
@@ -523,6 +647,12 @@ static int ui_json_key_exists(const char* text, const char* key)
     return strstr(text, key_pattern) != NULL;
 }
 
+/**
+ * @brief ui_hex_digit_value 函数。
+ *
+ * @param c 参数 `c`。
+ * @return 函数返回值。
+ */
 static int ui_hex_digit_value(char c)
 {
     if (c >= '0' && c <= '9') {
@@ -537,6 +667,13 @@ static int ui_hex_digit_value(char c)
     return -1;
 }
 
+/**
+ * @brief ui_parse_hex_byte 函数。
+ *
+ * @param text 参数 `text`。
+ * @param out_value 参数 `out_value`。
+ * @return 函数返回值。
+ */
 static int ui_parse_hex_byte(const char* text, unsigned char* out_value)
 {
     int hi = 0;
@@ -556,6 +693,13 @@ static int ui_parse_hex_byte(const char* text, unsigned char* out_value)
     return 1;
 }
 
+/**
+ * @brief ui_parse_hex_color 函数。
+ *
+ * @param hex_text 参数 `hex_text`。
+ * @param out_color 参数 `out_color`。
+ * @return 函数返回值。
+ */
 static int ui_parse_hex_color(const char* hex_text, struct nk_color* out_color)
 {
     size_t length = 0u;
@@ -589,6 +733,12 @@ static int ui_parse_hex_color(const char* hex_text, struct nk_color* out_color)
     return 1;
 }
 
+/**
+ * @brief ui_theme_path_has_json_extension 函数。
+ *
+ * @param path 参数 `path`。
+ * @return 函数返回值。
+ */
 static int ui_theme_path_has_json_extension(const char* path)
 {
     size_t length = 0u;
@@ -611,6 +761,14 @@ static int ui_theme_path_has_json_extension(const char* path)
            (tolower((unsigned char)ext[4]) == 'n');
 }
 
+/**
+ * @brief ui_theme_hash_bytes 函数。
+ *
+ * @param seed 参数 `seed`。
+ * @param data 参数 `data`。
+ * @param size 参数 `size`。
+ * @return 函数返回值。
+ */
 static unsigned long long ui_theme_hash_bytes(unsigned long long seed, const void* data, size_t size)
 {
     const unsigned char* bytes = (const unsigned char*)data;
@@ -627,6 +785,13 @@ static unsigned long long ui_theme_hash_bytes(unsigned long long seed, const voi
     return hash;
 }
 
+/**
+ * @brief ui_theme_hash_cstring 函数。
+ *
+ * @param seed 参数 `seed`。
+ * @param text 参数 `text`。
+ * @return 函数返回值。
+ */
 static unsigned long long ui_theme_hash_cstring(unsigned long long seed, const char* text)
 {
     if (!text) {
@@ -635,11 +800,24 @@ static unsigned long long ui_theme_hash_cstring(unsigned long long seed, const c
     return ui_theme_hash_bytes(seed, text, strlen(text));
 }
 
+/**
+ * @brief ui_theme_hash_u64 函数。
+ *
+ * @param seed 参数 `seed`。
+ * @param value 参数 `value`。
+ * @return 函数返回值。
+ */
 static unsigned long long ui_theme_hash_u64(unsigned long long seed, unsigned long long value)
 {
     return ui_theme_hash_bytes(seed, &value, sizeof(value));
 }
 
+/**
+ * @brief ui_theme_id_is_safe_for_json 函数。
+ *
+ * @param theme_id 参数 `theme_id`。
+ * @return 函数返回值。
+ */
 static int ui_theme_id_is_safe_for_json(const char* theme_id)
 {
     const unsigned char* cursor = (const unsigned char*)theme_id;
@@ -658,6 +836,12 @@ static int ui_theme_id_is_safe_for_json(const char* theme_id)
     return 1;
 }
 
+/**
+ * @brief ui_theme_filename_from_path 函数。
+ *
+ * @param path 参数 `path`。
+ * @return 函数返回值。
+ */
 static const char* ui_theme_filename_from_path(const char* path)
 {
     const char* last_slash = NULL;
@@ -681,6 +865,14 @@ static const char* ui_theme_filename_from_path(const char* path)
     return (last_slash > last_backslash) ? (last_slash + 1) : (last_backslash + 1);
 }
 
+/**
+ * @brief ui_theme_id_from_path 函数。
+ *
+ * @param path 参数 `path`。
+ * @param out_id 参数 `out_id`。
+ * @param out_id_size 参数 `out_id_size`。
+ * @return 函数返回值。
+ */
 static int ui_theme_id_from_path(const char* path, char* out_id, size_t out_id_size)
 {
     const char* filename = NULL;
@@ -710,6 +902,14 @@ static int ui_theme_id_from_path(const char* path, char* out_id, size_t out_id_s
     return write_length > 0u;
 }
 
+/**
+ * @brief ui_theme_apply_color_overrides 函数。
+ *
+ * @param source_path 参数 `source_path`。
+ * @param text 参数 `text`。
+ * @param tokens 参数 `tokens`。
+ * @return 无。
+ */
 static void ui_theme_apply_color_overrides(const char* source_path, const char* text, UiThemeTokens* tokens)
 {
     typedef struct UiThemeColorField {
@@ -758,6 +958,14 @@ static void ui_theme_apply_color_overrides(const char* source_path, const char* 
     }
 }
 
+/**
+ * @brief ui_theme_apply_float_overrides 函数。
+ *
+ * @param source_path 参数 `source_path`。
+ * @param text 参数 `text`。
+ * @param tokens 参数 `tokens`。
+ * @return 无。
+ */
 static void ui_theme_apply_float_overrides(const char* source_path, const char* text, UiThemeTokens* tokens)
 {
     typedef struct UiThemeFloatField {
@@ -796,6 +1004,14 @@ static void ui_theme_apply_float_overrides(const char* source_path, const char* 
     }
 }
 
+/**
+ * @brief ui_theme_apply_bool_overrides 函数。
+ *
+ * @param source_path 参数 `source_path`。
+ * @param text 参数 `text`。
+ * @param tokens 参数 `tokens`。
+ * @return 无。
+ */
 static void ui_theme_apply_bool_overrides(const char* source_path, const char* text, UiThemeTokens* tokens)
 {
     int bool_value = 0;
@@ -812,6 +1028,14 @@ static void ui_theme_apply_bool_overrides(const char* source_path, const char* t
     }
 }
 
+/**
+ * @brief ui_theme_clamp 函数。
+ *
+ * @param value 参数 `value`。
+ * @param min_value 参数 `min_value`。
+ * @param max_value 参数 `max_value`。
+ * @return 函数返回值。
+ */
 static float ui_theme_clamp(float value, float min_value, float max_value)
 {
     if (value < min_value) {
@@ -823,6 +1047,12 @@ static float ui_theme_clamp(float value, float min_value, float max_value)
     return value;
 }
 
+/**
+ * @brief ui_theme_clamp_tokens 函数。
+ *
+ * @param tokens 参数 `tokens`。
+ * @return 无。
+ */
 static void ui_theme_clamp_tokens(UiThemeTokens* tokens)
 {
     if (!tokens) {
@@ -837,6 +1067,14 @@ static void ui_theme_clamp_tokens(UiThemeTokens* tokens)
     tokens->transition_duration = ui_theme_clamp(tokens->transition_duration, 0.0f, 2.0f);
 }
 
+/**
+ * @brief ui_theme_store_custom_entry 函数。
+ *
+ * @param theme_id 参数 `theme_id`。
+ * @param label 参数 `label`。
+ * @param tokens 参数 `tokens`。
+ * @return 函数返回值。
+ */
 static int ui_theme_store_custom_entry(const char* theme_id,
                                        const char* label,
                                        const UiThemeTokens* tokens)
@@ -880,6 +1118,12 @@ static int ui_theme_store_custom_entry(const char* theme_id,
     return 1;
 }
 
+/**
+ * @brief ui_theme_load_external_file 函数。
+ *
+ * @param path 参数 `path`。
+ * @return 函数返回值。
+ */
 static int ui_theme_load_external_file(const char* path)
 {
     char* text = NULL;
@@ -944,6 +1188,17 @@ static int ui_theme_load_external_file(const char* path)
     return loaded;
 }
 
+/**
+ * @brief 重新扫描并加载外部主题目录。
+ * @param directory_path [in] 主题目录路径。
+ * @return 成功加载的主题数量。
+ *
+ * 算法步骤：
+ * 1. 备份当前外部主题集合；
+ * 2. 清空运行时外部主题表；
+ * 3. 扫描目录内 `.json` 文件并逐个解析；
+ * 4. 若本轮全部失败且之前有缓存，则回退到旧集合。
+ */
 int ui_theme_reload_external(const char* directory_path)
 {
     int loaded_count = 0;
@@ -1051,11 +1306,23 @@ int ui_theme_reload_external(const char* directory_path)
     return loaded_count;
 }
 
+/**
+ * @brief ui_theme_last_reload_error 函数。
+ *
+ * @param void 无参数。
+ * @return 函数返回值。
+ */
 const char* ui_theme_last_reload_error(void)
 {
     return g_last_reload_error;
 }
 
+/**
+ * @brief ui_theme_external_signature 函数。
+ *
+ * @param directory_path 参数 `directory_path`。
+ * @return 函数返回值。
+ */
 unsigned long long ui_theme_external_signature(const char* directory_path)
 {
     unsigned long long aggregate_hash = UI_THEME_HASH_OFFSET_BASIS;
@@ -1149,6 +1416,14 @@ unsigned long long ui_theme_external_signature(const char* directory_path)
     return aggregate_hash;
 }
 
+/**
+ * @brief ui_theme_load_selected_id 函数。
+ *
+ * @param path 参数 `path`。
+ * @param out_theme_id 参数 `out_theme_id`。
+ * @param out_theme_id_size 参数 `out_theme_id_size`。
+ * @return 函数返回值。
+ */
 int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_theme_id_size)
 {
     char* text = NULL;
@@ -1179,6 +1454,13 @@ int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_t
     return loaded && out_theme_id[0] != '\0';
 }
 
+/**
+ * @brief ui_duplicate_path_with_suffix 函数。
+ *
+ * @param path 参数 `path`。
+ * @param suffix 参数 `suffix`。
+ * @return 函数返回值。
+ */
 static char* ui_duplicate_path_with_suffix(const char* path, const char* suffix)
 {
     size_t path_length = 0u;
@@ -1202,6 +1484,13 @@ static char* ui_duplicate_path_with_suffix(const char* path, const char* suffix)
     return result;
 }
 
+/**
+ * @brief ui_replace_file_with_temp 函数。
+ *
+ * @param temp_path 参数 `temp_path`。
+ * @param target_path 参数 `target_path`。
+ * @return 函数返回值。
+ */
 static int ui_replace_file_with_temp(const char* temp_path, const char* target_path)
 {
     if (!temp_path || !target_path) {
@@ -1225,6 +1514,13 @@ static int ui_replace_file_with_temp(const char* temp_path, const char* target_p
 #endif
 }
 
+/**
+ * @brief ui_theme_save_selected_id 函数。
+ *
+ * @param path 参数 `path`。
+ * @param theme_id 参数 `theme_id`。
+ * @return 函数返回值。
+ */
 int ui_theme_save_selected_id(const char* path, const char* theme_id)
 {
     FILE* file = NULL;
@@ -1278,6 +1574,13 @@ int ui_theme_save_selected_id(const char* path, const char* theme_id)
     return 1;
 }
 
+/**
+ * @brief ui_theme_apply 函数。
+ *
+ * @param ctx 参数 `ctx`。
+ * @param tokens 参数 `tokens`。
+ * @return 无。
+ */
 void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens)
 {
     struct nk_color table[NK_COLOR_COUNT];

--- a/src/ui/ui_theme.c
+++ b/src/ui/ui_theme.c
@@ -65,12 +65,11 @@ static UiThemeTokens ui_theme_high_contrast_tokens(void);
 static int ui_theme_builtin_count(void);
 
 /**
- * @brief ui_theme_mix_channel 函数。
- *
- * @param a 参数 `a`。
- * @param b 参数 `b`。
- * @param t 参数 `t`。
- * @return 函数返回值。
+ * @brief Blends two color channels.
+ * @param a First color.
+ * @param b Second color.
+ * @param t Blend factor.
+ * @return Blended color.
  */
 static struct nk_color ui_theme_mix_channel(struct nk_color a, struct nk_color b, float t)
 {
@@ -91,10 +90,9 @@ static struct nk_color ui_theme_mix_channel(struct nk_color a, struct nk_color b
 }
 
 /**
- * @brief ui_theme_light_tokens 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Gets light theme tokens.
+ * @param void No parameters.
+ * @return Light theme tokens.
  */
 static UiThemeTokens ui_theme_light_tokens(void)
 {
@@ -138,10 +136,9 @@ static UiThemeTokens ui_theme_light_tokens(void)
 }
 
 /**
- * @brief ui_theme_dark_plus_tokens 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Gets dark plus theme tokens.
+ * @param void No parameters.
+ * @return Dark plus theme tokens.
  */
 static UiThemeTokens ui_theme_dark_plus_tokens(void)
 {
@@ -185,10 +182,9 @@ static UiThemeTokens ui_theme_dark_plus_tokens(void)
 }
 
 /**
- * @brief ui_theme_high_contrast_tokens 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Gets high contrast theme tokens.
+ * @param void No parameters.
+ * @return High contrast theme tokens.
  */
 static UiThemeTokens ui_theme_high_contrast_tokens(void)
 {
@@ -232,10 +228,9 @@ static UiThemeTokens ui_theme_high_contrast_tokens(void)
 }
 
 /**
- * @brief ui_theme_default_tokens 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Gets default theme tokens.
+ * @param void No parameters.
+ * @return Default theme tokens.
  */
 UiThemeTokens ui_theme_default_tokens(void)
 {
@@ -243,10 +238,9 @@ UiThemeTokens ui_theme_default_tokens(void)
 }
 
 /**
- * @brief ui_theme_builtin_count 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Gets the count of built-in themes.
+ * @param void No parameters.
+ * @return Built-in theme count.
  */
 static int ui_theme_builtin_count(void)
 {
@@ -254,10 +248,9 @@ static int ui_theme_builtin_count(void)
 }
 
 /**
- * @brief ui_theme_builtin_descriptor_at 函数。
- *
- * @param index 参数 `index`。
- * @return 函数返回值。
+ * @brief Gets built-in theme descriptor at index.
+ * @param index Theme index.
+ * @return Theme descriptor or NULL.
  */
 static const UiThemeDescriptor* ui_theme_builtin_descriptor_at(int index)
 {
@@ -268,10 +261,9 @@ static const UiThemeDescriptor* ui_theme_builtin_descriptor_at(int index)
 }
 
 /**
- * @brief ui_theme_builtin_tokens_at 函数。
- *
- * @param index 参数 `index`。
- * @return 函数返回值。
+ * @brief Gets built-in theme tokens at index.
+ * @param index Theme index.
+ * @return Theme tokens.
  */
 static UiThemeTokens ui_theme_builtin_tokens_at(int index)
 {
@@ -287,10 +279,9 @@ static UiThemeTokens ui_theme_builtin_tokens_at(int index)
 }
 
 /**
- * @brief ui_theme_custom_index_of_id 函数。
- *
- * @param theme_id 参数 `theme_id`。
- * @return 函数返回值。
+ * @brief Gets custom theme index by ID.
+ * @param theme_id Theme ID.
+ * @return Index or -1 if not found.
  */
 static int ui_theme_custom_index_of_id(const char* theme_id)
 {
@@ -307,10 +298,9 @@ static int ui_theme_custom_index_of_id(const char* theme_id)
 }
 
 /**
- * @brief ui_theme_count 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Gets the total theme count.
+ * @param void No parameters.
+ * @return Total theme count.
  */
 int ui_theme_count(void)
 {
@@ -318,10 +308,9 @@ int ui_theme_count(void)
 }
 
 /**
- * @brief ui_theme_descriptor_at 函数。
- *
- * @param index 参数 `index`。
- * @return 函数返回值。
+ * @brief Gets theme descriptor at index.
+ * @param index Theme index.
+ * @return Theme descriptor or NULL.
  */
 const UiThemeDescriptor* ui_theme_descriptor_at(int index)
 {
@@ -338,10 +327,9 @@ const UiThemeDescriptor* ui_theme_descriptor_at(int index)
 }
 
 /**
- * @brief ui_theme_index_of_id 函数。
- *
- * @param theme_id 参数 `theme_id`。
- * @return 函数返回值。
+ * @brief Gets theme index by ID.
+ * @param theme_id Theme ID.
+ * @return Index or -1 if not found.
  */
 int ui_theme_index_of_id(const char* theme_id)
 {
@@ -367,10 +355,9 @@ int ui_theme_index_of_id(const char* theme_id)
 }
 
 /**
- * @brief ui_theme_default_id 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Gets the default theme ID.
+ * @param void No parameters.
+ * @return Default theme ID string.
  */
 const char* ui_theme_default_id(void)
 {
@@ -378,10 +365,9 @@ const char* ui_theme_default_id(void)
 }
 
 /**
- * @brief ui_theme_tokens_for_id 函数。
- *
- * @param theme_id 参数 `theme_id`。
- * @return 函数返回值。
+ * @brief Gets theme tokens by ID.
+ * @param theme_id Theme ID.
+ * @return Theme tokens.
  */
 UiThemeTokens ui_theme_tokens_for_id(const char* theme_id)
 {
@@ -398,10 +384,9 @@ UiThemeTokens ui_theme_tokens_for_id(const char* theme_id)
 }
 
 /**
- * @brief ui_read_text_file 函数。
- *
- * @param path 参数 `path`。
- * @return 函数返回值。
+ * @brief Reads a text file.
+ * @param path File path.
+ * @return File contents or NULL.
  */
 static char* ui_read_text_file(const char* path)
 {
@@ -447,13 +432,12 @@ static char* ui_read_text_file(const char* path)
 }
 
 /**
- * @brief ui_extract_json_string_value 函数。
- *
- * @param text 参数 `text`。
- * @param key 参数 `key`。
- * @param out_value 参数 `out_value`。
- * @param out_value_size 参数 `out_value_size`。
- * @return 函数返回值。
+ * @brief Extracts a JSON string value.
+ * @param text JSON text.
+ * @param key Key name.
+ * @param out_value Output string buffer.
+ * @param out_value_size Buffer size.
+ * @return 1 on success, 0 on failure.
  */
 static int ui_extract_json_string_value(const char* text,
                                         const char* key,
@@ -521,12 +505,11 @@ static int ui_extract_json_string_value(const char* text,
 }
 
 /**
- * @brief ui_extract_json_number_value 函数。
- *
- * @param text 参数 `text`。
- * @param key 参数 `key`。
- * @param out_value 参数 `out_value`。
- * @return 函数返回值。
+ * @brief Extracts a JSON number value.
+ * @param text JSON text.
+ * @param key Key name.
+ * @param out_value Output value pointer.
+ * @return 1 on success, 0 on failure.
  */
 static int ui_extract_json_number_value(const char* text, const char* key, float* out_value)
 {
@@ -573,12 +556,11 @@ static int ui_extract_json_number_value(const char* text, const char* key, float
 }
 
 /**
- * @brief ui_extract_json_bool_value 函数。
- *
- * @param text 参数 `text`。
- * @param key 参数 `key`。
- * @param out_value 参数 `out_value`。
- * @return 函数返回值。
+ * @brief Extracts a JSON boolean value.
+ * @param text JSON text.
+ * @param key Key name.
+ * @param out_value Output value pointer.
+ * @return 1 on success, 0 on failure.
  */
 static int ui_extract_json_bool_value(const char* text, const char* key, int* out_value)
 {
@@ -625,11 +607,10 @@ static int ui_extract_json_bool_value(const char* text, const char* key, int* ou
 }
 
 /**
- * @brief ui_json_key_exists 函数。
- *
- * @param text 参数 `text`。
- * @param key 参数 `key`。
- * @return 函数返回值。
+ * @brief Checks if a JSON key exists.
+ * @param text JSON text.
+ * @param key Key name.
+ * @return 1 if exists, 0 otherwise.
  */
 static int ui_json_key_exists(const char* text, const char* key)
 {
@@ -648,10 +629,9 @@ static int ui_json_key_exists(const char* text, const char* key)
 }
 
 /**
- * @brief ui_hex_digit_value 函数。
- *
- * @param c 参数 `c`。
- * @return 函数返回值。
+ * @brief Converts a hex digit to integer value.
+ * @param c Hex character.
+ * @return Integer value or -1.
  */
 static int ui_hex_digit_value(char c)
 {
@@ -668,11 +648,10 @@ static int ui_hex_digit_value(char c)
 }
 
 /**
- * @brief ui_parse_hex_byte 函数。
- *
- * @param text 参数 `text`。
- * @param out_value 参数 `out_value`。
- * @return 函数返回值。
+ * @brief Parses a hex byte from text.
+ * @param text Text containing hex byte.
+ * @param out_value Output value pointer.
+ * @return 1 on success, 0 on failure.
  */
 static int ui_parse_hex_byte(const char* text, unsigned char* out_value)
 {
@@ -694,11 +673,10 @@ static int ui_parse_hex_byte(const char* text, unsigned char* out_value)
 }
 
 /**
- * @brief ui_parse_hex_color 函数。
- *
- * @param hex_text 参数 `hex_text`。
- * @param out_color 参数 `out_color`。
- * @return 函数返回值。
+ * @brief Parses a hex color string.
+ * @param hex_text Hex color string (e.g., "#rrggbb" or "#rrggbbaa").
+ * @param out_color Output color pointer.
+ * @return 1 on success, 0 on failure.
  */
 static int ui_parse_hex_color(const char* hex_text, struct nk_color* out_color)
 {
@@ -734,10 +712,9 @@ static int ui_parse_hex_color(const char* hex_text, struct nk_color* out_color)
 }
 
 /**
- * @brief ui_theme_path_has_json_extension 函数。
- *
- * @param path 参数 `path`。
- * @return 函数返回值。
+ * @brief Checks if path has .json extension.
+ * @param path File path.
+ * @return 1 if has .json extension, 0 otherwise.
  */
 static int ui_theme_path_has_json_extension(const char* path)
 {
@@ -762,12 +739,11 @@ static int ui_theme_path_has_json_extension(const char* path)
 }
 
 /**
- * @brief ui_theme_hash_bytes 函数。
- *
- * @param seed 参数 `seed`。
- * @param data 参数 `data`。
- * @param size 参数 `size`。
- * @return 函数返回值。
+ * @brief Computes hash of byte data.
+ * @param seed Hash seed.
+ * @param data Data bytes.
+ * @param size Data size.
+ * @return Hash value.
  */
 static unsigned long long ui_theme_hash_bytes(unsigned long long seed, const void* data, size_t size)
 {
@@ -786,11 +762,10 @@ static unsigned long long ui_theme_hash_bytes(unsigned long long seed, const voi
 }
 
 /**
- * @brief ui_theme_hash_cstring 函数。
- *
- * @param seed 参数 `seed`。
- * @param text 参数 `text`。
- * @return 函数返回值。
+ * @brief Computes hash of a C string.
+ * @param seed Hash seed.
+ * @param text C string.
+ * @return Hash value.
  */
 static unsigned long long ui_theme_hash_cstring(unsigned long long seed, const char* text)
 {
@@ -801,11 +776,10 @@ static unsigned long long ui_theme_hash_cstring(unsigned long long seed, const c
 }
 
 /**
- * @brief ui_theme_hash_u64 函数。
- *
- * @param seed 参数 `seed`。
- * @param value 参数 `value`。
- * @return 函数返回值。
+ * @brief Computes hash of a 64-bit value.
+ * @param seed Hash seed.
+ * @param value 64-bit value.
+ * @return Hash value.
  */
 static unsigned long long ui_theme_hash_u64(unsigned long long seed, unsigned long long value)
 {
@@ -813,10 +787,9 @@ static unsigned long long ui_theme_hash_u64(unsigned long long seed, unsigned lo
 }
 
 /**
- * @brief ui_theme_id_is_safe_for_json 函数。
- *
- * @param theme_id 参数 `theme_id`。
- * @return 函数返回值。
+ * @brief Checks if theme ID is safe for JSON.
+ * @param theme_id Theme ID to check.
+ * @return 1 if safe, 0 otherwise.
  */
 static int ui_theme_id_is_safe_for_json(const char* theme_id)
 {
@@ -837,10 +810,9 @@ static int ui_theme_id_is_safe_for_json(const char* theme_id)
 }
 
 /**
- * @brief ui_theme_filename_from_path 函数。
- *
- * @param path 参数 `path`。
- * @return 函数返回值。
+ * @brief Extracts filename from a path.
+ * @param path Full file path.
+ * @return Filename string.
  */
 static const char* ui_theme_filename_from_path(const char* path)
 {
@@ -866,12 +838,11 @@ static const char* ui_theme_filename_from_path(const char* path)
 }
 
 /**
- * @brief ui_theme_id_from_path 函数。
- *
- * @param path 参数 `path`。
- * @param out_id 参数 `out_id`。
- * @param out_id_size 参数 `out_id_size`。
- * @return 函数返回值。
+ * @brief Extracts theme ID from file path.
+ * @param path File path.
+ * @param out_id Output ID buffer.
+ * @param out_id_size Buffer size.
+ * @return 1 on success, 0 on failure.
  */
 static int ui_theme_id_from_path(const char* path, char* out_id, size_t out_id_size)
 {
@@ -903,12 +874,11 @@ static int ui_theme_id_from_path(const char* path, char* out_id, size_t out_id_s
 }
 
 /**
- * @brief ui_theme_apply_color_overrides 函数。
- *
- * @param source_path 参数 `source_path`。
- * @param text 参数 `text`。
- * @param tokens 参数 `tokens`。
- * @return 无。
+ * @brief Applies color overrides from JSON text.
+ * @param source_path Source file path (for logging).
+ * @param text JSON text.
+ * @param tokens Theme tokens to update.
+ * @return None.
  */
 static void ui_theme_apply_color_overrides(const char* source_path, const char* text, UiThemeTokens* tokens)
 {
@@ -959,12 +929,11 @@ static void ui_theme_apply_color_overrides(const char* source_path, const char* 
 }
 
 /**
- * @brief ui_theme_apply_float_overrides 函数。
- *
- * @param source_path 参数 `source_path`。
- * @param text 参数 `text`。
- * @param tokens 参数 `tokens`。
- * @return 无。
+ * @brief Applies float overrides from JSON text.
+ * @param source_path Source file path (for logging).
+ * @param text JSON text.
+ * @param tokens Theme tokens to update.
+ * @return None.
  */
 static void ui_theme_apply_float_overrides(const char* source_path, const char* text, UiThemeTokens* tokens)
 {
@@ -1005,12 +974,11 @@ static void ui_theme_apply_float_overrides(const char* source_path, const char* 
 }
 
 /**
- * @brief ui_theme_apply_bool_overrides 函数。
- *
- * @param source_path 参数 `source_path`。
- * @param text 参数 `text`。
- * @param tokens 参数 `tokens`。
- * @return 无。
+ * @brief Applies boolean overrides from JSON text.
+ * @param source_path Source file path (for logging).
+ * @param text JSON text.
+ * @param tokens Theme tokens to update.
+ * @return None.
  */
 static void ui_theme_apply_bool_overrides(const char* source_path, const char* text, UiThemeTokens* tokens)
 {
@@ -1029,12 +997,11 @@ static void ui_theme_apply_bool_overrides(const char* source_path, const char* t
 }
 
 /**
- * @brief ui_theme_clamp 函数。
- *
- * @param value 参数 `value`。
- * @param min_value 参数 `min_value`。
- * @param max_value 参数 `max_value`。
- * @return 函数返回值。
+ * @brief Clamps a value to a range.
+ * @param value Value to clamp.
+ * @param min_value Minimum value.
+ * @param max_value Maximum value.
+ * @return Clamped value.
  */
 static float ui_theme_clamp(float value, float min_value, float max_value)
 {
@@ -1048,10 +1015,9 @@ static float ui_theme_clamp(float value, float min_value, float max_value)
 }
 
 /**
- * @brief ui_theme_clamp_tokens 函数。
- *
- * @param tokens 参数 `tokens`。
- * @return 无。
+ * @brief Clamps theme token values to valid ranges.
+ * @param tokens Theme tokens to clamp.
+ * @return None.
  */
 static void ui_theme_clamp_tokens(UiThemeTokens* tokens)
 {
@@ -1068,12 +1034,11 @@ static void ui_theme_clamp_tokens(UiThemeTokens* tokens)
 }
 
 /**
- * @brief ui_theme_store_custom_entry 函数。
- *
- * @param theme_id 参数 `theme_id`。
- * @param label 参数 `label`。
- * @param tokens 参数 `tokens`。
- * @return 函数返回值。
+ * @brief Stores a custom theme entry.
+ * @param theme_id Theme ID.
+ * @param label Theme label.
+ * @param tokens Theme tokens.
+ * @return 1 on success, 0 on failure.
  */
 static int ui_theme_store_custom_entry(const char* theme_id,
                                        const char* label,
@@ -1119,10 +1084,9 @@ static int ui_theme_store_custom_entry(const char* theme_id,
 }
 
 /**
- * @brief ui_theme_load_external_file 函数。
- *
- * @param path 参数 `path`。
- * @return 函数返回值。
+ * @brief Loads an external theme file.
+ * @param path Theme file path.
+ * @return 1 on success, 0 on failure.
  */
 static int ui_theme_load_external_file(const char* path)
 {
@@ -1189,15 +1153,15 @@ static int ui_theme_load_external_file(const char* path)
 }
 
 /**
- * @brief 重新扫描并加载外部主题目录。
- * @param directory_path [in] 主题目录路径。
- * @return 成功加载的主题数量。
+ * @brief Rescans and reloads the external theme directory.
+ * @param directory_path [in] Theme directory path.
+ * @return Number of successfully loaded themes.
  *
- * 算法步骤：
- * 1. 备份当前外部主题集合；
- * 2. 清空运行时外部主题表；
- * 3. 扫描目录内 `.json` 文件并逐个解析；
- * 4. 若本轮全部失败且之前有缓存，则回退到旧集合。
+ * Algorithm steps:
+ * 1. Backs up current external theme set.
+ * 2. Clears runtime external theme table.
+ * 3. Scans .json files in directory and parses each.
+ * 4. If all fail this round and cache existed before, rolls back to old set.
  */
 int ui_theme_reload_external(const char* directory_path)
 {
@@ -1307,10 +1271,9 @@ int ui_theme_reload_external(const char* directory_path)
 }
 
 /**
- * @brief ui_theme_last_reload_error 函数。
- *
- * @param void 无参数。
- * @return 函数返回值。
+ * @brief Gets the last reload error message.
+ * @param void No parameters.
+ * @return Error message string.
  */
 const char* ui_theme_last_reload_error(void)
 {
@@ -1318,10 +1281,9 @@ const char* ui_theme_last_reload_error(void)
 }
 
 /**
- * @brief ui_theme_external_signature 函数。
- *
- * @param directory_path 参数 `directory_path`。
- * @return 函数返回值。
+ * @brief Computes signature of external theme directory.
+ * @param directory_path Directory path.
+ * @return Directory signature hash.
  */
 unsigned long long ui_theme_external_signature(const char* directory_path)
 {
@@ -1417,12 +1379,11 @@ unsigned long long ui_theme_external_signature(const char* directory_path)
 }
 
 /**
- * @brief ui_theme_load_selected_id 函数。
- *
- * @param path 参数 `path`。
- * @param out_theme_id 参数 `out_theme_id`。
- * @param out_theme_id_size 参数 `out_theme_id_size`。
- * @return 函数返回值。
+ * @brief Loads the selected theme ID from settings file.
+ * @param path Settings file path.
+ * @param out_theme_id Output theme ID buffer.
+ * @param out_theme_id_size Buffer size.
+ * @return 1 on success, 0 on failure.
  */
 int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_theme_id_size)
 {
@@ -1455,11 +1416,10 @@ int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_t
 }
 
 /**
- * @brief ui_duplicate_path_with_suffix 函数。
- *
- * @param path 参数 `path`。
- * @param suffix 参数 `suffix`。
- * @return 函数返回值。
+ * @brief Duplicates path with suffix appended.
+ * @param path Original path.
+ * @param suffix Suffix to append.
+ * @return Duplicated path or NULL.
  */
 static char* ui_duplicate_path_with_suffix(const char* path, const char* suffix)
 {
@@ -1485,11 +1445,10 @@ static char* ui_duplicate_path_with_suffix(const char* path, const char* suffix)
 }
 
 /**
- * @brief ui_replace_file_with_temp 函数。
- *
- * @param temp_path 参数 `temp_path`。
- * @param target_path 参数 `target_path`。
- * @return 函数返回值。
+ * @brief Replaces target file with temp file atomically.
+ * @param temp_path Temp file path.
+ * @param target_path Target file path.
+ * @return 1 on success, 0 on failure.
  */
 static int ui_replace_file_with_temp(const char* temp_path, const char* target_path)
 {
@@ -1515,11 +1474,10 @@ static int ui_replace_file_with_temp(const char* temp_path, const char* target_p
 }
 
 /**
- * @brief ui_theme_save_selected_id 函数。
- *
- * @param path 参数 `path`。
- * @param theme_id 参数 `theme_id`。
- * @return 函数返回值。
+ * @brief Saves the selected theme ID to settings file.
+ * @param path Settings file path.
+ * @param theme_id Theme ID to save.
+ * @return 1 on success, 0 on failure.
  */
 int ui_theme_save_selected_id(const char* path, const char* theme_id)
 {
@@ -1575,11 +1533,10 @@ int ui_theme_save_selected_id(const char* path, const char* theme_id)
 }
 
 /**
- * @brief ui_theme_apply 函数。
- *
- * @param ctx 参数 `ctx`。
- * @param tokens 参数 `tokens`。
- * @return 无。
+ * @brief Applies theme tokens to Nuklear context.
+ * @param ctx Nuklear context.
+ * @param tokens Theme tokens to apply.
+ * @return None.
  */
 void ui_theme_apply(struct nk_context* ctx, const UiThemeTokens* tokens)
 {


### PR DESCRIPTION
## Summary
- add Doxygen comments across the codebase with more consistent open-source documentation terminology
- preserve the existing `@brief`, `@param`, `@return`, and `@note` tags while tightening wording
- improve source-level documentation coverage without changing behavior

## Testing
- Build succeeds on all platforms (Windows/MinGW, Linux, macOS)
- Application launches and displays the canvas correctly
- No runtime regressions were observed during manual verification
