### PR TITLE
Refactor dialog and keyboard interaction architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ find_package(OpenGL REQUIRED)
 set(GLDRAW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/application.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/command_registry.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_actions.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/window.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/object.c
@@ -50,6 +51,9 @@ set(GLDRAW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/history.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/persistence.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/canvas/canvas_view.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/input/key_chord.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/input/keymap.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/input/input_router.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/tool_controller.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_system.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_system.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(GLDRAW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/application.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/command_registry.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_actions.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_dialogs.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/window.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/object.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/document.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(GLDRAW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/tool_controller.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_system.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_system.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_dialog.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_menu_def.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_menu_actions.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_menubar.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ find_package(OpenGL REQUIRED)
 set(GLDRAW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/application.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_actions.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/window.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/object.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/document.c

--- a/include/app/command_registry.h
+++ b/include/app/command_registry.h
@@ -1,0 +1,62 @@
+/**
+ * @file command_registry.h
+ * @brief Stable editor command definitions and execution helpers.
+ */
+#ifndef GLDRAW_APP_COMMAND_REGISTRY_H
+#define GLDRAW_APP_COMMAND_REGISTRY_H
+
+#include <input/keymap.h>
+#include <tools/tool.h>
+
+struct Workspace;
+
+typedef enum EditorCommand {
+    EDITOR_COMMAND_NONE = 0,
+    EDITOR_COMMAND_FILE_NEW,
+    EDITOR_COMMAND_FILE_OPEN,
+    EDITOR_COMMAND_FILE_SAVE,
+    EDITOR_COMMAND_FILE_SAVE_AS,
+    EDITOR_COMMAND_FILE_EXIT,
+    EDITOR_COMMAND_EDIT_UNDO,
+    EDITOR_COMMAND_EDIT_REDO,
+    EDITOR_COMMAND_EDIT_DELETE,
+    EDITOR_COMMAND_EDIT_SELECT_ALL,
+    EDITOR_COMMAND_VIEW_ZOOM_IN,
+    EDITOR_COMMAND_VIEW_ZOOM_OUT,
+    EDITOR_COMMAND_VIEW_ZOOM_FIT,
+    EDITOR_COMMAND_VIEW_TOGGLE_GRID,
+    EDITOR_COMMAND_VIEW_TOGGLE_INSPECTOR,
+    EDITOR_COMMAND_TOOL_SELECT,
+    EDITOR_COMMAND_TOOL_PAN,
+    EDITOR_COMMAND_TOOL_LINE,
+    EDITOR_COMMAND_TOOL_RECT,
+    EDITOR_COMMAND_TOOL_ELLIPSE,
+    EDITOR_COMMAND_HELP_SHORTCUTS,
+    EDITOR_COMMAND_HELP_ABOUT,
+    EDITOR_COMMAND_MODAL_CONFIRM,
+    EDITOR_COMMAND_MODAL_CANCEL
+} EditorCommand;
+
+typedef struct CommandDescriptor {
+    EditorCommand command;
+    const char* id;
+    const char* label;
+    KeyScope scope;
+    int menu_id;
+} CommandDescriptor;
+
+/** Look up a command descriptor by stable identifier. */
+const CommandDescriptor* command_registry_find_by_id(const char* command_id);
+/** Look up a command descriptor by menu action ID. */
+const CommandDescriptor* command_registry_find_by_menu_id(int id);
+/** Execute one command against the current editor state. */
+int command_registry_execute(struct Workspace* workspace,
+                             ToolContext* tool_context,
+                             EditorCommand command);
+/** Format the effective shortcut text for one menu action. */
+void command_registry_format_menu_shortcut(const struct Workspace* workspace,
+                                           int id,
+                                           char* buffer,
+                                           size_t buffer_size);
+
+#endif /* GLDRAW_APP_COMMAND_REGISTRY_H */

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -16,6 +16,7 @@
 #include <canvas/canvas_view.h>
 #include <document/document.h>
 #include <document/history.h>
+#include <input/keymap.h>
 #include <tools/tool_controller.h>
 
 struct Workspace;
@@ -67,6 +68,7 @@ typedef struct Workspace {
     DocumentHistory history;        /**< Undo/redo stacks */
     CanvasView canvas;              /**< Viewport, zoom, pan, and coordinate transforms */
     ToolController tools;           /**< Active tool and its runtime state */
+    EditorKeymap keymap;            /**< Effective keyboard mapping state */
     WorkspaceLayout layout;        /**< UI-computed layout rectangles (set by UI system) */
     char current_document_path[260]; /**< Active file path (empty for new documents) */
     char status_message[256];       /**< Current status bar message */

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -22,6 +22,25 @@ struct Workspace;
 /** Callback signature for workspace-level commands (save/load). */
 typedef int (*WorkspaceCommandFn)(struct Workspace* workspace, void* user_data);
 
+/** Destructive editor actions that may need unsaved-change confirmation. */
+typedef enum WorkspaceActionType {
+    WORKSPACE_ACTION_NONE = 0,
+    WORKSPACE_ACTION_NEW_DOCUMENT,
+    WORKSPACE_ACTION_OPEN_DOCUMENT,
+    WORKSPACE_ACTION_EXIT_APPLICATION
+} WorkspaceActionType;
+
+/** Workspace-managed modal states. */
+typedef enum WorkspaceModalType {
+    WORKSPACE_MODAL_NONE = 0,
+    WORKSPACE_MODAL_CONFIRM_UNSAVED
+} WorkspaceModalType;
+
+/** Callback signature for application-owned workspace action execution. */
+typedef int (*WorkspaceActionExecutorFn)(struct Workspace* workspace,
+                                         WorkspaceActionType action,
+                                         void* user_data);
+
 /** UI-computed layout snapshot shared with input/canvas subsystems. */
 typedef struct WorkspaceLayout {
     RectF window_bounds;
@@ -53,8 +72,11 @@ typedef struct Workspace {
     char status_message[256];       /**< Current status bar message */
     unsigned int saved_revision;     /**< Document revision last marked as saved */
     int document_dirty;             /**< Non-zero when current revision differs from saved_revision */
+    WorkspaceModalType modal_type;  /**< Active modal dialog state */
+    WorkspaceActionType pending_action; /**< Deferred action awaiting modal resolution */
     WorkspaceCommandFn save_document; /**< Workspace-level save callback */
     WorkspaceCommandFn load_document; /**< Workspace-level load callback */
+    WorkspaceActionExecutorFn execute_action; /**< Application-owned action executor */
     void* command_user_data;        /**< Caller-supplied context for command callbacks */
 } Workspace;
 

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -31,11 +31,51 @@ typedef enum WorkspaceActionType {
     WORKSPACE_ACTION_EXIT_APPLICATION
 } WorkspaceActionType;
 
-/** Workspace-managed modal states. */
-typedef enum WorkspaceModalType {
-    WORKSPACE_MODAL_NONE = 0,
-    WORKSPACE_MODAL_CONFIRM_UNSAVED
-} WorkspaceModalType;
+/** Top-level UI request kinds owned by the workspace. */
+typedef enum UiRequestType {
+    UI_REQUEST_NONE = 0,
+    UI_REQUEST_DIALOG
+} UiRequestType;
+
+/** Stable dialog kinds used to route dialog results back into business state. */
+typedef enum UiDialogKind {
+    UI_DIALOG_NONE = 0,
+    UI_DIALOG_CONFIRM_UNSAVED
+} UiDialogKind;
+
+/** Standard dialog button outcomes returned by reusable UI components. */
+typedef enum UiDialogResult {
+    UI_DIALOG_RESULT_NONE = 0,
+    UI_DIALOG_RESULT_PRIMARY,
+    UI_DIALOG_RESULT_SECONDARY,
+    UI_DIALOG_RESULT_CANCEL
+} UiDialogResult;
+
+/** Small reusable payload block reserved for future dialog-specific data. */
+typedef struct UiDialogPayload {
+    int int_values[4];
+    char text[128];
+} UiDialogPayload;
+
+/** Static button description used by generic dialog rendering. */
+typedef struct UiDialogButtonSpec {
+    char label[24];
+    UiDialogResult result;
+    int is_default;
+} UiDialogButtonSpec;
+
+/** Complete dialog state model owned by the workspace and rendered by UI components. */
+typedef struct UiDialogState {
+    UiDialogKind kind;
+    char title[64];
+    char message[256];
+    UiDialogPayload payload;
+    UiDialogButtonSpec buttons[3];
+    int button_count;
+    float width;
+    float height;
+    int modal;
+} UiDialogState;
 
 /** Callback signature for application-owned workspace action execution. */
 typedef int (*WorkspaceActionExecutorFn)(struct Workspace* workspace,
@@ -74,8 +114,8 @@ typedef struct Workspace {
     char status_message[256];       /**< Current status bar message */
     unsigned int saved_revision;     /**< Document revision last marked as saved */
     int document_dirty;             /**< Non-zero when current revision differs from saved_revision */
-    WorkspaceModalType modal_type;  /**< Active modal dialog state */
-    WorkspaceActionType pending_action; /**< Deferred action awaiting modal resolution */
+    UiRequestType active_request_type; /**< Active UI request type owned by the workspace */
+    UiDialogState active_dialog;    /**< Active reusable dialog state */
     WorkspaceCommandFn save_document; /**< Workspace-level save callback */
     WorkspaceCommandFn load_document; /**< Workspace-level load callback */
     WorkspaceActionExecutorFn execute_action; /**< Application-owned action executor */

--- a/include/app/workspace_actions.h
+++ b/include/app/workspace_actions.h
@@ -17,10 +17,10 @@
 
 /** Return non-zero when a workspace modal is currently active. */
 int workspace_modal_is_active(const Workspace* workspace);
-/** Return dialog title for current modal, or empty string when none. */
-const char* workspace_modal_title(const Workspace* workspace);
-/** Return dialog body text for current modal, or empty string when none. */
-const char* workspace_modal_message(const Workspace* workspace);
+/** Return the active dialog kind, or `UI_DIALOG_NONE` when none. */
+UiDialogKind workspace_active_dialog_kind(const Workspace* workspace);
+/** Resolve the active dialog using a generic dialog result. */
+int workspace_resolve_active_dialog(Workspace* workspace, UiDialogResult result);
 
 /** Request a workspace action, deferring through unsaved confirmation when needed. */
 int workspace_request_action(Workspace* workspace, WorkspaceActionType action);

--- a/include/app/workspace_actions.h
+++ b/include/app/workspace_actions.h
@@ -1,0 +1,34 @@
+/**
+ * @file workspace_actions.h
+ * @brief Workspace-level command arbitration and modal resolution helpers.
+ *
+ * Role in project:
+ * - Centralizes destructive document actions behind one request/confirm flow.
+ * - Keeps unsaved-change policy out of menu/UI/platform event call sites.
+ *
+ * Module relationships:
+ * - Called by application event handlers and menu actions.
+ * - Consumed by UI modal rendering to resolve pending actions.
+ */
+#ifndef GLDRAW_APP_WORKSPACE_ACTIONS_H
+#define GLDRAW_APP_WORKSPACE_ACTIONS_H
+
+#include <app/workspace.h>
+
+/** Return non-zero when a workspace modal is currently active. */
+int workspace_modal_is_active(const Workspace* workspace);
+/** Return dialog title for current modal, or empty string when none. */
+const char* workspace_modal_title(const Workspace* workspace);
+/** Return dialog body text for current modal, or empty string when none. */
+const char* workspace_modal_message(const Workspace* workspace);
+
+/** Request a workspace action, deferring through unsaved confirmation when needed. */
+int workspace_request_action(Workspace* workspace, WorkspaceActionType action);
+/** Resolve current modal by saving first, then continuing pending action on success. */
+int workspace_confirm_pending_action_save(Workspace* workspace);
+/** Resolve current modal by discarding changes and continuing pending action. */
+int workspace_confirm_pending_action_discard(Workspace* workspace);
+/** Cancel the active modal and clear the pending action. */
+void workspace_confirm_pending_action_cancel(Workspace* workspace);
+
+#endif /* GLDRAW_APP_WORKSPACE_ACTIONS_H */

--- a/include/app/workspace_actions.h
+++ b/include/app/workspace_actions.h
@@ -14,6 +14,7 @@
 #define GLDRAW_APP_WORKSPACE_ACTIONS_H
 
 #include <app/workspace.h>
+#include <app/workspace_dialogs.h>
 
 /** Return non-zero when a workspace modal is currently active. */
 int workspace_modal_is_active(const Workspace* workspace);

--- a/include/app/workspace_dialogs.h
+++ b/include/app/workspace_dialogs.h
@@ -1,0 +1,75 @@
+/**
+ * @file workspace_dialogs.h
+ * @brief Reusable workspace-owned dialog builders and lifecycle helpers.
+ *
+ * Role in project:
+ * - Centralizes generic dialog-state construction and workspace dialog ownership.
+ * - Provides reusable presets so business modules do not handcraft `UiDialogState`.
+ *
+ * Module relationships:
+ * - Called by workspace action flows and future business modules that need dialogs.
+ * - Consumed by UI rendering through `Workspace.active_dialog`.
+ */
+#ifndef GLDRAW_APP_WORKSPACE_DIALOGS_H
+#define GLDRAW_APP_WORKSPACE_DIALOGS_H
+
+#include <app/workspace.h>
+
+/** Immutable dialog shell configuration used by generic builders. */
+typedef struct UiDialogTemplate {
+    UiDialogKind kind;
+    const char* title;
+    const char* message;
+    float width;
+    float height;
+    int modal;
+} UiDialogTemplate;
+
+/** Immutable button definition used when assembling dialog presets. */
+typedef struct UiDialogButtonDefinition {
+    const char* label;
+    UiDialogResult result;
+    int is_default;
+} UiDialogButtonDefinition;
+
+struct Workspace;
+/** Dialog-specific result handler signature used by registered definitions. */
+typedef int (*UiDialogResolveFn)(struct Workspace* workspace, UiDialogResult result);
+
+/** Complete registered dialog definition: template, buttons, and resolver. */
+typedef struct UiDialogDefinition {
+    UiDialogTemplate dialog_template;
+    const UiDialogButtonDefinition* buttons;
+    int button_count;
+    UiDialogResolveFn resolve;
+} UiDialogDefinition;
+
+/** Reset one dialog state to an inactive default value. */
+void workspace_dialog_reset(UiDialogState* dialog);
+/** Apply a generic template to a dialog state. */
+void workspace_dialog_apply_template(UiDialogState* dialog, const UiDialogTemplate* dialog_template);
+/** Append one button definition when capacity allows. Returns non-zero on success. */
+int workspace_dialog_add_button(UiDialogState* dialog, const UiDialogButtonDefinition* button);
+/** Look up one registered dialog definition by kind. */
+const UiDialogDefinition* workspace_dialog_definition(UiDialogKind kind);
+/** Open one dialog from a template, payload, and button definitions. */
+int workspace_dialog_open_from_template(Workspace* workspace,
+                                        const UiDialogTemplate* dialog_template,
+                                        const UiDialogPayload* payload,
+                                        const UiDialogButtonDefinition* buttons,
+                                        int button_count);
+/** Open one registered dialog definition with the supplied payload. */
+int workspace_dialog_open_definition(Workspace* workspace,
+                                     const UiDialogDefinition* definition,
+                                     const UiDialogPayload* payload);
+/** Open one fully prepared dialog as the workspace-owned active request. */
+int workspace_dialog_open(Workspace* workspace, const UiDialogState* dialog);
+/** Close the workspace-owned active dialog request. */
+void workspace_dialog_close(Workspace* workspace);
+/** Resolve the active dialog according to its kind and the returned result. */
+int workspace_dialog_resolve(Workspace* workspace, UiDialogResult result);
+
+/** Open the standard unsaved-changes confirmation dialog. */
+int workspace_dialog_open_confirm_unsaved(Workspace* workspace, WorkspaceActionType pending_action);
+
+#endif /* GLDRAW_APP_WORKSPACE_DIALOGS_H */

--- a/include/input/input_router.h
+++ b/include/input/input_router.h
@@ -1,0 +1,29 @@
+/**
+ * @file input_router.h
+ * @brief Keyboard event routing from platform callbacks to editor commands.
+ */
+#ifndef GLDRAW_INPUT_INPUT_ROUTER_H
+#define GLDRAW_INPUT_INPUT_ROUTER_H
+
+#include <input/keymap.h>
+#include <tools/tool.h>
+
+struct Workspace;
+
+typedef struct KeyEvent {
+    int key;
+    int mods;
+    int action;
+    int repeated;
+} KeyEvent;
+
+typedef struct InputRouterContext {
+    struct Workspace* workspace;
+    ToolContext* tool_context;
+    int ui_has_keyboard_focus;
+} InputRouterContext;
+
+/** Handle one key event through modal/global/tool routing. */
+int input_router_handle_key(const InputRouterContext* context, const KeyEvent* event);
+
+#endif /* GLDRAW_INPUT_INPUT_ROUTER_H */

--- a/include/input/key_chord.h
+++ b/include/input/key_chord.h
@@ -1,0 +1,26 @@
+/**
+ * @file key_chord.h
+ * @brief Normalized keyboard chord parsing and formatting helpers.
+ */
+#ifndef GLDRAW_INPUT_KEY_CHORD_H
+#define GLDRAW_INPUT_KEY_CHORD_H
+
+#include <stddef.h>
+
+typedef struct KeyChord {
+    int key;
+    int mods;
+} KeyChord;
+
+/** Return a zero-value chord representing "unbound". */
+KeyChord key_chord_none(void);
+/** Return non-zero when the chord contains a concrete key. */
+int key_chord_is_valid(KeyChord chord);
+/** Compare two chords for exact key/mod equivalence. */
+int key_chord_equals(KeyChord a, KeyChord b);
+/** Parse a human-readable chord such as `Ctrl+Shift+Z`. */
+int key_chord_parse(const char* text, KeyChord* out_chord);
+/** Format a chord into a human-readable string. */
+void key_chord_format(KeyChord chord, char* buffer, size_t buffer_size);
+
+#endif /* GLDRAW_INPUT_KEY_CHORD_H */

--- a/include/input/keymap.h
+++ b/include/input/keymap.h
@@ -1,0 +1,48 @@
+/**
+ * @file keymap.h
+ * @brief Scope-aware command keymap with default and user override layers.
+ */
+#ifndef GLDRAW_INPUT_KEYMAP_H
+#define GLDRAW_INPUT_KEYMAP_H
+
+#include <input/key_chord.h>
+
+#define KEYMAP_MAX_BINDINGS 64
+
+typedef enum KeyScope {
+    KEY_SCOPE_GLOBAL = 0,
+    KEY_SCOPE_MODAL,
+    KEY_SCOPE_TOOL,
+    KEY_SCOPE_COUNT
+} KeyScope;
+
+typedef struct KeyBinding {
+    const char* command_id;
+    KeyScope scope;
+    KeyChord primary;
+    KeyChord secondary;
+} KeyBinding;
+
+typedef struct EditorKeymap {
+    KeyBinding defaults[KEYMAP_MAX_BINDINGS];
+    int default_count;
+    KeyBinding user_overrides[KEYMAP_MAX_BINDINGS];
+    int user_override_count;
+    char settings_path[260];
+    char last_error[256];
+} EditorKeymap;
+
+/** Initialize the keymap and load user overrides when available. */
+void keymap_init(EditorKeymap* keymap, const char* settings_path);
+/** Clear runtime state owned by the keymap. */
+void keymap_shutdown(EditorKeymap* keymap);
+/** Resolve a scope/key chord to a command identifier, or `NULL` when unbound. */
+const char* keymap_lookup_command(const EditorKeymap* keymap, KeyScope scope, KeyChord chord);
+/** Get the effective shortcut text for a command, using the first bound chord. */
+void keymap_format_command_shortcut(const EditorKeymap* keymap,
+                                    const char* command_id,
+                                    KeyScope scope,
+                                    char* buffer,
+                                    size_t buffer_size);
+
+#endif /* GLDRAW_INPUT_KEYMAP_H */

--- a/include/ui/ui_dialog.h
+++ b/include/ui/ui_dialog.h
@@ -1,0 +1,20 @@
+/**
+ * @file ui_dialog.h
+ * @brief Reusable modal dialog rendering helpers.
+ */
+#ifndef GLDRAW_UI_UI_DIALOG_H
+#define GLDRAW_UI_UI_DIALOG_H
+
+#include <app/workspace.h>
+
+#ifndef NK_NUKLEAR_H_
+struct nk_context;
+#endif
+
+/** Render one workspace-owned dialog and return the user result for this frame. */
+UiDialogResult ui_dialog_show(struct nk_context* ctx,
+                              const UiDialogState* dialog,
+                              int window_width,
+                              int window_height);
+
+#endif /* GLDRAW_UI_UI_DIALOG_H */

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -13,10 +13,13 @@
  */
 #include <app/application.h>
 
+#include <app/command_registry.h>
+#include <app/workspace_actions.h>
 #include <app/workspace.h>
 #include <base/log.h>
 #include <base/math2d.h>
 #include <document/persistence.h>
+#include <input/input_router.h>
 #include <platform/window.h>
 #include <render/render_system.h>
 #include <ui/ui_menu_actions.h>
@@ -30,6 +33,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define APP_KEYMAP_SETTINGS_PATH "gldraw.keymap.json"
+
 typedef struct {
   PlatformWindow window;
   Workspace workspace;
@@ -41,6 +46,9 @@ typedef struct {
 
 static int app_workspace_save(Workspace *workspace, void *user_data);
 static int app_workspace_load(Workspace *workspace, void *user_data);
+static int app_workspace_execute_action(Workspace *workspace,
+                                        WorkspaceActionType action,
+                                        void *user_data);
 
 /**
  * @brief Write formatted status text into workspace status buffer.
@@ -133,6 +141,28 @@ static void app_reset_tool_state(Application *app) {
   tool_controller_init(&app->workspace.tools);
 }
 
+static int app_new_document(Application *app) {
+  if (!app) {
+    return 0;
+  }
+
+  document_reset(&app->workspace.document);
+  document_history_shutdown(&app->workspace.history);
+  if (!document_history_init(&app->workspace.history)) {
+    LOG_ERROR("%s", "Failed to reinitialize history");
+    app_set_status(app, "History reset failed");
+    return 0;
+  }
+
+  app_reset_tool_state(app);
+  canvas_view_set_center_zoom(&app->workspace.canvas, vec2_make(0.0f, 0.0f),
+                              1.0f);
+  app->workspace.current_document_path[0] = '\0';
+  workspace_mark_saved(&app->workspace);
+  app_set_status(app, "New empty document");
+  return 1;
+}
+
 /**
  * @brief Save current document to JSON and refresh dirty tracking.
  * @param app [in,out] Application state.
@@ -202,6 +232,16 @@ static int app_load_document(Application *app) {
   return 1;
 }
 
+static int app_exit_application(Application *app) {
+  if (!app || !app->window.handle) {
+    return 0;
+  }
+
+  glfwSetWindowShouldClose(app->window.handle, GLFW_TRUE);
+  app_set_status(app, "Closing application");
+  return 1;
+}
+
 /** Workspace save callback adapter. Complexity: same as `app_save_document`. */
 static int app_workspace_save(Workspace *workspace, void *user_data) {
   (void)workspace;
@@ -212,6 +252,25 @@ static int app_workspace_save(Workspace *workspace, void *user_data) {
 static int app_workspace_load(Workspace *workspace, void *user_data) {
   (void)workspace;
   return app_load_document((Application *)user_data);
+}
+
+static int app_workspace_execute_action(Workspace *workspace,
+                                        WorkspaceActionType action,
+                                        void *user_data) {
+  Application *app = (Application *)user_data;
+  (void)workspace;
+
+  switch (action) {
+  case WORKSPACE_ACTION_NEW_DOCUMENT:
+    return app_new_document(app);
+  case WORKSPACE_ACTION_OPEN_DOCUMENT:
+    return app_load_document(app);
+  case WORKSPACE_ACTION_EXIT_APPLICATION:
+    return app_exit_application(app);
+  case WORKSPACE_ACTION_NONE:
+  default:
+    return 0;
+  }
 }
 
 /** Load startup document if present; otherwise keep empty document. Complexity:
@@ -440,63 +499,24 @@ static void key_callback(GLFWwindow *handle, int key, int scancode, int action,
                          int mods) {
   Application *app = (Application *)glfwGetWindowUserPointer(handle);
   ToolContext context;
+  InputRouterContext router_context;
+  KeyEvent event;
   (void)scancode;
 
-  if (!app || action != GLFW_PRESS) {
-    return;
-  }
-
-  if (key == GLFW_KEY_ESCAPE &&
-      app->workspace.tools.active_kind == TOOL_KIND_SELECT) {
-    glfwSetWindowShouldClose(handle, GLFW_TRUE);
-    return;
-  }
-
-  /* Menu shortcuts via centralized handler */
-  if ((mods & GLFW_MOD_CONTROL) != 0) {
-    switch (key) {
-    case GLFW_KEY_N:
-      ui_menu_execute(&app->workspace, MENU_ID_FILE_NEW);
-      return;
-    case GLFW_KEY_O:
-      app_load_document(app);
-      return;
-    case GLFW_KEY_S:
-      app_save_document(app);
-      return;
-    case GLFW_KEY_Z:
-      ui_menu_execute(&app->workspace, MENU_ID_EDIT_UNDO);
-      return;
-    case GLFW_KEY_Y:
-      ui_menu_execute(&app->workspace, MENU_ID_EDIT_REDO);
-      return;
-    case GLFW_KEY_A:
-      ui_menu_execute(&app->workspace, MENU_ID_EDIT_SELECT_ALL);
-      return;
-    case GLFW_KEY_0:
-      ui_menu_execute(&app->workspace, MENU_ID_VIEW_ZOOM_FIT);
-      return;
-    case GLFW_KEY_EQUAL:
-    case GLFW_KEY_KP_ADD:
-      ui_menu_execute(&app->workspace, MENU_ID_VIEW_ZOOM_IN);
-      return;
-    case GLFW_KEY_MINUS:
-    case GLFW_KEY_KP_SUBTRACT:
-      ui_menu_execute(&app->workspace, MENU_ID_VIEW_ZOOM_OUT);
-      return;
-    default:
-      break;
-    }
-  }
-
-  /* Help shortcut (question mark) */
-  if (key == GLFW_KEY_SLASH && (mods & GLFW_MOD_SHIFT) != 0) {
-    ui_menu_execute(&app->workspace, MENU_ID_HELP_SHORTCUTS);
+  if (!app) {
     return;
   }
 
   context = app_tool_context(app);
-  tool_controller_key_down(&app->workspace.tools, &context, key, mods);
+  router_context.workspace = &app->workspace;
+  router_context.tool_context = &context;
+  router_context.ui_has_keyboard_focus =
+      app->ui ? ui_system_has_active_interaction(app->ui) : 0;
+  event.key = key;
+  event.mods = mods;
+  event.action = action;
+  event.repeated = (action == GLFW_REPEAT);
+  input_router_handle_key(&router_context, &event);
 }
 
 /** GLFW scroll callback: zoom canvas at cursor unless blocked by UI. */
@@ -518,6 +538,17 @@ static void scroll_callback(GLFWwindow *handle, double xoffset,
   context = app_tool_context(app);
   tool_controller_scroll(&app->workspace.tools, &context, app->cursor_screen,
                          (float)yoffset);
+}
+
+static void window_close_callback(GLFWwindow *handle) {
+  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+
+  if (!app) {
+    return;
+  }
+
+  glfwSetWindowShouldClose(handle, GLFW_FALSE);
+  workspace_request_action(&app->workspace, WORKSPACE_ACTION_EXIT_APPLICATION);
 }
 
 /**
@@ -543,9 +574,11 @@ static int app_init(Application *app) {
   }
   canvas_view_init(&app->workspace.canvas, &app->workspace.document, viewport);
   tool_controller_init(&app->workspace.tools);
+  keymap_init(&app->workspace.keymap, APP_KEYMAP_SETTINGS_PATH);
   app_set_document_path(app, app_default_document_path());
   app->workspace.save_document = app_workspace_save;
   app->workspace.load_document = app_workspace_load;
+  app->workspace.execute_action = app_workspace_execute_action;
   app->workspace.command_user_data = app;
   workspace_mark_saved(&app->workspace);
   app_set_status(app, "Initializing editor");
@@ -571,6 +604,7 @@ static int app_init(Application *app) {
   glfwSetMouseButtonCallback(app->window.handle, mouse_button_callback);
   glfwSetKeyCallback(app->window.handle, key_callback);
   glfwSetScrollCallback(app->window.handle, scroll_callback);
+  glfwSetWindowCloseCallback(app->window.handle, window_close_callback);
 
   render_system_resize(app->renderer, app->window.width, app->window.height);
   update_canvas_viewport(app);
@@ -598,6 +632,7 @@ static void app_shutdown(Application *app) {
   ui_system_destroy(app->ui);
   render_system_destroy(app->renderer);
   tool_controller_shutdown(&app->workspace.tools);
+  keymap_shutdown(&app->workspace.keymap);
   document_history_shutdown(&app->workspace.history);
   document_shutdown(&app->workspace.document);
   platform_window_shutdown(&app->window);

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -8,7 +8,8 @@
  *
  * Module relationships:
  * - Uses workspace as central state container.
- * - Coordinates platform window, render system, UI system, tools, and persistence.
+ * - Coordinates platform window, render system, UI system, tools, and
+ * persistence.
  */
 #include <app/application.h>
 
@@ -18,9 +19,9 @@
 #include <document/persistence.h>
 #include <platform/window.h>
 #include <render/render_system.h>
-#include <ui/ui_system.h>
 #include <ui/ui_menu_actions.h>
 #include <ui/ui_menu_def.h>
+#include <ui/ui_system.h>
 
 #include <GLFW/glfw3.h>
 
@@ -30,16 +31,16 @@
 #include <string.h>
 
 typedef struct {
-    PlatformWindow window;
-    Workspace workspace;
-    RenderSystem* renderer;
-    UiSystem* ui;
-    Vec2 cursor_screen;
-    int cursor_inside_canvas;
+  PlatformWindow window;
+  Workspace workspace;
+  RenderSystem *renderer;
+  UiSystem *ui;
+  Vec2 cursor_screen;
+  int cursor_inside_canvas;
 } Application;
 
-static int app_workspace_save(Workspace* workspace, void* user_data);
-static int app_workspace_load(Workspace* workspace, void* user_data);
+static int app_workspace_save(Workspace *workspace, void *user_data);
+static int app_workspace_load(Workspace *workspace, void *user_data);
 
 /**
  * @brief Write formatted status text into workspace status buffer.
@@ -55,53 +56,48 @@ static int app_workspace_load(Workspace* workspace, void* user_data);
  * - Uses `vsnprintf` with explicit buffer size to avoid overflow.
  * Time complexity: `O(L)` where `L` is formatted output length.
  */
-static void app_set_status(Application* app, const char* fmt, ...)
-{
-    va_list args;
+static void app_set_status(Application *app, const char *fmt, ...) {
+  va_list args;
 
-    if (!app || !fmt) {
-        return;
-    }
+  if (!app || !fmt) {
+    return;
+  }
 
-    va_start(args, fmt);
-    vsnprintf(app->workspace.status_message,
-              sizeof(app->workspace.status_message),
-              fmt,
-              args);
-    va_end(args);
+  va_start(args, fmt);
+  vsnprintf(app->workspace.status_message,
+            sizeof(app->workspace.status_message), fmt, args);
+  va_end(args);
 }
 
-/** Check if file exists by opening it in read-binary mode. Complexity: `O(1)` (metadata + open). */
-static int app_file_exists(const char* path)
-{
-    FILE* file = NULL;
+/** Check if file exists by opening it in read-binary mode. Complexity: `O(1)`
+ * (metadata + open). */
+static int app_file_exists(const char *path) {
+  FILE *file = NULL;
 
-    if (!path || path[0] == '\0') {
-        return 0;
-    }
+  if (!path || path[0] == '\0') {
+    return 0;
+  }
 
-    file = fopen(path, "rb");
-    if (!file) {
-        return 0;
-    }
+  file = fopen(path, "rb");
+  if (!file) {
+    return 0;
+  }
 
-    fclose(file);
-    return 1;
+  fclose(file);
+  return 1;
 }
 
-/** Return fallback document path used when workspace path is empty. Complexity: `O(1)`. */
-static const char* app_default_document_path(void)
-{
-    return "document.json";
-}
+/** Return fallback document path used when workspace path is empty. Complexity:
+ * `O(1)`. */
+static const char *app_default_document_path(void) { return "document.json"; }
 
-/** Resolve active document path (workspace path or default). Complexity: `O(1)`. */
-static const char* app_current_document_path(const Application* app)
-{
-    if (app->workspace.current_document_path[0] != '\0') {
-        return app->workspace.current_document_path;
-    }
-    return app_default_document_path();
+/** Resolve active document path (workspace path or default). Complexity:
+ * `O(1)`. */
+static const char *app_current_document_path(const Application *app) {
+  if (app->workspace.current_document_path[0] != '\0') {
+    return app->workspace.current_document_path;
+  }
+  return app_default_document_path();
 }
 
 /**
@@ -114,27 +110,27 @@ static const char* app_current_document_path(const Application* app)
  * - Uses bounded copy and forced NUL termination.
  * Time complexity: `O(min(len(path), capacity))`.
  */
-static void app_set_document_path(Application* app, const char* path)
-{
-    if (!app || !path) {
-        return;
-    }
+static void app_set_document_path(Application *app, const char *path) {
+  if (!app || !path) {
+    return;
+  }
 
-    strncpy(app->workspace.current_document_path,
-            path,
-            sizeof(app->workspace.current_document_path) - 1u);
-    app->workspace.current_document_path[sizeof(app->workspace.current_document_path) - 1u] = '\0';
+  strncpy(app->workspace.current_document_path, path,
+          sizeof(app->workspace.current_document_path) - 1u);
+  app->workspace
+      .current_document_path[sizeof(app->workspace.current_document_path) -
+                             1u] = '\0';
 }
 
-/** Reset tool controller runtime state after major document changes. Complexity: `O(tool_count)`. */
-static void app_reset_tool_state(Application* app)
-{
-    if (!app) {
-        return;
-    }
+/** Reset tool controller runtime state after major document changes.
+ * Complexity: `O(tool_count)`. */
+static void app_reset_tool_state(Application *app) {
+  if (!app) {
+    return;
+  }
 
-    tool_controller_shutdown(&app->workspace.tools);
-    tool_controller_init(&app->workspace.tools);
+  tool_controller_shutdown(&app->workspace.tools);
+  tool_controller_init(&app->workspace.tools);
 }
 
 /**
@@ -147,21 +143,20 @@ static void app_reset_tool_state(Application* app)
  *
  * Time complexity: dominated by serialization, roughly `O(object_count)`.
  */
-static int app_save_document(Application* app)
-{
-    const char* path = app_current_document_path(app);
+static int app_save_document(Application *app) {
+  const char *path = app_current_document_path(app);
 
-    if (!document_save_json(&app->workspace.document, path)) {
-        LOG_ERROR("%s", "Save document failed");
-        app_set_status(app, "Save failed: %s", path);
-        return 0;
-    }
+  if (!document_save_json(&app->workspace.document, path)) {
+    LOG_ERROR("%s", "Save document failed");
+    app_set_status(app, "Save failed: %s", path);
+    return 0;
+  }
 
-    app_set_document_path(app, path);
-    workspace_mark_saved(&app->workspace);
-    app_set_status(app, "Saved document: %s", path);
-    LOG_INFO("Saved document: %s", path);
-    return 1;
+  app_set_document_path(app, path);
+  workspace_mark_saved(&app->workspace);
+  app_set_status(app, "Saved document: %s", path);
+  LOG_INFO("Saved document: %s", path);
+  return 1;
 }
 
 /**
@@ -173,255 +168,260 @@ static int app_save_document(Application* app)
  * - History and tool state are rebuilt after load so stale snapshots/pointers
  *   cannot reference objects from the previous document.
  *
- * Time complexity: dominated by parse/build, roughly `O(file_size + object_count)`.
+ * Time complexity: dominated by parse/build, roughly `O(file_size +
+ * object_count)`.
  */
-static int app_load_document(Application* app)
-{
-    const char* path = app_current_document_path(app);
+static int app_load_document(Application *app) {
+  const char *path = app_current_document_path(app);
 
-    if (!app_file_exists(path)) {
-        LOG_WARN("Document file not found: %s", path);
-        app_set_status(app, "Document not found: %s", path);
-        return 0;
-    }
+  if (!app_file_exists(path)) {
+    LOG_WARN("Document file not found: %s", path);
+    app_set_status(app, "Document not found: %s", path);
+    return 0;
+  }
 
-    if (!document_load_json(&app->workspace.document, path)) {
-        LOG_ERROR("%s", "Load document failed");
-        app_set_status(app, "Load failed: %s", path);
-        return 0;
-    }
+  if (!document_load_json(&app->workspace.document, path)) {
+    LOG_ERROR("%s", "Load document failed");
+    app_set_status(app, "Load failed: %s", path);
+    return 0;
+  }
 
-    /* Rebuild history against the newly loaded object graph.
-       Reusing old snapshots would leave dangling object pointers. */
-    document_history_shutdown(&app->workspace.history);
-    if (!document_history_init(&app->workspace.history)) {
-        LOG_ERROR("%s", "Failed to reinitialize history after document load");
-        app_set_status(app, "History reset failed after load");
-        return 0;
-    }
-    app_reset_tool_state(app);
-    app_set_document_path(app, path);
-    workspace_mark_saved(&app->workspace);
-    app_set_status(app, "Loaded document: %s", path);
-    LOG_INFO("Loaded document: %s", path);
-    return 1;
+  /* Rebuild history against the newly loaded object graph.
+     Reusing old snapshots would leave dangling object pointers. */
+  document_history_shutdown(&app->workspace.history);
+  if (!document_history_init(&app->workspace.history)) {
+    LOG_ERROR("%s", "Failed to reinitialize history after document load");
+    app_set_status(app, "History reset failed after load");
+    return 0;
+  }
+  app_reset_tool_state(app);
+  app_set_document_path(app, path);
+  workspace_mark_saved(&app->workspace);
+  app_set_status(app, "Loaded document: %s", path);
+  LOG_INFO("Loaded document: %s", path);
+  return 1;
 }
 
 /** Workspace save callback adapter. Complexity: same as `app_save_document`. */
-static int app_workspace_save(Workspace* workspace, void* user_data)
-{
-    (void)workspace;
-    return app_save_document((Application*)user_data);
+static int app_workspace_save(Workspace *workspace, void *user_data) {
+  (void)workspace;
+  return app_save_document((Application *)user_data);
 }
 
 /** Workspace load callback adapter. Complexity: same as `app_load_document`. */
-static int app_workspace_load(Workspace* workspace, void* user_data)
-{
-    (void)workspace;
-    return app_load_document((Application*)user_data);
+static int app_workspace_load(Workspace *workspace, void *user_data) {
+  (void)workspace;
+  return app_load_document((Application *)user_data);
 }
 
-/** Load startup document if present; otherwise keep empty document. Complexity: `O(file_size)` when file exists. */
-static void app_open_startup_document(Application* app)
-{
-    const char* path = app_current_document_path(app);
+/** Load startup document if present; otherwise keep empty document. Complexity:
+ * `O(file_size)` when file exists. */
+static void app_open_startup_document(Application *app) {
+  const char *path = app_current_document_path(app);
 
-    if (!app) {
-        return;
+  if (!app) {
+    return;
+  }
+
+  if (app_file_exists(path)) {
+    if (!app_load_document(app)) {
+      app_set_status(app, "Startup load failed: %s", path);
     }
+    return;
+  }
 
-    if (app_file_exists(path)) {
-        if (!app_load_document(app)) {
-            app_set_status(app, "Startup load failed: %s", path);
-        }
-        return;
-    }
-
-    app_set_status(app, "New empty document");
+  app_set_status(app, "New empty document");
 }
 
-/** Build tool context struct from application-owned workspace pointers. Complexity: `O(1)`. */
-static ToolContext app_tool_context(Application* app)
-{
-    ToolContext context;
-    context.workspace = &app->workspace;
-    context.document = &app->workspace.document;
-    context.history = &app->workspace.history;
-    context.canvas = &app->workspace.canvas;
-    return context;
+/** Build tool context struct from application-owned workspace pointers.
+ * Complexity: `O(1)`. */
+static ToolContext app_tool_context(Application *app) {
+  ToolContext context;
+  context.workspace = &app->workspace;
+  context.document = &app->workspace.document;
+  context.history = &app->workspace.history;
+  context.canvas = &app->workspace.canvas;
+  return context;
 }
 
 /**
  * @brief Decide whether pointer input should be blocked from canvas tools.
- * @return Non-zero when UI interaction or non-canvas regions should consume input.
+ * @return Non-zero when UI interaction or non-canvas regions should consume
+ * input.
  *
  * Why:
  * - Prevents accidental drawing/selection while interacting with UI widgets.
  *
  * Complexity: `O(1)`.
  */
-static int app_pointer_blocks_canvas(const Application* app, Vec2 screen_pos)
-{
-    if (!app) {
-        return 0;
-    }
+static int app_pointer_blocks_canvas(const Application *app, Vec2 screen_pos) {
+  if (!app) {
+    return 0;
+  }
 
-    if (app->ui && ui_system_blocks_pointer(app->ui, screen_pos)) {
-        return 1;
-    }
+  if (app->ui && ui_system_blocks_pointer(app->ui, screen_pos)) {
+    return 1;
+  }
 
-    return app->ui && !ui_system_point_in_canvas(app->ui, screen_pos);
+  return app->ui && !ui_system_point_in_canvas(app->ui, screen_pos);
 }
 
-/** Sync tool controller's last pointer anchor with current cursor state. Complexity: `O(1)`. */
-static void app_sync_tool_pointer_anchor(Application* app)
-{
-    if (!app) {
-        return;
-    }
+/** Sync tool controller's last pointer anchor with current cursor state.
+ * Complexity: `O(1)`. */
+static void app_sync_tool_pointer_anchor(Application *app) {
+  if (!app) {
+    return;
+  }
 
-    app->workspace.tools.last_screen = app->cursor_screen;
-    app->workspace.tools.last_world =
-        canvas_view_screen_to_world(&app->workspace.canvas, app->cursor_screen);
+  app->workspace.tools.last_screen = app->cursor_screen;
+  app->workspace.tools.last_world =
+      canvas_view_screen_to_world(&app->workspace.canvas, app->cursor_screen);
 }
 
-/** Refresh cursor-in-canvas flag for uncaptured pointer movement. Complexity: `O(1)`. */
-static void app_sync_canvas_boundary(Application* app)
-{
-    int inside_canvas = 0;
+/** Refresh cursor-in-canvas flag for uncaptured pointer movement. Complexity:
+ * `O(1)`. */
+static void app_sync_canvas_boundary(Application *app) {
+  int inside_canvas = 0;
 
-    if (!app || app->workspace.tools.pointer_captured) {
-        return;
-    }
+  if (!app || app->workspace.tools.pointer_captured) {
+    return;
+  }
 
-    inside_canvas = app->ui ? ui_system_point_in_canvas(app->ui, app->cursor_screen) : 1;
-    if (inside_canvas != app->cursor_inside_canvas) {
-        app->cursor_inside_canvas = inside_canvas;
-        app_sync_tool_pointer_anchor(app);
-    }
+  inside_canvas =
+      app->ui ? ui_system_point_in_canvas(app->ui, app->cursor_screen) : 1;
+  if (inside_canvas != app->cursor_inside_canvas) {
+    app->cursor_inside_canvas = inside_canvas;
+    app_sync_tool_pointer_anchor(app);
+  }
 }
 
-/** Update canvas viewport and theme background from latest UI layout. Complexity: `O(1)`. */
-static void update_canvas_viewport(Application* app)
-{
-    RectF viewport;
-    RectF fallback_window = {0.0f, 0.0f, 1.0f, 1.0f};
+/** Update canvas viewport and theme background from latest UI layout.
+ * Complexity: `O(1)`. */
+static void update_canvas_viewport(Application *app) {
+  RectF viewport;
+  RectF fallback_window = {0.0f, 0.0f, 1.0f, 1.0f};
 
-    if (!app) {
-        return;
+  if (!app) {
+    return;
+  }
+
+  if (app->ui) {
+    viewport = ui_system_content_bounds(app->ui);
+    fallback_window = ui_system_window_bounds(app->ui);
+  } else {
+    viewport = app->workspace.layout.canvas_content_bounds;
+    fallback_window.w = (float)app->window.width;
+    fallback_window.h = (float)app->window.height;
+    if (fallback_window.w < 1.0f) {
+      fallback_window.w = 1.0f;
     }
-
-    if (app->ui) {
-        viewport = ui_system_content_bounds(app->ui);
-        fallback_window = ui_system_window_bounds(app->ui);
-    } else {
-        viewport = app->workspace.layout.canvas_content_bounds;
-        fallback_window.w = (float)app->window.width;
-        fallback_window.h = (float)app->window.height;
-        if (fallback_window.w < 1.0f) {
-            fallback_window.w = 1.0f;
-        }
-        if (fallback_window.h < 1.0f) {
-            fallback_window.h = 1.0f;
-        }
+    if (fallback_window.h < 1.0f) {
+      fallback_window.h = 1.0f;
     }
+  }
 
-    if (viewport.w <= 1.0f || viewport.h <= 1.0f) {
-        viewport = fallback_window;
-    }
+  if (viewport.w <= 1.0f || viewport.h <= 1.0f) {
+    viewport = fallback_window;
+  }
 
-    if (app->ui) {
-        app->workspace.canvas.background = ui_system_canvas_background(app->ui);
-    }
+  if (app->ui) {
+    app->workspace.canvas.background = ui_system_canvas_background(app->ui);
+  }
 
-    canvas_view_set_viewport(&app->workspace.canvas, viewport);
-    app_sync_canvas_boundary(app);
+  canvas_view_set_viewport(&app->workspace.canvas, viewport);
+  app_sync_canvas_boundary(app);
 }
 
-/** Build a `ToolEvent` from current cursor and previous anchor state. Complexity: `O(1)`. */
-static ToolEvent make_tool_event(Application* app, int button, int mods, float wheel_y)
-{
-    ToolEvent event;
-    event.screen_pos = app->cursor_screen;
-    event.world_pos = canvas_view_screen_to_world(&app->workspace.canvas, app->cursor_screen);
-    event.delta_screen = vec2_sub(event.screen_pos, app->workspace.tools.last_screen);
-    event.delta_world = vec2_sub(event.world_pos, app->workspace.tools.last_world);
-    event.button = button;
-    event.mods = mods;
-    event.wheel_y = wheel_y;
-    return event;
+/** Build a `ToolEvent` from current cursor and previous anchor state.
+ * Complexity: `O(1)`. */
+static ToolEvent make_tool_event(Application *app, int button, int mods,
+                                 float wheel_y) {
+  ToolEvent event;
+  event.screen_pos = app->cursor_screen;
+  event.world_pos =
+      canvas_view_screen_to_world(&app->workspace.canvas, app->cursor_screen);
+  event.delta_screen =
+      vec2_sub(event.screen_pos, app->workspace.tools.last_screen);
+  event.delta_world =
+      vec2_sub(event.world_pos, app->workspace.tools.last_world);
+  event.button = button;
+  event.mods = mods;
+  event.wheel_y = wheel_y;
+  return event;
 }
 
-/** GLFW framebuffer resize callback: update viewport and renderer dimensions. */
-static void framebuffer_size_callback(GLFWwindow* handle, int width, int height)
-{
-    Application* app = (Application*)glfwGetWindowUserPointer(handle);
-    if (!app) {
-        return;
-    }
-    app->window.width = width;
-    app->window.height = height;
-    update_canvas_viewport(app);
-    render_system_resize(app->renderer, width, height);
+/** GLFW framebuffer resize callback: update viewport and renderer dimensions.
+ */
+static void framebuffer_size_callback(GLFWwindow *handle, int width,
+                                      int height) {
+  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+  if (!app) {
+    return;
+  }
+  app->window.width = width;
+  app->window.height = height;
+  update_canvas_viewport(app);
+  render_system_resize(app->renderer, width, height);
 }
 
-/** GLFW cursor callback: route pointer-move to active tool when canvas is interactive. */
-static void cursor_pos_callback(GLFWwindow* handle, double xpos, double ypos)
-{
-    Application* app = (Application*)glfwGetWindowUserPointer(handle);
-    ToolContext context;
-    ToolEvent event;
+/** GLFW cursor callback: route pointer-move to active tool when canvas is
+ * interactive. */
+static void cursor_pos_callback(GLFWwindow *handle, double xpos, double ypos) {
+  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+  ToolContext context;
+  ToolEvent event;
 
-    if (!app) {
-        return;
-    }
+  if (!app) {
+    return;
+  }
 
-    app->cursor_screen = vec2_make((float)xpos, (float)ypos);
-    app_sync_canvas_boundary(app);
+  app->cursor_screen = vec2_make((float)xpos, (float)ypos);
+  app_sync_canvas_boundary(app);
 
-    if (!app->workspace.tools.pointer_captured &&
-        app_pointer_blocks_canvas(app, app->cursor_screen)) {
-        return;
-    }
+  if (!app->workspace.tools.pointer_captured &&
+      app_pointer_blocks_canvas(app, app->cursor_screen)) {
+    return;
+  }
 
-    context = app_tool_context(app);
-    event = make_tool_event(app, -1, 0, 0.0f);
+  context = app_tool_context(app);
+  event = make_tool_event(app, -1, 0, 0.0f);
 
-    tool_controller_pointer_move(&app->workspace.tools, &context, &event);
+  tool_controller_pointer_move(&app->workspace.tools, &context, &event);
 }
 
 /** GLFW mouse callback: route press/release with pointer capture semantics. */
-static void mouse_button_callback(GLFWwindow* handle, int button, int action, int mods)
-{
-    Application* app = (Application*)glfwGetWindowUserPointer(handle);
-    ToolContext context;
-    ToolEvent event;
+static void mouse_button_callback(GLFWwindow *handle, int button, int action,
+                                  int mods) {
+  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+  ToolContext context;
+  ToolEvent event;
 
-    if (!app) {
+  if (!app) {
+    return;
+  }
+
+  if (action == GLFW_PRESS) {
+    if (!app->workspace.tools.pointer_captured &&
+        app_pointer_blocks_canvas(app, app->cursor_screen)) {
+      return;
+    }
+    context = app_tool_context(app);
+    event = make_tool_event(app, button, mods, 0.0f);
+    tool_controller_pointer_down(&app->workspace.tools, &context, &event);
+  } else if (action == GLFW_RELEASE) {
+    /* Ignore release outside canvas unless we previously captured the pointer.
+       This keeps drag/end-state transitions consistent across window regions.
+     */
+    if (!app->workspace.tools.pointer_captured) {
+      if (app_pointer_blocks_canvas(app, app->cursor_screen)) {
         return;
+      }
+      return;
     }
-
-    if (action == GLFW_PRESS) {
-        if (!app->workspace.tools.pointer_captured &&
-            app_pointer_blocks_canvas(app, app->cursor_screen)) {
-            return;
-        }
-        context = app_tool_context(app);
-        event = make_tool_event(app, button, mods, 0.0f);
-        tool_controller_pointer_down(&app->workspace.tools, &context, &event);
-    } else if (action == GLFW_RELEASE) {
-        /* Ignore release outside canvas unless we previously captured the pointer.
-           This keeps drag/end-state transitions consistent across window regions. */
-        if (!app->workspace.tools.pointer_captured) {
-            if (app_pointer_blocks_canvas(app, app->cursor_screen)) {
-                return;
-            }
-            return;
-        }
-        context = app_tool_context(app);
-        event = make_tool_event(app, button, mods, 0.0f);
-        tool_controller_pointer_up(&app->workspace.tools, &context, &event);
-    }
+    context = app_tool_context(app);
+    event = make_tool_event(app, button, mods, 0.0f);
+    tool_controller_pointer_up(&app->workspace.tools, &context, &event);
+  }
 }
 
 /**
@@ -436,86 +436,88 @@ static void mouse_button_callback(GLFWwindow* handle, int button, int action, in
  * - Global document/view commands must win over tool-specific key handlers
  *   for predictable editor behavior.
  */
-static void key_callback(GLFWwindow* handle, int key, int scancode, int action, int mods)
-{
-    Application* app = (Application*)glfwGetWindowUserPointer(handle);
-    ToolContext context;
-    (void)scancode;
+static void key_callback(GLFWwindow *handle, int key, int scancode, int action,
+                         int mods) {
+  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+  ToolContext context;
+  (void)scancode;
 
-    if (!app || action != GLFW_PRESS) {
-        return;
+  if (!app || action != GLFW_PRESS) {
+    return;
+  }
+
+  if (key == GLFW_KEY_ESCAPE &&
+      app->workspace.tools.active_kind == TOOL_KIND_SELECT) {
+    glfwSetWindowShouldClose(handle, GLFW_TRUE);
+    return;
+  }
+
+  /* Menu shortcuts via centralized handler */
+  if ((mods & GLFW_MOD_CONTROL) != 0) {
+    switch (key) {
+    case GLFW_KEY_N:
+      ui_menu_execute(&app->workspace, MENU_ID_FILE_NEW);
+      return;
+    case GLFW_KEY_O:
+      app_load_document(app);
+      return;
+    case GLFW_KEY_S:
+      app_save_document(app);
+      return;
+    case GLFW_KEY_Z:
+      ui_menu_execute(&app->workspace, MENU_ID_EDIT_UNDO);
+      return;
+    case GLFW_KEY_Y:
+      ui_menu_execute(&app->workspace, MENU_ID_EDIT_REDO);
+      return;
+    case GLFW_KEY_A:
+      ui_menu_execute(&app->workspace, MENU_ID_EDIT_SELECT_ALL);
+      return;
+    case GLFW_KEY_0:
+      ui_menu_execute(&app->workspace, MENU_ID_VIEW_ZOOM_FIT);
+      return;
+    case GLFW_KEY_EQUAL:
+    case GLFW_KEY_KP_ADD:
+      ui_menu_execute(&app->workspace, MENU_ID_VIEW_ZOOM_IN);
+      return;
+    case GLFW_KEY_MINUS:
+    case GLFW_KEY_KP_SUBTRACT:
+      ui_menu_execute(&app->workspace, MENU_ID_VIEW_ZOOM_OUT);
+      return;
+    default:
+      break;
     }
+  }
 
-    if (key == GLFW_KEY_ESCAPE && app->workspace.tools.active_kind == TOOL_KIND_SELECT) {
-        glfwSetWindowShouldClose(handle, GLFW_TRUE);
-        return;
-    }
+  /* Help shortcut (question mark) */
+  if (key == GLFW_KEY_SLASH && (mods & GLFW_MOD_SHIFT) != 0) {
+    ui_menu_execute(&app->workspace, MENU_ID_HELP_SHORTCUTS);
+    return;
+  }
 
-    /* Menu shortcuts via centralized handler */
-    if ((mods & GLFW_MOD_CONTROL) != 0) {
-        switch (key) {
-        case GLFW_KEY_N:
-            ui_menu_execute(&app->workspace, MENU_ID_FILE_NEW);
-            return;
-        case GLFW_KEY_O:
-            app_load_document(app);
-            return;
-        case GLFW_KEY_S:
-            app_save_document(app);
-            return;
-        case GLFW_KEY_Z:
-            ui_menu_execute(&app->workspace, MENU_ID_EDIT_UNDO);
-            return;
-        case GLFW_KEY_Y:
-            ui_menu_execute(&app->workspace, MENU_ID_EDIT_REDO);
-            return;
-        case GLFW_KEY_A:
-            ui_menu_execute(&app->workspace, MENU_ID_EDIT_SELECT_ALL);
-            return;
-        case GLFW_KEY_0:
-            ui_menu_execute(&app->workspace, MENU_ID_VIEW_ZOOM_FIT);
-            return;
-        case GLFW_KEY_EQUAL:
-        case GLFW_KEY_KP_ADD:
-            ui_menu_execute(&app->workspace, MENU_ID_VIEW_ZOOM_IN);
-            return;
-        case GLFW_KEY_MINUS:
-        case GLFW_KEY_KP_SUBTRACT:
-            ui_menu_execute(&app->workspace, MENU_ID_VIEW_ZOOM_OUT);
-            return;
-        default:
-            break;
-        }
-    }
-
-    /* Help shortcut (question mark) */
-    if (key == GLFW_KEY_SLASH && (mods & GLFW_MOD_SHIFT) != 0) {
-        ui_menu_execute(&app->workspace, MENU_ID_HELP_SHORTCUTS);
-        return;
-    }
-
-    context = app_tool_context(app);
-    tool_controller_key_down(&app->workspace.tools, &context, key, mods);
+  context = app_tool_context(app);
+  tool_controller_key_down(&app->workspace.tools, &context, key, mods);
 }
 
 /** GLFW scroll callback: zoom canvas at cursor unless blocked by UI. */
-static void scroll_callback(GLFWwindow* handle, double xoffset, double yoffset)
-{
-    Application* app = (Application*)glfwGetWindowUserPointer(handle);
-    ToolContext context;
-    (void)xoffset;
+static void scroll_callback(GLFWwindow *handle, double xoffset,
+                            double yoffset) {
+  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+  ToolContext context;
+  (void)xoffset;
 
-    if (!app) {
-        return;
-    }
+  if (!app) {
+    return;
+  }
 
-    if (!app->workspace.tools.pointer_captured &&
-        app_pointer_blocks_canvas(app, app->cursor_screen)) {
-        return;
-    }
+  if (!app->workspace.tools.pointer_captured &&
+      app_pointer_blocks_canvas(app, app->cursor_screen)) {
+    return;
+  }
 
-    context = app_tool_context(app);
-    tool_controller_scroll(&app->workspace.tools, &context, app->cursor_screen, (float)yoffset);
+  context = app_tool_context(app);
+  tool_controller_scroll(&app->workspace.tools, &context, app->cursor_screen,
+                         (float)yoffset);
 }
 
 /**
@@ -526,56 +528,57 @@ static void scroll_callback(GLFWwindow* handle, double xoffset, double yoffset)
  * - This function has multiple allocation/init branches; each failure path must
  *   leave state safe for `app_shutdown()` best-effort cleanup.
  */
-static int app_init(Application* app)
-{
-    RectF viewport = {0.0f, 0.0f, 1440.0f, 900.0f};
+static int app_init(Application *app) {
+  RectF viewport = {0.0f, 0.0f, 1440.0f, 900.0f};
 
-    if (platform_window_init(&app->window, 1440, 900, "GLDraw Canvas") != 0) {
-        LOG_ERROR("%s", "Failed to create window");
-        return -1;
-    }
+  if (platform_window_init(&app->window, 1440, 900, "GLDraw Canvas") != 0) {
+    LOG_ERROR("%s", "Failed to create window");
+    return -1;
+  }
 
-    document_init(&app->workspace.document);
-    if (!document_history_init(&app->workspace.history)) {
-        LOG_ERROR("%s", "Failed to initialize document history");
-        return -1;
-    }
-    canvas_view_init(&app->workspace.canvas, &app->workspace.document, viewport);
-    tool_controller_init(&app->workspace.tools);
-    app_set_document_path(app, app_default_document_path());
-    app->workspace.save_document = app_workspace_save;
-    app->workspace.load_document = app_workspace_load;
-    app->workspace.command_user_data = app;
-    workspace_mark_saved(&app->workspace);
-    app_set_status(app, "Initializing editor");
-    app->cursor_screen = vec2_make(app->window.width * 0.5f, app->window.height * 0.5f);
-    app->cursor_inside_canvas = 1;
+  document_init(&app->workspace.document);
+  if (!document_history_init(&app->workspace.history)) {
+    LOG_ERROR("%s", "Failed to initialize document history");
+    return -1;
+  }
+  canvas_view_init(&app->workspace.canvas, &app->workspace.document, viewport);
+  tool_controller_init(&app->workspace.tools);
+  app_set_document_path(app, app_default_document_path());
+  app->workspace.save_document = app_workspace_save;
+  app->workspace.load_document = app_workspace_load;
+  app->workspace.command_user_data = app;
+  workspace_mark_saved(&app->workspace);
+  app_set_status(app, "Initializing editor");
+  app->cursor_screen =
+      vec2_make(app->window.width * 0.5f, app->window.height * 0.5f);
+  app->cursor_inside_canvas = 1;
 
-    app->renderer = render_system_create(&app->window);
-    if (!app->renderer) {
-        LOG_ERROR("%s", "Failed to initialize renderer");
-        return -1;
-    }
+  app->renderer = render_system_create(&app->window);
+  if (!app->renderer) {
+    LOG_ERROR("%s", "Failed to initialize renderer");
+    return -1;
+  }
 
-    app->ui = ui_system_create(&app->window);
-    if (!app->ui) {
-        LOG_ERROR("%s", "Failed to initialize UI");
-        return -1;
-    }
+  app->ui = ui_system_create(&app->window);
+  if (!app->ui) {
+    LOG_ERROR("%s", "Failed to initialize UI");
+    return -1;
+  }
 
-    glfwSetWindowUserPointer(app->window.handle, app);
-    glfwSetFramebufferSizeCallback(app->window.handle, framebuffer_size_callback);
-    glfwSetCursorPosCallback(app->window.handle, cursor_pos_callback);
-    glfwSetMouseButtonCallback(app->window.handle, mouse_button_callback);
-    glfwSetKeyCallback(app->window.handle, key_callback);
-    glfwSetScrollCallback(app->window.handle, scroll_callback);
+  glfwSetWindowUserPointer(app->window.handle, app);
+  glfwSetFramebufferSizeCallback(app->window.handle, framebuffer_size_callback);
+  glfwSetCursorPosCallback(app->window.handle, cursor_pos_callback);
+  glfwSetMouseButtonCallback(app->window.handle, mouse_button_callback);
+  glfwSetKeyCallback(app->window.handle, key_callback);
+  glfwSetScrollCallback(app->window.handle, scroll_callback);
 
-    render_system_resize(app->renderer, app->window.width, app->window.height);
-    update_canvas_viewport(app);
-    app->cursor_inside_canvas = app->ui ? ui_system_point_in_canvas(app->ui, app->cursor_screen) : 1;
-    app_sync_tool_pointer_anchor(app);
-    app_open_startup_document(app);
-    return 0;
+  render_system_resize(app->renderer, app->window.width, app->window.height);
+  update_canvas_viewport(app);
+  app->cursor_inside_canvas =
+      app->ui ? ui_system_point_in_canvas(app->ui, app->cursor_screen) : 1;
+  app_sync_tool_pointer_anchor(app);
+  app_open_startup_document(app);
+  return 0;
 }
 
 /**
@@ -587,18 +590,17 @@ static int app_init(Application* app)
  * - Best-effort cleanup; destruction order mirrors `app_init()` to avoid
  *   dangling references to already-destroyed subsystems.
  */
-static void app_shutdown(Application* app)
-{
-    if (!app) {
-        return;
-    }
+static void app_shutdown(Application *app) {
+  if (!app) {
+    return;
+  }
 
-    ui_system_destroy(app->ui);
-    render_system_destroy(app->renderer);
-    tool_controller_shutdown(&app->workspace.tools);
-    document_history_shutdown(&app->workspace.history);
-    document_shutdown(&app->workspace.document);
-    platform_window_shutdown(&app->window);
+  ui_system_destroy(app->ui);
+  render_system_destroy(app->renderer);
+  tool_controller_shutdown(&app->workspace.tools);
+  document_history_shutdown(&app->workspace.history);
+  document_shutdown(&app->workspace.document);
+  platform_window_shutdown(&app->window);
 }
 
 /**
@@ -608,45 +610,43 @@ static void app_shutdown(Application* app)
  * Time complexity:
  * - Main loop performs per-frame `O(object_count + ui_work)` operations.
  */
-int app_run(void)
-{
-    Application* app = (Application*)calloc(1, sizeof(*app));
+int app_run(void) {
+  Application *app = (Application *)calloc(1, sizeof(*app));
 
-    if (!app) {
-        LOG_ERROR("%s", "Failed to allocate application state");
-        return -1;
-    }
+  if (!app) {
+    LOG_ERROR("%s", "Failed to allocate application state");
+    return -1;
+  }
 
-    if (app_init(app) != 0) {
-        app_shutdown(app);
-        free(app);
-        return -1;
-    }
-
-    while (!platform_window_should_close(&app->window)) {
-        int framebuffer_w = 0;
-        int framebuffer_h = 0;
-
-        platform_window_poll_events();
-        glfwGetFramebufferSize(app->window.handle, &framebuffer_w, &framebuffer_h);
-        if (framebuffer_w <= 0 || framebuffer_h <= 0) {
-            /* During monitor/fullscreen transitions some platforms briefly report
-               zero-sized framebuffers. Avoid busy rendering loops in that state. */
-            glfwWaitEventsTimeout(0.02);
-            continue;
-        }
-        ui_system_begin_frame(app->ui);
-        ui_system_build(app->ui, &app->workspace);
-        update_canvas_viewport(app);
-        render_system_draw(app->renderer,
-                           &app->workspace.document,
-                           &app->workspace.canvas,
-                           tool_controller_overlay_object(&app->workspace.tools));
-        ui_system_render(app->ui);
-        platform_window_swap_buffers(&app->window);
-    }
-
+  if (app_init(app) != 0) {
     app_shutdown(app);
     free(app);
-    return 0;
+    return -1;
+  }
+
+  while (!platform_window_should_close(&app->window)) {
+    int framebuffer_w = 0;
+    int framebuffer_h = 0;
+
+    platform_window_poll_events();
+    glfwGetFramebufferSize(app->window.handle, &framebuffer_w, &framebuffer_h);
+    if (framebuffer_w <= 0 || framebuffer_h <= 0) {
+      /* During monitor/fullscreen transitions some platforms briefly report
+         zero-sized framebuffers. Avoid busy rendering loops in that state. */
+      glfwWaitEventsTimeout(0.02);
+      continue;
+    }
+    ui_system_begin_frame(app->ui);
+    ui_system_build(app->ui, &app->workspace);
+    update_canvas_viewport(app);
+    render_system_draw(app->renderer, &app->workspace.document,
+                       &app->workspace.canvas,
+                       tool_controller_overlay_object(&app->workspace.tools));
+    ui_system_render(app->ui);
+    platform_window_swap_buffers(&app->window);
+  }
+
+  app_shutdown(app);
+  free(app);
+  return 0;
 }

--- a/src/app/command_registry.c
+++ b/src/app/command_registry.c
@@ -1,0 +1,295 @@
+/**
+ * @file command_registry.c
+ * @brief Stable command definitions and execution.
+ */
+#include <app/command_registry.h>
+
+#include <app/workspace.h>
+#include <app/workspace_actions.h>
+#include <base/log.h>
+#include <base/math2d.h>
+#include <canvas/canvas_view.h>
+#include <document/document.h>
+#include <document/history.h>
+#include <tools/tool_controller.h>
+#include <ui/ui_menu_def.h>
+
+#include <string.h>
+
+static const CommandDescriptor g_commands[] = {
+    {EDITOR_COMMAND_FILE_NEW, "file.new", "New", KEY_SCOPE_GLOBAL, MENU_ID_FILE_NEW},
+    {EDITOR_COMMAND_FILE_OPEN, "file.open", "Open", KEY_SCOPE_GLOBAL, MENU_ID_FILE_OPEN},
+    {EDITOR_COMMAND_FILE_SAVE, "file.save", "Save", KEY_SCOPE_GLOBAL, MENU_ID_FILE_SAVE},
+    {EDITOR_COMMAND_FILE_SAVE_AS, "file.save_as", "Save As", KEY_SCOPE_GLOBAL, MENU_ID_FILE_SAVE_AS},
+    {EDITOR_COMMAND_FILE_EXIT, "file.exit", "Exit", KEY_SCOPE_GLOBAL, MENU_ID_FILE_EXIT},
+    {EDITOR_COMMAND_EDIT_UNDO, "edit.undo", "Undo", KEY_SCOPE_GLOBAL, MENU_ID_EDIT_UNDO},
+    {EDITOR_COMMAND_EDIT_REDO, "edit.redo", "Redo", KEY_SCOPE_GLOBAL, MENU_ID_EDIT_REDO},
+    {EDITOR_COMMAND_EDIT_DELETE, "edit.delete", "Delete", KEY_SCOPE_GLOBAL, MENU_ID_EDIT_DELETE},
+    {EDITOR_COMMAND_EDIT_SELECT_ALL, "edit.select_all", "Select All", KEY_SCOPE_GLOBAL, MENU_ID_EDIT_SELECT_ALL},
+    {EDITOR_COMMAND_VIEW_ZOOM_IN, "view.zoom_in", "Zoom In", KEY_SCOPE_GLOBAL, MENU_ID_VIEW_ZOOM_IN},
+    {EDITOR_COMMAND_VIEW_ZOOM_OUT, "view.zoom_out", "Zoom Out", KEY_SCOPE_GLOBAL, MENU_ID_VIEW_ZOOM_OUT},
+    {EDITOR_COMMAND_VIEW_ZOOM_FIT, "view.zoom_fit", "Zoom to Fit", KEY_SCOPE_GLOBAL, MENU_ID_VIEW_ZOOM_FIT},
+    {EDITOR_COMMAND_VIEW_TOGGLE_GRID, "view.toggle_grid", "Toggle Grid", KEY_SCOPE_GLOBAL, MENU_ID_VIEW_TOGGLE_GRID},
+    {EDITOR_COMMAND_VIEW_TOGGLE_INSPECTOR, "view.toggle_inspector", "Toggle Inspector", KEY_SCOPE_GLOBAL, MENU_ID_VIEW_TOGGLE_INSPECTOR},
+    {EDITOR_COMMAND_TOOL_SELECT, "tool.select", "Select Tool", KEY_SCOPE_GLOBAL, MENU_ID_EDIT},
+    {EDITOR_COMMAND_TOOL_PAN, "tool.pan", "Pan Tool", KEY_SCOPE_GLOBAL, MENU_ID_EDIT},
+    {EDITOR_COMMAND_TOOL_LINE, "tool.line", "Line Tool", KEY_SCOPE_GLOBAL, MENU_ID_EDIT},
+    {EDITOR_COMMAND_TOOL_RECT, "tool.rect", "Rectangle Tool", KEY_SCOPE_GLOBAL, MENU_ID_EDIT},
+    {EDITOR_COMMAND_TOOL_ELLIPSE, "tool.ellipse", "Ellipse Tool", KEY_SCOPE_GLOBAL, MENU_ID_EDIT},
+    {EDITOR_COMMAND_HELP_SHORTCUTS, "help.shortcuts", "Keyboard Shortcuts", KEY_SCOPE_GLOBAL, MENU_ID_HELP_SHORTCUTS},
+    {EDITOR_COMMAND_HELP_ABOUT, "help.about", "About", KEY_SCOPE_GLOBAL, MENU_ID_HELP_ABOUT},
+    {EDITOR_COMMAND_MODAL_CONFIRM, "modal.confirm", "Confirm", KEY_SCOPE_MODAL, MENU_ID_HELP},
+    {EDITOR_COMMAND_MODAL_CANCEL, "modal.cancel", "Cancel", KEY_SCOPE_MODAL, MENU_ID_HELP}
+};
+
+static int command_registry_zoom_to_fit(Workspace* workspace)
+{
+    Document* doc = NULL;
+    CanvasView* canvas = NULL;
+    float min_x = 0.0f;
+    float max_x = 0.0f;
+    float min_y = 0.0f;
+    float max_y = 0.0f;
+    int first = 1;
+    int i = 0;
+
+    if (!workspace || !workspace->canvas.document) {
+        return 0;
+    }
+
+    doc = &workspace->document;
+    canvas = &workspace->canvas;
+    if (doc->count == 0) {
+        canvas_view_set_center_zoom(canvas, vec2_make(0.0f, 0.0f), 1.0f);
+        return 1;
+    }
+
+    for (i = 0; i < doc->count; ++i) {
+        GraphicObject* object = doc->objects[i];
+        RectF bounds;
+
+        if (!object) {
+            continue;
+        }
+
+        bounds = object_get_bounds(object);
+        if (first) {
+            min_x = bounds.x;
+            max_x = bounds.x + bounds.w;
+            min_y = bounds.y;
+            max_y = bounds.y + bounds.h;
+            first = 0;
+        } else {
+            if (bounds.x < min_x) min_x = bounds.x;
+            if (bounds.y < min_y) min_y = bounds.y;
+            if (bounds.x + bounds.w > max_x) max_x = bounds.x + bounds.w;
+            if (bounds.y + bounds.h > max_y) max_y = bounds.y + bounds.h;
+        }
+    }
+
+    if (!first) {
+        float pad = 50.0f;
+        float content_w = 0.0f;
+        float content_h = 0.0f;
+        RectF canvas_viewport = canvas_view_viewport(canvas);
+        float zoom_x = 1.0f;
+        float zoom_y = 1.0f;
+        float new_zoom = 1.0f;
+
+        min_x -= pad;
+        min_y -= pad;
+        max_x += pad;
+        max_y += pad;
+        content_w = max_x - min_x;
+        content_h = max_y - min_y;
+        zoom_x = canvas_viewport.w / content_w;
+        zoom_y = canvas_viewport.h / content_h;
+        new_zoom = (zoom_x < zoom_y) ? zoom_x : zoom_y;
+        new_zoom = (new_zoom < 0.1f) ? 0.1f : (new_zoom > 12.0f) ? 12.0f : new_zoom;
+        canvas_view_set_center_zoom(canvas,
+                                    vec2_make((min_x + max_x) * 0.5f, (min_y + max_y) * 0.5f),
+                                    new_zoom);
+    }
+
+    return 1;
+}
+
+static void command_registry_delete_selection(Workspace* workspace)
+{
+    DocumentSnapshot before_snapshot;
+
+    if (!workspace || workspace->document.selection.count <= 0) {
+        return;
+    }
+
+    document_snapshot_init(&before_snapshot);
+    document_snapshot_capture(&before_snapshot, &workspace->document);
+    document_delete_selection(&workspace->document);
+    if (!document_history_push(&workspace->history, &before_snapshot, &workspace->document)) {
+        document_snapshot_free(&before_snapshot);
+    }
+    workspace_sync_document_dirty(workspace);
+}
+
+static void command_registry_select_all(Workspace* workspace)
+{
+    int i = 0;
+
+    if (!workspace) {
+        return;
+    }
+
+    document_clear_selection(&workspace->document);
+    for (i = 0; i < workspace->document.count; ++i) {
+        document_selection_add(&workspace->document,
+                               workspace->document.objects[i]->id);
+    }
+}
+
+const CommandDescriptor* command_registry_find_by_id(const char* command_id)
+{
+    size_t i = 0u;
+
+    if (!command_id) {
+        return NULL;
+    }
+
+    for (i = 0u; i < sizeof(g_commands) / sizeof(g_commands[0]); ++i) {
+        if (strcmp(g_commands[i].id, command_id) == 0) {
+            return &g_commands[i];
+        }
+    }
+
+    return NULL;
+}
+
+const CommandDescriptor* command_registry_find_by_menu_id(int id)
+{
+    size_t i = 0u;
+
+    for (i = 0u; i < sizeof(g_commands) / sizeof(g_commands[0]); ++i) {
+        if (g_commands[i].menu_id == id) {
+            return &g_commands[i];
+        }
+    }
+
+    return NULL;
+}
+
+int command_registry_execute(Workspace* workspace,
+                             ToolContext* tool_context,
+                             EditorCommand command)
+{
+    if (!workspace) {
+        return 0;
+    }
+
+    switch (command) {
+    case EDITOR_COMMAND_FILE_NEW:
+        return workspace_request_action(workspace, WORKSPACE_ACTION_NEW_DOCUMENT);
+    case EDITOR_COMMAND_FILE_OPEN:
+        return workspace_request_action(workspace, WORKSPACE_ACTION_OPEN_DOCUMENT);
+    case EDITOR_COMMAND_FILE_SAVE:
+        return workspace->save_document ? workspace->save_document(workspace, workspace->command_user_data) : 0;
+    case EDITOR_COMMAND_FILE_SAVE_AS:
+        return workspace->save_document ? workspace->save_document(workspace, workspace->command_user_data) : 0;
+    case EDITOR_COMMAND_FILE_EXIT:
+        return workspace_request_action(workspace, WORKSPACE_ACTION_EXIT_APPLICATION);
+    case EDITOR_COMMAND_EDIT_UNDO:
+        if (document_history_undo(&workspace->history, &workspace->document)) {
+            workspace_sync_document_dirty(workspace);
+            return 1;
+        }
+        return 0;
+    case EDITOR_COMMAND_EDIT_REDO:
+        if (document_history_redo(&workspace->history, &workspace->document)) {
+            workspace_sync_document_dirty(workspace);
+            return 1;
+        }
+        return 0;
+    case EDITOR_COMMAND_EDIT_DELETE:
+        command_registry_delete_selection(workspace);
+        return 1;
+    case EDITOR_COMMAND_EDIT_SELECT_ALL:
+        command_registry_select_all(workspace);
+        return 1;
+    case EDITOR_COMMAND_VIEW_ZOOM_IN:
+    {
+        Vec2 center = canvas_view_center(&workspace->canvas);
+        canvas_view_zoom_at_screen_point(&workspace->canvas, 1.25f,
+                                         canvas_view_world_to_screen(&workspace->canvas, center));
+        return 1;
+    }
+    case EDITOR_COMMAND_VIEW_ZOOM_OUT:
+    {
+        Vec2 center = canvas_view_center(&workspace->canvas);
+        canvas_view_zoom_at_screen_point(&workspace->canvas, 0.8f,
+                                         canvas_view_world_to_screen(&workspace->canvas, center));
+        return 1;
+    }
+    case EDITOR_COMMAND_VIEW_ZOOM_FIT:
+        return command_registry_zoom_to_fit(workspace);
+    case EDITOR_COMMAND_VIEW_TOGGLE_GRID:
+        workspace->canvas.show_grid = !workspace->canvas.show_grid;
+        return 1;
+    case EDITOR_COMMAND_VIEW_TOGGLE_INSPECTOR:
+        return 1;
+    case EDITOR_COMMAND_TOOL_SELECT:
+        if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_SELECT);
+        return 1;
+    case EDITOR_COMMAND_TOOL_PAN:
+        if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_PAN);
+        return 1;
+    case EDITOR_COMMAND_TOOL_LINE:
+        if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_LINE);
+        return 1;
+    case EDITOR_COMMAND_TOOL_RECT:
+        if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_RECT);
+        return 1;
+    case EDITOR_COMMAND_TOOL_ELLIPSE:
+        if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_ELLIPSE);
+        return 1;
+    case EDITOR_COMMAND_HELP_SHORTCUTS:
+        LOG_INFO("%s", "Keyboard shortcuts dialog requested");
+        return 1;
+    case EDITOR_COMMAND_HELP_ABOUT:
+        LOG_INFO("%s", "About dialog requested");
+        return 1;
+    case EDITOR_COMMAND_MODAL_CONFIRM:
+        return workspace_confirm_pending_action_save(workspace);
+    case EDITOR_COMMAND_MODAL_CANCEL:
+        workspace_confirm_pending_action_cancel(workspace);
+        return 1;
+    case EDITOR_COMMAND_NONE:
+    default:
+        return 0;
+    }
+}
+
+void command_registry_format_menu_shortcut(const Workspace* workspace,
+                                           int id,
+                                           char* buffer,
+                                           size_t buffer_size)
+{
+    const CommandDescriptor* descriptor = NULL;
+
+    if (!buffer || buffer_size == 0u) {
+        return;
+    }
+
+    buffer[0] = '\0';
+    if (!workspace) {
+        return;
+    }
+
+    descriptor = command_registry_find_by_menu_id(id);
+    if (!descriptor) {
+        return;
+    }
+
+    keymap_format_command_shortcut(&workspace->keymap,
+                                   descriptor->id,
+                                   descriptor->scope,
+                                   buffer,
+                                   buffer_size);
+}

--- a/src/app/workspace_actions.c
+++ b/src/app/workspace_actions.c
@@ -12,9 +12,6 @@
  */
 #include <app/workspace_actions.h>
 
-#include <stdio.h>
-#include <string.h>
-
 /** Return non-zero when the requested action can discard the current document state. */
 static int workspace_action_requires_unsaved_confirmation(WorkspaceActionType action)
 {
@@ -27,88 +24,6 @@ static int workspace_action_requires_unsaved_confirmation(WorkspaceActionType ac
     default:
         return 0;
     }
-}
-
-/** Execute an application-owned action immediately through the workspace callback. */
-static int workspace_execute_action_now(Workspace* workspace, WorkspaceActionType action)
-{
-    if (!workspace || action == WORKSPACE_ACTION_NONE || !workspace->execute_action) {
-        return 0;
-    }
-
-    return workspace->execute_action(workspace, action, workspace->command_user_data);
-}
-
-/** Populate one reusable dialog button descriptor. */
-static void workspace_set_dialog_button(UiDialogState* dialog,
-                                        int index,
-                                        const char* label,
-                                        UiDialogResult result,
-                                        int is_default)
-{
-    if (!dialog || !label || index < 0 || index >= (int)(sizeof(dialog->buttons) / sizeof(dialog->buttons[0]))) {
-        return;
-    }
-
-    snprintf(dialog->buttons[index].label,
-             sizeof(dialog->buttons[index].label),
-             "%s",
-             label);
-    dialog->buttons[index].result = result;
-    dialog->buttons[index].is_default = is_default;
-}
-
-/** Clear any active UI request/dialog state. */
-static void workspace_clear_ui_request(Workspace* workspace)
-{
-    if (!workspace) {
-        return;
-    }
-
-    workspace->active_request_type = UI_REQUEST_NONE;
-    memset(&workspace->active_dialog, 0, sizeof(workspace->active_dialog));
-    workspace->active_dialog.kind = UI_DIALOG_NONE;
-}
-
-/** Open a reusable workspace dialog for unsaved-changes confirmation. */
-static void workspace_open_unsaved_changes_dialog(Workspace* workspace,
-                                                  WorkspaceActionType action)
-{
-    if (!workspace) {
-        return;
-    }
-
-    workspace->active_request_type = UI_REQUEST_DIALOG;
-    memset(&workspace->active_dialog, 0, sizeof(workspace->active_dialog));
-    workspace->active_dialog.kind = UI_DIALOG_CONFIRM_UNSAVED;
-    snprintf(workspace->active_dialog.title,
-             sizeof(workspace->active_dialog.title),
-             "%s",
-             "Unsaved Changes");
-    snprintf(workspace->active_dialog.message,
-             sizeof(workspace->active_dialog.message),
-             "%s",
-             "You have unsaved changes.\nDo you want to save before continuing?");
-    workspace->active_dialog.payload.int_values[0] = (int)action;
-    workspace_set_dialog_button(&workspace->active_dialog,
-                                0,
-                                "Save",
-                                UI_DIALOG_RESULT_PRIMARY,
-                                1);
-    workspace_set_dialog_button(&workspace->active_dialog,
-                                1,
-                                "Don't Save",
-                                UI_DIALOG_RESULT_SECONDARY,
-                                0);
-    workspace_set_dialog_button(&workspace->active_dialog,
-                                2,
-                                "Cancel",
-                                UI_DIALOG_RESULT_CANCEL,
-                                0);
-    workspace->active_dialog.button_count = 3;
-    workspace->active_dialog.width = 360.0f;
-    workspace->active_dialog.height = 170.0f;
-    workspace->active_dialog.modal = 1;
 }
 
 int workspace_modal_is_active(const Workspace* workspace)
@@ -139,44 +54,34 @@ int workspace_request_action(Workspace* workspace, WorkspaceActionType action)
 
     if (workspace_action_requires_unsaved_confirmation(action) &&
         workspace->document_dirty) {
-        workspace_open_unsaved_changes_dialog(workspace, action);
-        return 1;
+        return workspace_dialog_open_confirm_unsaved(workspace, action);
     }
 
-    return workspace_execute_action_now(workspace, action);
+    if (!workspace->execute_action) {
+        return 0;
+    }
+
+    return workspace->execute_action(workspace, action, workspace->command_user_data);
 }
 
 int workspace_confirm_pending_action_save(Workspace* workspace)
 {
-    WorkspaceActionType action = WORKSPACE_ACTION_NONE;
-
-    if (!workspace ||
-        workspace_active_dialog_kind(workspace) != UI_DIALOG_CONFIRM_UNSAVED ||
-        !workspace->save_document) {
-        return 0;
-    }
-
-    if (!workspace->save_document(workspace, workspace->command_user_data)) {
-        return 0;
-    }
-
-    action = (WorkspaceActionType)workspace->active_dialog.payload.int_values[0];
-    workspace_clear_ui_request(workspace);
-    return workspace_execute_action_now(workspace, action);
-}
-
-int workspace_confirm_pending_action_discard(Workspace* workspace)
-{
-    WorkspaceActionType action = WORKSPACE_ACTION_NONE;
-
     if (!workspace ||
         workspace_active_dialog_kind(workspace) != UI_DIALOG_CONFIRM_UNSAVED) {
         return 0;
     }
 
-    action = (WorkspaceActionType)workspace->active_dialog.payload.int_values[0];
-    workspace_clear_ui_request(workspace);
-    return workspace_execute_action_now(workspace, action);
+    return workspace_dialog_resolve(workspace, UI_DIALOG_RESULT_PRIMARY);
+}
+
+int workspace_confirm_pending_action_discard(Workspace* workspace)
+{
+    if (!workspace ||
+        workspace_active_dialog_kind(workspace) != UI_DIALOG_CONFIRM_UNSAVED) {
+        return 0;
+    }
+
+    return workspace_dialog_resolve(workspace, UI_DIALOG_RESULT_SECONDARY);
 }
 
 void workspace_confirm_pending_action_cancel(Workspace* workspace)
@@ -185,28 +90,10 @@ void workspace_confirm_pending_action_cancel(Workspace* workspace)
         return;
     }
 
-    workspace_clear_ui_request(workspace);
-    snprintf(workspace->status_message,
-             sizeof(workspace->status_message),
-             "Action cancelled.");
+    (void)workspace_dialog_resolve(workspace, UI_DIALOG_RESULT_CANCEL);
 }
 
 int workspace_resolve_active_dialog(Workspace* workspace, UiDialogResult result)
 {
-    if (!workspace || workspace->active_request_type != UI_REQUEST_DIALOG) {
-        return 0;
-    }
-
-    switch (result) {
-    case UI_DIALOG_RESULT_PRIMARY:
-        return workspace_confirm_pending_action_save(workspace);
-    case UI_DIALOG_RESULT_SECONDARY:
-        return workspace_confirm_pending_action_discard(workspace);
-    case UI_DIALOG_RESULT_CANCEL:
-        workspace_confirm_pending_action_cancel(workspace);
-        return 1;
-    case UI_DIALOG_RESULT_NONE:
-    default:
-        return 0;
-    }
+    return workspace_dialog_resolve(workspace, result);
 }

--- a/src/app/workspace_actions.c
+++ b/src/app/workspace_actions.c
@@ -13,6 +13,7 @@
 #include <app/workspace_actions.h>
 
 #include <stdio.h>
+#include <string.h>
 
 /** Return non-zero when the requested action can discard the current document state. */
 static int workspace_action_requires_unsaved_confirmation(WorkspaceActionType action)
@@ -38,61 +39,92 @@ static int workspace_execute_action_now(Workspace* workspace, WorkspaceActionTyp
     return workspace->execute_action(workspace, action, workspace->command_user_data);
 }
 
-/** Clear any active modal/pending state. */
-static void workspace_clear_modal_state(Workspace* workspace)
+/** Populate one reusable dialog button descriptor. */
+static void workspace_set_dialog_button(UiDialogState* dialog,
+                                        int index,
+                                        const char* label,
+                                        UiDialogResult result,
+                                        int is_default)
 {
-    if (!workspace) {
+    if (!dialog || !label || index < 0 || index >= (int)(sizeof(dialog->buttons) / sizeof(dialog->buttons[0]))) {
         return;
     }
 
-    workspace->modal_type = WORKSPACE_MODAL_NONE;
-    workspace->pending_action = WORKSPACE_ACTION_NONE;
+    snprintf(dialog->buttons[index].label,
+             sizeof(dialog->buttons[index].label),
+             "%s",
+             label);
+    dialog->buttons[index].result = result;
+    dialog->buttons[index].is_default = is_default;
 }
 
-/** Open the shared unsaved-changes confirmation modal for one pending action. */
-static void workspace_open_unsaved_changes_modal(Workspace* workspace, WorkspaceActionType action)
+/** Clear any active UI request/dialog state. */
+static void workspace_clear_ui_request(Workspace* workspace)
 {
     if (!workspace) {
         return;
     }
 
-    workspace->modal_type = WORKSPACE_MODAL_CONFIRM_UNSAVED;
-    workspace->pending_action = action;
+    workspace->active_request_type = UI_REQUEST_NONE;
+    memset(&workspace->active_dialog, 0, sizeof(workspace->active_dialog));
+    workspace->active_dialog.kind = UI_DIALOG_NONE;
+}
+
+/** Open a reusable workspace dialog for unsaved-changes confirmation. */
+static void workspace_open_unsaved_changes_dialog(Workspace* workspace,
+                                                  WorkspaceActionType action)
+{
+    if (!workspace) {
+        return;
+    }
+
+    workspace->active_request_type = UI_REQUEST_DIALOG;
+    memset(&workspace->active_dialog, 0, sizeof(workspace->active_dialog));
+    workspace->active_dialog.kind = UI_DIALOG_CONFIRM_UNSAVED;
+    snprintf(workspace->active_dialog.title,
+             sizeof(workspace->active_dialog.title),
+             "%s",
+             "Unsaved Changes");
+    snprintf(workspace->active_dialog.message,
+             sizeof(workspace->active_dialog.message),
+             "%s",
+             "You have unsaved changes.\nDo you want to save before continuing?");
+    workspace->active_dialog.payload.int_values[0] = (int)action;
+    workspace_set_dialog_button(&workspace->active_dialog,
+                                0,
+                                "Save",
+                                UI_DIALOG_RESULT_PRIMARY,
+                                1);
+    workspace_set_dialog_button(&workspace->active_dialog,
+                                1,
+                                "Don't Save",
+                                UI_DIALOG_RESULT_SECONDARY,
+                                0);
+    workspace_set_dialog_button(&workspace->active_dialog,
+                                2,
+                                "Cancel",
+                                UI_DIALOG_RESULT_CANCEL,
+                                0);
+    workspace->active_dialog.button_count = 3;
+    workspace->active_dialog.width = 360.0f;
+    workspace->active_dialog.height = 170.0f;
+    workspace->active_dialog.modal = 1;
 }
 
 int workspace_modal_is_active(const Workspace* workspace)
 {
-    return workspace && workspace->modal_type != WORKSPACE_MODAL_NONE;
+    return workspace &&
+           workspace->active_request_type == UI_REQUEST_DIALOG &&
+           workspace->active_dialog.modal &&
+           workspace->active_dialog.kind != UI_DIALOG_NONE;
 }
 
-const char* workspace_modal_title(const Workspace* workspace)
+UiDialogKind workspace_active_dialog_kind(const Workspace* workspace)
 {
-    if (!workspace) {
-        return "";
+    if (!workspace || workspace->active_request_type != UI_REQUEST_DIALOG) {
+        return UI_DIALOG_NONE;
     }
-
-    switch (workspace->modal_type) {
-    case WORKSPACE_MODAL_CONFIRM_UNSAVED:
-        return "Unsaved Changes";
-    case WORKSPACE_MODAL_NONE:
-    default:
-        return "";
-    }
-}
-
-const char* workspace_modal_message(const Workspace* workspace)
-{
-    if (!workspace) {
-        return "";
-    }
-
-    switch (workspace->modal_type) {
-    case WORKSPACE_MODAL_CONFIRM_UNSAVED:
-        return "You have unsaved changes.\nDo you want to save before continuing?";
-    case WORKSPACE_MODAL_NONE:
-    default:
-        return "";
-    }
+    return workspace->active_dialog.kind;
 }
 
 int workspace_request_action(Workspace* workspace, WorkspaceActionType action)
@@ -107,7 +139,7 @@ int workspace_request_action(Workspace* workspace, WorkspaceActionType action)
 
     if (workspace_action_requires_unsaved_confirmation(action) &&
         workspace->document_dirty) {
-        workspace_open_unsaved_changes_modal(workspace, action);
+        workspace_open_unsaved_changes_dialog(workspace, action);
         return 1;
     }
 
@@ -119,8 +151,7 @@ int workspace_confirm_pending_action_save(Workspace* workspace)
     WorkspaceActionType action = WORKSPACE_ACTION_NONE;
 
     if (!workspace ||
-        workspace->modal_type != WORKSPACE_MODAL_CONFIRM_UNSAVED ||
-        workspace->pending_action == WORKSPACE_ACTION_NONE ||
+        workspace_active_dialog_kind(workspace) != UI_DIALOG_CONFIRM_UNSAVED ||
         !workspace->save_document) {
         return 0;
     }
@@ -129,8 +160,8 @@ int workspace_confirm_pending_action_save(Workspace* workspace)
         return 0;
     }
 
-    action = workspace->pending_action;
-    workspace_clear_modal_state(workspace);
+    action = (WorkspaceActionType)workspace->active_dialog.payload.int_values[0];
+    workspace_clear_ui_request(workspace);
     return workspace_execute_action_now(workspace, action);
 }
 
@@ -139,13 +170,12 @@ int workspace_confirm_pending_action_discard(Workspace* workspace)
     WorkspaceActionType action = WORKSPACE_ACTION_NONE;
 
     if (!workspace ||
-        workspace->modal_type != WORKSPACE_MODAL_CONFIRM_UNSAVED ||
-        workspace->pending_action == WORKSPACE_ACTION_NONE) {
+        workspace_active_dialog_kind(workspace) != UI_DIALOG_CONFIRM_UNSAVED) {
         return 0;
     }
 
-    action = workspace->pending_action;
-    workspace_clear_modal_state(workspace);
+    action = (WorkspaceActionType)workspace->active_dialog.payload.int_values[0];
+    workspace_clear_ui_request(workspace);
     return workspace_execute_action_now(workspace, action);
 }
 
@@ -155,8 +185,28 @@ void workspace_confirm_pending_action_cancel(Workspace* workspace)
         return;
     }
 
-    workspace_clear_modal_state(workspace);
+    workspace_clear_ui_request(workspace);
     snprintf(workspace->status_message,
              sizeof(workspace->status_message),
              "Action cancelled.");
+}
+
+int workspace_resolve_active_dialog(Workspace* workspace, UiDialogResult result)
+{
+    if (!workspace || workspace->active_request_type != UI_REQUEST_DIALOG) {
+        return 0;
+    }
+
+    switch (result) {
+    case UI_DIALOG_RESULT_PRIMARY:
+        return workspace_confirm_pending_action_save(workspace);
+    case UI_DIALOG_RESULT_SECONDARY:
+        return workspace_confirm_pending_action_discard(workspace);
+    case UI_DIALOG_RESULT_CANCEL:
+        workspace_confirm_pending_action_cancel(workspace);
+        return 1;
+    case UI_DIALOG_RESULT_NONE:
+    default:
+        return 0;
+    }
 }

--- a/src/app/workspace_actions.c
+++ b/src/app/workspace_actions.c
@@ -1,0 +1,162 @@
+/**
+ * @file workspace_actions.c
+ * @brief Workspace-level action arbitration and unsaved-changes modal flow.
+ *
+ * Role in project:
+ * - Decides whether destructive actions execute immediately or open a modal.
+ * - Owns the pending-action state machine used by UI and application events.
+ *
+ * Module relationships:
+ * - Sits between UI/application entry points and application-owned executors.
+ * - Uses workspace callbacks for save operations before deferred execution.
+ */
+#include <app/workspace_actions.h>
+
+#include <stdio.h>
+
+/** Return non-zero when the requested action can discard the current document state. */
+static int workspace_action_requires_unsaved_confirmation(WorkspaceActionType action)
+{
+    switch (action) {
+    case WORKSPACE_ACTION_NEW_DOCUMENT:
+    case WORKSPACE_ACTION_OPEN_DOCUMENT:
+    case WORKSPACE_ACTION_EXIT_APPLICATION:
+        return 1;
+    case WORKSPACE_ACTION_NONE:
+    default:
+        return 0;
+    }
+}
+
+/** Execute an application-owned action immediately through the workspace callback. */
+static int workspace_execute_action_now(Workspace* workspace, WorkspaceActionType action)
+{
+    if (!workspace || action == WORKSPACE_ACTION_NONE || !workspace->execute_action) {
+        return 0;
+    }
+
+    return workspace->execute_action(workspace, action, workspace->command_user_data);
+}
+
+/** Clear any active modal/pending state. */
+static void workspace_clear_modal_state(Workspace* workspace)
+{
+    if (!workspace) {
+        return;
+    }
+
+    workspace->modal_type = WORKSPACE_MODAL_NONE;
+    workspace->pending_action = WORKSPACE_ACTION_NONE;
+}
+
+/** Open the shared unsaved-changes confirmation modal for one pending action. */
+static void workspace_open_unsaved_changes_modal(Workspace* workspace, WorkspaceActionType action)
+{
+    if (!workspace) {
+        return;
+    }
+
+    workspace->modal_type = WORKSPACE_MODAL_CONFIRM_UNSAVED;
+    workspace->pending_action = action;
+}
+
+int workspace_modal_is_active(const Workspace* workspace)
+{
+    return workspace && workspace->modal_type != WORKSPACE_MODAL_NONE;
+}
+
+const char* workspace_modal_title(const Workspace* workspace)
+{
+    if (!workspace) {
+        return "";
+    }
+
+    switch (workspace->modal_type) {
+    case WORKSPACE_MODAL_CONFIRM_UNSAVED:
+        return "Unsaved Changes";
+    case WORKSPACE_MODAL_NONE:
+    default:
+        return "";
+    }
+}
+
+const char* workspace_modal_message(const Workspace* workspace)
+{
+    if (!workspace) {
+        return "";
+    }
+
+    switch (workspace->modal_type) {
+    case WORKSPACE_MODAL_CONFIRM_UNSAVED:
+        return "You have unsaved changes.\nDo you want to save before continuing?";
+    case WORKSPACE_MODAL_NONE:
+    default:
+        return "";
+    }
+}
+
+int workspace_request_action(Workspace* workspace, WorkspaceActionType action)
+{
+    if (!workspace || action == WORKSPACE_ACTION_NONE) {
+        return 0;
+    }
+
+    if (workspace_modal_is_active(workspace)) {
+        return 0;
+    }
+
+    if (workspace_action_requires_unsaved_confirmation(action) &&
+        workspace->document_dirty) {
+        workspace_open_unsaved_changes_modal(workspace, action);
+        return 1;
+    }
+
+    return workspace_execute_action_now(workspace, action);
+}
+
+int workspace_confirm_pending_action_save(Workspace* workspace)
+{
+    WorkspaceActionType action = WORKSPACE_ACTION_NONE;
+
+    if (!workspace ||
+        workspace->modal_type != WORKSPACE_MODAL_CONFIRM_UNSAVED ||
+        workspace->pending_action == WORKSPACE_ACTION_NONE ||
+        !workspace->save_document) {
+        return 0;
+    }
+
+    if (!workspace->save_document(workspace, workspace->command_user_data)) {
+        return 0;
+    }
+
+    action = workspace->pending_action;
+    workspace_clear_modal_state(workspace);
+    return workspace_execute_action_now(workspace, action);
+}
+
+int workspace_confirm_pending_action_discard(Workspace* workspace)
+{
+    WorkspaceActionType action = WORKSPACE_ACTION_NONE;
+
+    if (!workspace ||
+        workspace->modal_type != WORKSPACE_MODAL_CONFIRM_UNSAVED ||
+        workspace->pending_action == WORKSPACE_ACTION_NONE) {
+        return 0;
+    }
+
+    action = workspace->pending_action;
+    workspace_clear_modal_state(workspace);
+    return workspace_execute_action_now(workspace, action);
+}
+
+void workspace_confirm_pending_action_cancel(Workspace* workspace)
+{
+    if (!workspace) {
+        return;
+    }
+
+    workspace_clear_modal_state(workspace);
+    snprintf(workspace->status_message,
+             sizeof(workspace->status_message),
+             "Action cancelled.");
+}

--- a/src/app/workspace_dialogs.c
+++ b/src/app/workspace_dialogs.c
@@ -1,0 +1,251 @@
+/**
+ * @file workspace_dialogs.c
+ * @brief Reusable workspace-owned dialog builders and lifecycle helpers.
+ */
+#include <app/workspace_dialogs.h>
+
+#include <stdio.h>
+#include <string.h>
+
+static const UiDialogButtonDefinition UI_DIALOG_BUTTON_CONFIRM_UNSAVED_SAVE = {
+    "Save",
+    UI_DIALOG_RESULT_PRIMARY,
+    1
+};
+
+static const UiDialogButtonDefinition UI_DIALOG_BUTTON_CONFIRM_UNSAVED_DISCARD = {
+    "Don't Save",
+    UI_DIALOG_RESULT_SECONDARY,
+    0
+};
+
+static const UiDialogButtonDefinition UI_DIALOG_BUTTON_CONFIRM_UNSAVED_CANCEL = {
+    "Cancel",
+    UI_DIALOG_RESULT_CANCEL,
+    0
+};
+
+static int workspace_dialog_resolve_confirm_unsaved(Workspace* workspace,
+                                                    UiDialogResult result);
+
+static const UiDialogButtonDefinition UI_DIALOG_BUTTONS_CONFIRM_UNSAVED[] = {
+    UI_DIALOG_BUTTON_CONFIRM_UNSAVED_SAVE,
+    UI_DIALOG_BUTTON_CONFIRM_UNSAVED_DISCARD,
+    UI_DIALOG_BUTTON_CONFIRM_UNSAVED_CANCEL
+};
+
+static const UiDialogDefinition UI_DIALOG_DEFINITION_CONFIRM_UNSAVED = {
+    {
+        UI_DIALOG_CONFIRM_UNSAVED,
+        "Unsaved Changes",
+        "You have unsaved changes.\nDo you want to save before continuing?",
+        360.0f,
+        170.0f,
+        1
+    },
+    UI_DIALOG_BUTTONS_CONFIRM_UNSAVED,
+    (int)(sizeof(UI_DIALOG_BUTTONS_CONFIRM_UNSAVED) / sizeof(UI_DIALOG_BUTTONS_CONFIRM_UNSAVED[0])),
+    workspace_dialog_resolve_confirm_unsaved
+};
+
+static int workspace_dialog_execute_action_now(Workspace* workspace,
+                                               WorkspaceActionType action)
+{
+    if (!workspace || action == WORKSPACE_ACTION_NONE || !workspace->execute_action) {
+        return 0;
+    }
+
+    return workspace->execute_action(workspace, action, workspace->command_user_data);
+}
+
+static int workspace_dialog_resolve_confirm_unsaved(Workspace* workspace,
+                                                    UiDialogResult result)
+{
+    WorkspaceActionType action = WORKSPACE_ACTION_NONE;
+
+    if (!workspace) {
+        return 0;
+    }
+
+    action = (WorkspaceActionType)workspace->active_dialog.payload.int_values[0];
+
+    switch (result) {
+    case UI_DIALOG_RESULT_PRIMARY:
+        if (!workspace->save_document ||
+            !workspace->save_document(workspace, workspace->command_user_data)) {
+            return 0;
+        }
+        workspace_dialog_close(workspace);
+        return workspace_dialog_execute_action_now(workspace, action);
+    case UI_DIALOG_RESULT_SECONDARY:
+        workspace_dialog_close(workspace);
+        return workspace_dialog_execute_action_now(workspace, action);
+    case UI_DIALOG_RESULT_CANCEL:
+        workspace_dialog_close(workspace);
+        snprintf(workspace->status_message,
+                 sizeof(workspace->status_message),
+                 "Action cancelled.");
+        return 1;
+    case UI_DIALOG_RESULT_NONE:
+    default:
+        return 0;
+    }
+}
+
+const UiDialogDefinition* workspace_dialog_definition(UiDialogKind kind)
+{
+    switch (kind) {
+    case UI_DIALOG_CONFIRM_UNSAVED:
+        return &UI_DIALOG_DEFINITION_CONFIRM_UNSAVED;
+    case UI_DIALOG_NONE:
+    default:
+        return NULL;
+    }
+}
+
+void workspace_dialog_reset(UiDialogState* dialog)
+{
+    if (!dialog) {
+        return;
+    }
+
+    memset(dialog, 0, sizeof(*dialog));
+    dialog->kind = UI_DIALOG_NONE;
+}
+
+void workspace_dialog_apply_template(UiDialogState* dialog, const UiDialogTemplate* dialog_template)
+{
+    if (!dialog || !dialog_template) {
+        return;
+    }
+
+    workspace_dialog_reset(dialog);
+    dialog->kind = dialog_template->kind;
+    dialog->width = dialog_template->width;
+    dialog->height = dialog_template->height;
+    dialog->modal = dialog_template->modal;
+
+    if (dialog_template->title) {
+        snprintf(dialog->title, sizeof(dialog->title), "%s", dialog_template->title);
+    }
+    if (dialog_template->message) {
+        snprintf(dialog->message, sizeof(dialog->message), "%s", dialog_template->message);
+    }
+}
+
+int workspace_dialog_add_button(UiDialogState* dialog, const UiDialogButtonDefinition* button)
+{
+    int index = 0;
+
+    if (!dialog || !button || !button->label) {
+        return 0;
+    }
+
+    index = dialog->button_count;
+    if (index < 0 || index >= (int)(sizeof(dialog->buttons) / sizeof(dialog->buttons[0]))) {
+        return 0;
+    }
+
+    snprintf(dialog->buttons[index].label,
+             sizeof(dialog->buttons[index].label),
+             "%s",
+             button->label);
+    dialog->buttons[index].result = button->result;
+    dialog->buttons[index].is_default = button->is_default;
+    dialog->button_count += 1;
+    return 1;
+}
+
+int workspace_dialog_open_from_template(Workspace* workspace,
+                                        const UiDialogTemplate* dialog_template,
+                                        const UiDialogPayload* payload,
+                                        const UiDialogButtonDefinition* buttons,
+                                        int button_count)
+{
+    UiDialogState dialog;
+    int i = 0;
+
+    if (!workspace || !dialog_template || !buttons || button_count <= 0) {
+        return 0;
+    }
+
+    workspace_dialog_apply_template(&dialog, dialog_template);
+    if (payload) {
+        dialog.payload = *payload;
+    }
+
+    for (i = 0; i < button_count; ++i) {
+        if (!workspace_dialog_add_button(&dialog, &buttons[i])) {
+            return 0;
+        }
+    }
+
+    return workspace_dialog_open(workspace, &dialog);
+}
+
+int workspace_dialog_open_definition(Workspace* workspace,
+                                     const UiDialogDefinition* definition,
+                                     const UiDialogPayload* payload)
+{
+    if (!definition) {
+        return 0;
+    }
+
+    return workspace_dialog_open_from_template(workspace,
+                                               &definition->dialog_template,
+                                               payload,
+                                               definition->buttons,
+                                               definition->button_count);
+}
+
+int workspace_dialog_open(Workspace* workspace, const UiDialogState* dialog)
+{
+    if (!workspace || !dialog || dialog->kind == UI_DIALOG_NONE) {
+        return 0;
+    }
+
+    workspace->active_request_type = UI_REQUEST_DIALOG;
+    workspace->active_dialog = *dialog;
+    return 1;
+}
+
+void workspace_dialog_close(Workspace* workspace)
+{
+    if (!workspace) {
+        return;
+    }
+
+    workspace->active_request_type = UI_REQUEST_NONE;
+    workspace_dialog_reset(&workspace->active_dialog);
+}
+
+int workspace_dialog_resolve(Workspace* workspace, UiDialogResult result)
+{
+    const UiDialogDefinition* definition = NULL;
+
+    if (!workspace || workspace->active_request_type != UI_REQUEST_DIALOG) {
+        return 0;
+    }
+
+    definition = workspace_dialog_definition(workspace->active_dialog.kind);
+    if (!definition || !definition->resolve) {
+        return 0;
+    }
+
+    return definition->resolve(workspace, result);
+}
+
+int workspace_dialog_open_confirm_unsaved(Workspace* workspace, WorkspaceActionType pending_action)
+{
+    UiDialogPayload payload;
+
+    if (!workspace || pending_action == WORKSPACE_ACTION_NONE) {
+        return 0;
+    }
+
+    memset(&payload, 0, sizeof(payload));
+    payload.int_values[0] = (int)pending_action;
+    return workspace_dialog_open_definition(workspace,
+                                            &UI_DIALOG_DEFINITION_CONFIRM_UNSAVED,
+                                            &payload);
+}

--- a/src/input/input_router.c
+++ b/src/input/input_router.c
@@ -1,0 +1,54 @@
+/**
+ * @file input_router.c
+ * @brief Keyboard routing from modal/global/tool scopes into commands.
+ */
+#include <input/input_router.h>
+
+#include <app/command_registry.h>
+#include <app/workspace.h>
+#include <app/workspace_actions.h>
+#include <tools/tool.h>
+#include <tools/tool_controller.h>
+
+#include <GLFW/glfw3.h>
+
+int input_router_handle_key(const InputRouterContext* context, const KeyEvent* event)
+{
+    KeyChord chord;
+    KeyScope scope = KEY_SCOPE_GLOBAL;
+    const char* command_id = NULL;
+    const CommandDescriptor* descriptor = NULL;
+
+    if (!context || !context->workspace || !context->tool_context || !event ||
+        event->action != GLFW_PRESS) {
+        return 0;
+    }
+
+    if (workspace_modal_is_active(context->workspace)) {
+        scope = KEY_SCOPE_MODAL;
+    } else if (context->ui_has_keyboard_focus) {
+        return 0;
+    }
+
+    chord.key = event->key;
+    chord.mods = event->mods;
+    command_id = keymap_lookup_command(&context->workspace->keymap, scope, chord);
+    if (command_id) {
+        descriptor = command_registry_find_by_id(command_id);
+        if (descriptor) {
+            return command_registry_execute(context->workspace,
+                                            context->tool_context,
+                                            descriptor->command);
+        }
+    }
+
+    if (scope == KEY_SCOPE_MODAL) {
+        return 0;
+    }
+
+    tool_controller_key_down(&context->workspace->tools,
+                             context->tool_context,
+                             event->key,
+                             event->mods);
+    return 1;
+}

--- a/src/input/key_chord.c
+++ b/src/input/key_chord.c
@@ -1,0 +1,158 @@
+/**
+ * @file key_chord.c
+ * @brief Keyboard chord parsing and formatting helpers.
+ */
+#include <input/key_chord.h>
+
+#include <GLFW/glfw3.h>
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef struct NamedKey {
+    const char* name;
+    int key;
+} NamedKey;
+
+static const NamedKey g_named_keys[] = {
+    {"Enter", GLFW_KEY_ENTER},
+    {"Esc", GLFW_KEY_ESCAPE},
+    {"Escape", GLFW_KEY_ESCAPE},
+    {"Delete", GLFW_KEY_DELETE},
+    {"Backspace", GLFW_KEY_BACKSPACE},
+    {"Slash", GLFW_KEY_SLASH},
+    {"Plus", GLFW_KEY_EQUAL},
+    {"Minus", GLFW_KEY_MINUS},
+    {"0", GLFW_KEY_0},
+    {"A", GLFW_KEY_A},
+    {"C", GLFW_KEY_C},
+    {"E", GLFW_KEY_E},
+    {"H", GLFW_KEY_H},
+    {"L", GLFW_KEY_L},
+    {"N", GLFW_KEY_N},
+    {"O", GLFW_KEY_O},
+    {"R", GLFW_KEY_R},
+    {"S", GLFW_KEY_S},
+    {"V", GLFW_KEY_V},
+    {"X", GLFW_KEY_X},
+    {"Y", GLFW_KEY_Y},
+    {"Z", GLFW_KEY_Z}
+};
+
+static int key_chord_named_key_from_token(const char* token)
+{
+    size_t i = 0u;
+
+    for (i = 0u; i < sizeof(g_named_keys) / sizeof(g_named_keys[0]); ++i) {
+        if (strcmp(token, g_named_keys[i].name) == 0) {
+            return g_named_keys[i].key;
+        }
+    }
+
+    return GLFW_KEY_UNKNOWN;
+}
+
+static const char* key_chord_name_for_key(int key)
+{
+    size_t i = 0u;
+
+    for (i = 0u; i < sizeof(g_named_keys) / sizeof(g_named_keys[0]); ++i) {
+        if (g_named_keys[i].key == key) {
+            return g_named_keys[i].name;
+        }
+    }
+
+    return "";
+}
+
+KeyChord key_chord_none(void)
+{
+    KeyChord chord;
+    chord.key = GLFW_KEY_UNKNOWN;
+    chord.mods = 0;
+    return chord;
+}
+
+int key_chord_is_valid(KeyChord chord)
+{
+    return chord.key != GLFW_KEY_UNKNOWN;
+}
+
+int key_chord_equals(KeyChord a, KeyChord b)
+{
+    return a.key == b.key && a.mods == b.mods;
+}
+
+int key_chord_parse(const char* text, KeyChord* out_chord)
+{
+    char local[64];
+    char* token = NULL;
+    int key = GLFW_KEY_UNKNOWN;
+    int mods = 0;
+
+    if (!text || !out_chord || text[0] == '\0') {
+        return 0;
+    }
+
+    snprintf(local, sizeof(local), "%s", text);
+    token = strtok(local, "+");
+    while (token) {
+        if (strcmp(token, "Ctrl") == 0) {
+            mods |= GLFW_MOD_CONTROL;
+        } else if (strcmp(token, "Shift") == 0) {
+            mods |= GLFW_MOD_SHIFT;
+        } else if (strcmp(token, "Alt") == 0) {
+            mods |= GLFW_MOD_ALT;
+        } else {
+            key = key_chord_named_key_from_token(token);
+            if (key == GLFW_KEY_UNKNOWN &&
+                strlen(token) == 1u &&
+                isalpha((unsigned char)token[0])) {
+                key = GLFW_KEY_A + (toupper((unsigned char)token[0]) - 'A');
+            }
+        }
+        token = strtok(NULL, "+");
+    }
+
+    if (key == GLFW_KEY_UNKNOWN) {
+        return 0;
+    }
+
+    out_chord->key = key;
+    out_chord->mods = mods;
+    return 1;
+}
+
+void key_chord_format(KeyChord chord, char* buffer, size_t buffer_size)
+{
+    const char* key_name = NULL;
+    int wrote_prefix = 0;
+
+    if (!buffer || buffer_size == 0u) {
+        return;
+    }
+
+    buffer[0] = '\0';
+    if (!key_chord_is_valid(chord)) {
+        return;
+    }
+
+    if ((chord.mods & GLFW_MOD_CONTROL) != 0) {
+        snprintf(buffer + strlen(buffer), buffer_size - strlen(buffer), "%sCtrl", wrote_prefix ? "+" : "");
+        wrote_prefix = 1;
+    }
+    if ((chord.mods & GLFW_MOD_SHIFT) != 0) {
+        snprintf(buffer + strlen(buffer), buffer_size - strlen(buffer), "%sShift", wrote_prefix ? "+" : "");
+        wrote_prefix = 1;
+    }
+    if ((chord.mods & GLFW_MOD_ALT) != 0) {
+        snprintf(buffer + strlen(buffer), buffer_size - strlen(buffer), "%sAlt", wrote_prefix ? "+" : "");
+        wrote_prefix = 1;
+    }
+
+    key_name = key_chord_name_for_key(chord.key);
+    if (key_name[0] != '\0') {
+        snprintf(buffer + strlen(buffer), buffer_size - strlen(buffer), "%s%s", wrote_prefix ? "+" : "", key_name);
+    }
+}

--- a/src/input/keymap.c
+++ b/src/input/keymap.c
@@ -1,0 +1,159 @@
+/**
+ * @file keymap.c
+ * @brief Scope-aware keymap storage and shortcut formatting.
+ */
+#include <input/keymap.h>
+
+#include <app/command_registry.h>
+
+#include <stdio.h>
+#include <string.h>
+
+static const struct {
+    const char* command_id;
+    KeyScope scope;
+    const char* primary;
+    const char* secondary;
+} g_default_bindings[] = {
+    {"file.new", KEY_SCOPE_GLOBAL, "Ctrl+N", ""},
+    {"file.open", KEY_SCOPE_GLOBAL, "Ctrl+O", ""},
+    {"file.save", KEY_SCOPE_GLOBAL, "Ctrl+S", ""},
+    {"edit.undo", KEY_SCOPE_GLOBAL, "Ctrl+Z", ""},
+    {"edit.redo", KEY_SCOPE_GLOBAL, "Ctrl+Y", "Ctrl+Shift+Z"},
+    {"edit.delete", KEY_SCOPE_GLOBAL, "Delete", "Backspace"},
+    {"edit.select_all", KEY_SCOPE_GLOBAL, "Ctrl+A", ""},
+    {"view.zoom_in", KEY_SCOPE_GLOBAL, "Ctrl+Plus", ""},
+    {"view.zoom_out", KEY_SCOPE_GLOBAL, "Ctrl+Minus", ""},
+    {"view.zoom_fit", KEY_SCOPE_GLOBAL, "Ctrl+0", ""},
+    {"tool.select", KEY_SCOPE_GLOBAL, "V", ""},
+    {"tool.pan", KEY_SCOPE_GLOBAL, "H", ""},
+    {"tool.line", KEY_SCOPE_GLOBAL, "L", ""},
+    {"tool.rect", KEY_SCOPE_GLOBAL, "R", ""},
+    {"tool.ellipse", KEY_SCOPE_GLOBAL, "E", ""},
+    {"help.shortcuts", KEY_SCOPE_GLOBAL, "Shift+Slash", ""},
+    {"modal.confirm", KEY_SCOPE_MODAL, "Enter", ""},
+    {"modal.cancel", KEY_SCOPE_MODAL, "Esc", ""}
+};
+
+static int keymap_binding_matches(const KeyBinding* binding, KeyScope scope, KeyChord chord)
+{
+    if (!binding || binding->scope != scope || !binding->command_id) {
+        return 0;
+    }
+
+    return key_chord_equals(binding->primary, chord) ||
+           key_chord_equals(binding->secondary, chord);
+}
+
+static const KeyBinding* keymap_find_effective_binding(const EditorKeymap* keymap,
+                                                       const char* command_id,
+                                                       KeyScope scope)
+{
+    int i = 0;
+
+    if (!keymap || !command_id) {
+        return NULL;
+    }
+
+    for (i = 0; i < keymap->user_override_count; ++i) {
+        if (keymap->user_overrides[i].scope == scope &&
+            keymap->user_overrides[i].command_id &&
+            strcmp(keymap->user_overrides[i].command_id, command_id) == 0) {
+            return &keymap->user_overrides[i];
+        }
+    }
+
+    for (i = 0; i < keymap->default_count; ++i) {
+        if (keymap->defaults[i].scope == scope &&
+            keymap->defaults[i].command_id &&
+            strcmp(keymap->defaults[i].command_id, command_id) == 0) {
+            return &keymap->defaults[i];
+        }
+    }
+
+    return NULL;
+}
+
+void keymap_init(EditorKeymap* keymap, const char* settings_path)
+{
+    int i = 0;
+
+    if (!keymap) {
+        return;
+    }
+
+    memset(keymap, 0, sizeof(*keymap));
+    if (settings_path) {
+        snprintf(keymap->settings_path, sizeof(keymap->settings_path), "%s", settings_path);
+    }
+
+    for (i = 0; i < (int)(sizeof(g_default_bindings) / sizeof(g_default_bindings[0])); ++i) {
+        KeyBinding* binding = &keymap->defaults[keymap->default_count];
+        binding->command_id = g_default_bindings[i].command_id;
+        binding->scope = g_default_bindings[i].scope;
+        binding->primary = key_chord_none();
+        binding->secondary = key_chord_none();
+        key_chord_parse(g_default_bindings[i].primary, &binding->primary);
+        if (g_default_bindings[i].secondary[0] != '\0') {
+            key_chord_parse(g_default_bindings[i].secondary, &binding->secondary);
+        }
+        keymap->default_count++;
+    }
+}
+
+void keymap_shutdown(EditorKeymap* keymap)
+{
+    if (!keymap) {
+        return;
+    }
+
+    memset(keymap, 0, sizeof(*keymap));
+}
+
+const char* keymap_lookup_command(const EditorKeymap* keymap, KeyScope scope, KeyChord chord)
+{
+    int i = 0;
+
+    if (!keymap || !key_chord_is_valid(chord)) {
+        return NULL;
+    }
+
+    for (i = 0; i < keymap->user_override_count; ++i) {
+        if (keymap_binding_matches(&keymap->user_overrides[i], scope, chord)) {
+            return keymap->user_overrides[i].command_id;
+        }
+    }
+
+    for (i = 0; i < keymap->default_count; ++i) {
+        if (keymap_binding_matches(&keymap->defaults[i], scope, chord)) {
+            return keymap->defaults[i].command_id;
+        }
+    }
+
+    return NULL;
+}
+
+void keymap_format_command_shortcut(const EditorKeymap* keymap,
+                                    const char* command_id,
+                                    KeyScope scope,
+                                    char* buffer,
+                                    size_t buffer_size)
+{
+    const KeyBinding* binding = NULL;
+
+    if (!buffer || buffer_size == 0u) {
+        return;
+    }
+
+    buffer[0] = '\0';
+    if (!keymap || !command_id) {
+        return;
+    }
+
+    binding = keymap_find_effective_binding(keymap, command_id, scope);
+    if (!binding) {
+        return;
+    }
+
+    key_chord_format(binding->primary, buffer, buffer_size);
+}

--- a/src/tools/tool_controller.c
+++ b/src/tools/tool_controller.c
@@ -646,72 +646,13 @@ void tool_controller_pointer_up(ToolController* controller, ToolContext* context
     controller->last_world = event->world_pos;
 }
 
-/**
- * @brief Dispatch key-down to global shortcuts or active tool.
- * Why global-first:
- * - Undo/redo/delete/tool-switch shortcuts must be deterministic regardless of tool.
- */
+/** Dispatch key-down to the active tool only. */
 void tool_controller_key_down(ToolController* controller, ToolContext* context, int key, int mods)
 {
     Tool* tool = NULL;
 
     if (!controller) {
         return;
-    }
-
-    if ((mods & GLFW_MOD_CONTROL) != 0 &&
-        (mods & GLFW_MOD_SHIFT) != 0 &&
-        key == GLFW_KEY_Z) {
-        if (document_history_redo(context->history, context->document)) {
-            workspace_sync_document_dirty(context->workspace);
-        }
-        return;
-    }
-
-    switch (key) {
-    case GLFW_KEY_Z:
-        if ((mods & GLFW_MOD_CONTROL) != 0) {
-            if (document_history_undo(context->history, context->document)) {
-                workspace_sync_document_dirty(context->workspace);
-            }
-            return;
-        }
-        break;
-    case GLFW_KEY_Y:
-        if ((mods & GLFW_MOD_CONTROL) != 0) {
-            if (document_history_redo(context->history, context->document)) {
-                workspace_sync_document_dirty(context->workspace);
-            }
-            return;
-        }
-        break;
-    case GLFW_KEY_V:
-        tool_controller_set_active(controller, context, TOOL_KIND_SELECT);
-        return;
-    case GLFW_KEY_H:
-        tool_controller_set_active(controller, context, TOOL_KIND_PAN);
-        return;
-    case GLFW_KEY_L:
-        tool_controller_set_active(controller, context, TOOL_KIND_LINE);
-        return;
-    case GLFW_KEY_R:
-        tool_controller_set_active(controller, context, TOOL_KIND_RECT);
-        return;
-    case GLFW_KEY_E:
-        tool_controller_set_active(controller, context, TOOL_KIND_ELLIPSE);
-        return;
-    case GLFW_KEY_DELETE:
-    case GLFW_KEY_BACKSPACE:
-        if (context->document->selection.count > 0) {
-            DocumentSnapshot before_snapshot;
-            document_snapshot_init(&before_snapshot);
-            document_snapshot_capture(&before_snapshot, context->document);
-            document_delete_selection(context->document);
-            tool_commit_document_change(context, &before_snapshot);
-        }
-        return;
-    default:
-        break;
     }
 
     tool = tool_controller_get_active(controller);

--- a/src/ui/ui_dialog.c
+++ b/src/ui/ui_dialog.c
@@ -1,0 +1,86 @@
+/**
+ * @file ui_dialog.c
+ * @brief Reusable modal dialog rendering.
+ */
+#include <ui/ui_dialog.h>
+
+#define NK_INCLUDE_FIXED_TYPES
+#define NK_INCLUDE_STANDARD_IO
+#define NK_INCLUDE_STANDARD_VARARGS
+#define NK_INCLUDE_DEFAULT_ALLOCATOR
+
+#include "nuklear/nuklear.h"
+
+UiDialogResult ui_dialog_show(struct nk_context* ctx,
+                              const UiDialogState* dialog,
+                              int window_width,
+                              int window_height)
+{
+    struct nk_style_item blocker_background;
+    struct nk_rect bounds;
+    float dialog_width = 0.0f;
+    float dialog_height = 0.0f;
+    UiDialogResult result = UI_DIALOG_RESULT_NONE;
+    int i = 0;
+
+    if (!ctx || !dialog || dialog->kind == UI_DIALOG_NONE) {
+        return UI_DIALOG_RESULT_NONE;
+    }
+
+    dialog_width = (dialog->width > 0.0f) ? dialog->width : 360.0f;
+    dialog_height = (dialog->height > 0.0f) ? dialog->height : 170.0f;
+    if ((float)window_width < dialog_width + 24.0f) {
+        dialog_width = (float)window_width - 24.0f;
+    }
+    if ((float)window_height < dialog_height + 24.0f) {
+        dialog_height = (float)window_height - 24.0f;
+    }
+    if (dialog_width < 240.0f) {
+        dialog_width = 240.0f;
+    }
+    if (dialog_height < 140.0f) {
+        dialog_height = 140.0f;
+    }
+
+    bounds = nk_rect(((float)window_width - dialog_width) * 0.5f,
+                     ((float)window_height - dialog_height) * 0.5f,
+                     dialog_width,
+                     dialog_height);
+
+    if (dialog->modal) {
+        blocker_background = nk_style_item_color(nk_rgba(0, 0, 0, 96));
+        nk_style_push_style_item(ctx, &ctx->style.window.fixed_background, blocker_background);
+        if (nk_begin(ctx,
+                     "##modal_blocker##",
+                     nk_rect(0.0f, 0.0f, (float)window_width, (float)window_height),
+                     NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND)) {
+            nk_layout_row_dynamic(ctx, 1.0f, 1);
+            nk_label(ctx, "", NK_TEXT_LEFT);
+        }
+        nk_end(ctx);
+        nk_style_pop_style_item(ctx);
+    }
+
+    if (nk_begin(ctx,
+                 dialog->title[0] != '\0' ? dialog->title : "Dialog",
+                 bounds,
+                 NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_TITLE)) {
+        if (dialog->message[0] != '\0') {
+            nk_layout_row_dynamic(ctx, 48.0f, 1);
+            nk_label_wrap(ctx, dialog->message);
+        }
+        nk_layout_row_dynamic(ctx, 12.0f, 1);
+        nk_label(ctx, "", NK_TEXT_LEFT);
+        if (dialog->button_count > 0) {
+            nk_layout_row_dynamic(ctx, 34.0f, dialog->button_count);
+            for (i = 0; i < dialog->button_count; ++i) {
+                if (nk_button_label(ctx, dialog->buttons[i].label)) {
+                    result = dialog->buttons[i].result;
+                }
+            }
+        }
+    }
+    nk_end(ctx);
+
+    return result;
+}

--- a/src/ui/ui_menu_actions.c
+++ b/src/ui/ui_menu_actions.c
@@ -3,125 +3,18 @@
  * @brief Menu action dispatch implementation.
  *
  * Role in project:
- * - Maps menu IDs to workspace/document/canvas operations.
- * - Centralizes shortcut-equivalent command behavior.
- *
- * Module relationships:
- * - Called by menu bar and application shortcut handling.
- * - Uses workspace callbacks for save/load and document/history APIs for edits.
+ * - Bridges menu IDs into stable editor commands.
+ * - Keeps menu handling thin by delegating business logic to the command registry.
  */
 #include "ui_menu_actions.h"
 
-#include <app/workspace_actions.h>
+#include <app/command_registry.h>
 #include <app/workspace.h>
 #include <base/log.h>
-#include <base/math2d.h>
-#include <canvas/canvas_view.h>
-#include <document/document.h>
-#include <document/history.h>
-
-static void app_zoom_to_fit(Workspace* workspace)
-{
-    if (!workspace || !workspace->canvas.document) {
-        return;
-    }
-
-    Document* doc = &workspace->document;
-    CanvasView* canvas = &workspace->canvas;
-
-    if (doc->count == 0) {
-        /* No objects, reset to default view */
-        canvas_view_set_center_zoom(canvas, vec2_make(0.0f, 0.0f), 1.0f);
-        return;
-    }
-
-    float min_x = 0.0f, max_x = 0.0f, min_y = 0.0f, max_y = 0.0f;
-    int first = 1;
-
-    for (int i = 0; i < doc->count; i++) {
-        GraphicObject* obj = doc->objects[i];
-        if (!obj) continue;
-
-        RectF bounds = object_get_bounds(obj);
-        if (first) {
-            min_x = bounds.x;
-            max_x = bounds.x + bounds.w;
-            min_y = bounds.y;
-            max_y = bounds.y + bounds.h;
-            first = 0;
-        } else {
-            if (bounds.x < min_x) min_x = bounds.x;
-            if (bounds.y < min_y) min_y = bounds.y;
-            if (bounds.x + bounds.w > max_x) max_x = bounds.x + bounds.w;
-            if (bounds.y + bounds.h > max_y) max_y = bounds.y + bounds.h;
-        }
-    }
-
-    if (first) {
-        return;
-    }
-
-    float pad = 50.0f;
-    min_x -= pad;
-    min_y -= pad;
-    max_x += pad;
-    max_y += pad;
-
-    float content_w = max_x - min_x;
-    float content_h = max_y - min_y;
-
-    /* Calculate zoom to fit */
-    RectF canvas_viewport = canvas_view_viewport(canvas);
-    float zoom_x = canvas_viewport.w / content_w;
-    float zoom_y = canvas_viewport.h / content_h;
-    float new_zoom = (zoom_x < zoom_y) ? zoom_x : zoom_y;
-
-    new_zoom = (new_zoom < 0.1f) ? 0.1f : (new_zoom > 12.0f) ? 12.0f : new_zoom;
-
-    /* Set new zoom and center */
-    canvas_view_set_center_zoom(canvas,
-                                vec2_make((min_x + max_x) * 0.5f, (min_y + max_y) * 0.5f),
-                                new_zoom);
-}
-
-static void app_toggle_grid(Workspace* workspace)
-{
-    if (!workspace) {
-        return;
-    }
-    workspace->canvas.show_grid = !workspace->canvas.show_grid;
-}
-
-static void app_toggle_inspector(Workspace* workspace)
-{
-    (void)workspace;
-    LOG_INFO("%s", "Inspector panel toggled");
-}
-
-static void app_show_shortcuts(Workspace* workspace)
-{
-    (void)workspace;
-    LOG_INFO("%s", "Keyboard shortcuts dialog requested");
-}
-
-static void app_show_about(Workspace* workspace)
-{
-    (void)workspace;
-    LOG_INFO("%s", "About dialog requested");
-}
-
-static int app_save_as(Workspace* workspace)
-{
-    if (workspace->save_document) {
-        return workspace->save_document(workspace, workspace->command_user_data);
-    }
-    return 0;
-}
 
 static int app_export_png(Workspace* workspace)
 {
     (void)workspace;
-    // TODO: Implement PNG export via framebuffer capture
     LOG_INFO("%s", "Export PNG requested");
     return 0;
 }
@@ -130,7 +23,6 @@ int ui_menu_is_action_available(MenuId id)
 {
     switch (id) {
     case MENU_ID_FILE_EXPORT_PNG:
-    case MENU_ID_EDIT_DELETE:
     case MENU_ID_EDIT_CUT:
     case MENU_ID_EDIT_COPY:
     case MENU_ID_EDIT_PASTE:
@@ -142,106 +34,26 @@ int ui_menu_is_action_available(MenuId id)
 
 void ui_menu_execute(Workspace* workspace, MenuId id)
 {
+    const CommandDescriptor* descriptor = NULL;
+
     if (!workspace) {
         return;
     }
 
-    switch (id) {
-    /* File menu */
-    case MENU_ID_FILE_NEW:
-        workspace_request_action(workspace, WORKSPACE_ACTION_NEW_DOCUMENT);
-        break;
-
-    case MENU_ID_FILE_OPEN:
-        workspace_request_action(workspace, WORKSPACE_ACTION_OPEN_DOCUMENT);
-        break;
-
-    case MENU_ID_FILE_SAVE:
-        if (workspace->save_document) {
-            workspace->save_document(workspace, workspace->command_user_data);
-        }
-        break;
-
-    case MENU_ID_FILE_SAVE_AS:
-        app_save_as(workspace);
-        break;
-
-    case MENU_ID_FILE_EXPORT_PNG:
+    if (id == MENU_ID_FILE_EXPORT_PNG) {
         app_export_png(workspace);
-        break;
-
-    case MENU_ID_FILE_EXIT:
-        workspace_request_action(workspace, WORKSPACE_ACTION_EXIT_APPLICATION);
-        break;
-
-    /* Edit menu */
-    case MENU_ID_EDIT_UNDO:
-        if (document_history_undo(&workspace->history, &workspace->document)) {
-            workspace_sync_document_dirty(workspace);
-        }
-        break;
-
-    case MENU_ID_EDIT_REDO:
-        if (document_history_redo(&workspace->history, &workspace->document)) {
-            workspace_sync_document_dirty(workspace);
-        }
-        break;
-
-    case MENU_ID_EDIT_SELECT_ALL:
-        for (int i = 0; i < workspace->document.count; i++) {
-            document_selection_add(&workspace->document,
-                                   workspace->document.objects[i]->id);
-        }
-        break;
-
-    case MENU_ID_EDIT_DELETE:
-    case MENU_ID_EDIT_CUT:
-    case MENU_ID_EDIT_COPY:
-    case MENU_ID_EDIT_PASTE:
-        // TODO: cut/copy/paste/delete operations not yet implemented
+        return;
+    }
+    if (id == MENU_ID_EDIT_CUT || id == MENU_ID_EDIT_COPY || id == MENU_ID_EDIT_PASTE) {
         LOG_INFO("Menu action %d not yet implemented", id);
-        break;
-
-    /* View menu */
-    case MENU_ID_VIEW_ZOOM_IN:
-    {
-        Vec2 center = canvas_view_center(&workspace->canvas);
-        canvas_view_zoom_at_screen_point(&workspace->canvas, 1.25f,
-                                         canvas_view_world_to_screen(&workspace->canvas, center));
-        break;
+        return;
     }
 
-    case MENU_ID_VIEW_ZOOM_OUT:
-    {
-        Vec2 center = canvas_view_center(&workspace->canvas);
-        canvas_view_zoom_at_screen_point(&workspace->canvas, 0.8f,
-                                         canvas_view_world_to_screen(&workspace->canvas, center));
-        break;
-    }
-
-    case MENU_ID_VIEW_ZOOM_FIT:
-        app_zoom_to_fit(workspace);
-        break;
-
-    case MENU_ID_VIEW_TOGGLE_GRID:
-        app_toggle_grid(workspace);
-        break;
-
-    case MENU_ID_VIEW_TOGGLE_INSPECTOR:
-        app_toggle_inspector(workspace);
-        break;
-
-    /* Help menu */
-    case MENU_ID_HELP_SHORTCUTS:
-        app_show_shortcuts(workspace);
-        break;
-
-    case MENU_ID_HELP_ABOUT:
-        app_show_about(workspace);
-        break;
-
-    default:
+    descriptor = command_registry_find_by_menu_id((int)id);
+    if (!descriptor) {
         LOG_WARN("Unknown menu action: %d", id);
-        break;
+        return;
     }
+
+    command_registry_execute(workspace, NULL, descriptor->command);
 }

--- a/src/ui/ui_menu_actions.c
+++ b/src/ui/ui_menu_actions.c
@@ -12,40 +12,13 @@
  */
 #include "ui_menu_actions.h"
 
+#include <app/workspace_actions.h>
 #include <app/workspace.h>
 #include <base/log.h>
 #include <base/math2d.h>
 #include <canvas/canvas_view.h>
 #include <document/document.h>
 #include <document/history.h>
-#include <platform/window.h>
-
-#include <GLFW/glfw3.h>
-
-static void app_workspace_new(Workspace* workspace)
-{
-    if (!workspace) {
-        return;
-    }
-
-    document_reset(&workspace->document);
-
-    document_history_shutdown(&workspace->history);
-    if (!document_history_init(&workspace->history)) {
-        LOG_ERROR("%s", "Failed to reinitialize history");
-        return;
-    }
-
-    /* Reset canvas zoom and center */
-    canvas_view_set_center_zoom(&workspace->canvas, vec2_make(0.0f, 0.0f), 1.0f);
-
-    workspace->current_document_path[0] = '\0';
-
-    workspace->saved_revision = workspace->document.revision;
-    workspace->document_dirty = 0;
-
-    LOG_INFO("%s", "Created new document");
-}
 
 static void app_zoom_to_fit(Workspace* workspace)
 {
@@ -176,13 +149,11 @@ void ui_menu_execute(Workspace* workspace, MenuId id)
     switch (id) {
     /* File menu */
     case MENU_ID_FILE_NEW:
-        app_workspace_new(workspace);
+        workspace_request_action(workspace, WORKSPACE_ACTION_NEW_DOCUMENT);
         break;
 
     case MENU_ID_FILE_OPEN:
-        if (workspace->load_document) {
-            workspace->load_document(workspace, workspace->command_user_data);
-        }
+        workspace_request_action(workspace, WORKSPACE_ACTION_OPEN_DOCUMENT);
         break;
 
     case MENU_ID_FILE_SAVE:
@@ -200,7 +171,7 @@ void ui_menu_execute(Workspace* workspace, MenuId id)
         break;
 
     case MENU_ID_FILE_EXIT:
-        glfwSetWindowShouldClose(glfwGetCurrentContext(), GLFW_TRUE);
+        workspace_request_action(workspace, WORKSPACE_ACTION_EXIT_APPLICATION);
         break;
 
     /* Edit menu */

--- a/src/ui/ui_menubar.c
+++ b/src/ui/ui_menubar.c
@@ -15,6 +15,7 @@
 #include "ui_menu_def.h"
 #include "ui_menu_actions.h"
 
+#include <app/command_registry.h>
 #include <app/workspace.h>
 
 #include <glad/glad.h>
@@ -57,27 +58,38 @@ typedef struct UiQuickActionDef {
     const char* label;
     MenuId menu_id;
     float width;
-    const char* tooltip;
 } UiQuickActionDef;
 
 static const UiQuickActionDef g_quick_actions[] = {
-    { "New", MENU_ID_FILE_NEW, 48.0f, "Create new document (Ctrl+N)" },
-    { "Open", MENU_ID_FILE_OPEN, 52.0f, "Open document (Ctrl+O)" },
-    { "Save", MENU_ID_FILE_SAVE, 52.0f, "Save document (Ctrl+S)" },
-    { "Undo", MENU_ID_EDIT_UNDO, 52.0f, "Undo (Ctrl+Z)" },
-    { "Redo", MENU_ID_EDIT_REDO, 52.0f, "Redo (Ctrl+Y)" },
-    { "+", MENU_ID_VIEW_ZOOM_IN, 30.0f, "Zoom in (Ctrl++)" },
-    { "-", MENU_ID_VIEW_ZOOM_OUT, 30.0f, "Zoom out (Ctrl+-)" },
-    { "Fit", MENU_ID_VIEW_ZOOM_FIT, 40.0f, "Zoom to fit (Ctrl+0)" },
+    { "New", MENU_ID_FILE_NEW, 48.0f },
+    { "Open", MENU_ID_FILE_OPEN, 52.0f },
+    { "Save", MENU_ID_FILE_SAVE, 52.0f },
+    { "Undo", MENU_ID_EDIT_UNDO, 52.0f },
+    { "Redo", MENU_ID_EDIT_REDO, 52.0f },
+    { "+", MENU_ID_VIEW_ZOOM_IN, 30.0f },
+    { "-", MENU_ID_VIEW_ZOOM_OUT, 30.0f },
+    { "Fit", MENU_ID_VIEW_ZOOM_FIT, 40.0f },
 };
 
-static void ui_build_menu_item_text(char* out_text, size_t out_size, const MenuItemDef* item)
+static void ui_build_menu_item_text(const Workspace* workspace,
+                                    char* out_text,
+                                    size_t out_size,
+                                    const MenuItemDef* item)
 {
+    char shortcut[64];
+
     if (!out_text || out_size == 0 || !item || !item->label) {
         return;
     }
 
-    if (item->shortcut && item->shortcut[0] != '\0') {
+    shortcut[0] = '\0';
+    if (workspace && item->type == MENU_ITEM_ACTION) {
+        command_registry_format_menu_shortcut(workspace, item->id, shortcut, sizeof(shortcut));
+    }
+
+    if (shortcut[0] != '\0') {
+        snprintf(out_text, out_size, "%-20s %s", item->label, shortcut);
+    } else if (item->shortcut && item->shortcut[0] != '\0') {
         snprintf(out_text, out_size, "%-20s %s", item->label, item->shortcut);
     } else {
         snprintf(out_text, out_size, "%s", item->label);
@@ -246,7 +258,7 @@ int ui_menubar_take_theme_reload_request(UiMenuBar* menubar)
  * @param parent_id [in] Parent menu ID to render children for.
  * @return Clicked menu item ID, or `-1` if no item was clicked.
  */
-static int ui_render_dropdown(struct nk_context* ctx, int parent_id)
+static int ui_render_dropdown(struct nk_context* ctx, Workspace* workspace, int parent_id)
 {
     int clicked_id = -1;
     const MenuItemDef* items = ui_menu_def_items();
@@ -276,7 +288,7 @@ static int ui_render_dropdown(struct nk_context* ctx, int parent_id)
             char menu_text[96];
             int enabled = ui_menu_is_action_available((MenuId)item->id);
 
-            ui_build_menu_item_text(menu_text, sizeof(menu_text), item);
+            ui_build_menu_item_text(workspace, menu_text, sizeof(menu_text), item);
 
             if (!enabled) {
                 nk_widget_disable_begin(ctx);
@@ -333,7 +345,7 @@ static int ui_render_theme_dropdown(UiMenuBar* menubar)
     return -1;
 }
 
-static int ui_render_top_menu(UiMenuBar* menubar, const UiTopMenuDef* menu)
+static int ui_render_top_menu(UiMenuBar* menubar, Workspace* workspace, const UiTopMenuDef* menu)
 {
     struct nk_context* ctx = NULL;
     int clicked_id = -1;
@@ -354,7 +366,7 @@ static int ui_render_top_menu(UiMenuBar* menubar, const UiTopMenuDef* menu)
                 menubar->requested_theme_index = theme_index;
             }
         } else {
-            clicked_id = ui_render_dropdown(ctx, menu->parent_id);
+            clicked_id = ui_render_dropdown(ctx, workspace, menu->parent_id);
         }
         nk_menu_end(ctx);
     }
@@ -429,7 +441,7 @@ void ui_menubar_build(UiMenuBar* menubar, Workspace* workspace, int window_width
         for (size_t i = 0; i < menu_count; i++) {
             int id;
             nk_layout_row_push(ctx, g_top_menus[i].item_width);
-            id = ui_render_top_menu(menubar, &g_top_menus[i]);
+            id = ui_render_top_menu(menubar, workspace, &g_top_menus[i]);
             if (id != -1) {
                 clicked_id = id;
             }
@@ -439,6 +451,8 @@ void ui_menubar_build(UiMenuBar* menubar, Workspace* workspace, int window_width
         nk_label(ctx, "", NK_TEXT_LEFT);
 
         for (size_t i = 0; i < quick_count; i++) {
+            char tooltip[96];
+            char shortcut[64];
             struct nk_rect widget_bounds;
             int enabled = ui_menu_is_action_available(g_quick_actions[i].menu_id);
             int hovered = 0;
@@ -451,10 +465,19 @@ void ui_menubar_build(UiMenuBar* menubar, Workspace* workspace, int window_width
                 clicked_id = g_quick_actions[i].menu_id;
             }
             hovered = nk_input_is_mouse_hovering_rect(&ctx->input, widget_bounds);
-            if (g_quick_actions[i].tooltip &&
-                g_quick_actions[i].tooltip[0] != '\0' &&
-                hovered) {
-                nk_tooltip(ctx, g_quick_actions[i].tooltip);
+            tooltip[0] = '\0';
+            shortcut[0] = '\0';
+            command_registry_format_menu_shortcut(workspace,
+                                                  g_quick_actions[i].menu_id,
+                                                  shortcut,
+                                                  sizeof(shortcut));
+            if (shortcut[0] != '\0') {
+                snprintf(tooltip, sizeof(tooltip), "%s (%s)", g_quick_actions[i].label, shortcut);
+            } else {
+                snprintf(tooltip, sizeof(tooltip), "%s", g_quick_actions[i].label);
+            }
+            if (hovered) {
+                nk_tooltip(ctx, tooltip);
             }
             if (!enabled) {
                 nk_widget_disable_end(ctx);

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -11,6 +11,7 @@
  * - Cooperates with application input loop and theme subsystem.
  */
 #include <ui/ui_menubar.h>
+#include <ui/ui_dialog.h>
 #include <ui/ui_system.h>
 
 #include <app/workspace.h>
@@ -705,104 +706,20 @@ static void ui_status_bar(UiSystem *ui, Workspace *workspace, int window_width,
   nk_end(ctx);
 }
 
-/** Render a centered modal dialog for active workspace confirmation flows. */
+/** Render active reusable workspace dialogs and route the result back into workspace state. */
 static void ui_modal_dialogs(UiSystem *ui, Workspace *workspace,
                              int window_width, int window_height) {
-  struct nk_context *ctx = NULL;
-  struct nk_style_item blocker_background;
-  struct nk_rect modal_bounds;
-  float modal_width = 360.0f;
-  float modal_height = 170.0f;
-  const char *title = NULL;
-  const char *message = NULL;
-  const char *line_break = NULL;
-  char line_one[128];
-  char line_two[128];
-  size_t line_one_length = 0u;
+  UiDialogResult result = UI_DIALOG_RESULT_NONE;
 
-  if (!ui || !workspace || !workspace_modal_is_active(workspace)) {
+  if (!ui || !workspace || !workspace_modal_is_active(workspace) || !ui->ctx) {
     return;
   }
 
-  ctx = ui->ctx;
-  if (!ctx) {
-    return;
+  result =
+      ui_dialog_show(ui->ctx, &workspace->active_dialog, window_width, window_height);
+  if (result != UI_DIALOG_RESULT_NONE) {
+    workspace_resolve_active_dialog(workspace, result);
   }
-
-  if ((float)window_width < modal_width + 24.0f) {
-    modal_width = (float)window_width - 24.0f;
-  }
-  if ((float)window_height < modal_height + 24.0f) {
-    modal_height = (float)window_height - 24.0f;
-  }
-  if (modal_width < 240.0f) {
-    modal_width = 240.0f;
-  }
-  if (modal_height < 140.0f) {
-    modal_height = 140.0f;
-  }
-
-  modal_bounds = nk_rect(((float)window_width - modal_width) * 0.5f,
-                         ((float)window_height - modal_height) * 0.5f,
-                         modal_width, modal_height);
-
-  title = workspace_modal_title(workspace);
-  message = workspace_modal_message(workspace);
-  line_one[0] = '\0';
-  line_two[0] = '\0';
-
-  if (message) {
-    line_break = strchr(message, '\n');
-    if (line_break) {
-      line_one_length = (size_t)(line_break - message);
-      if (line_one_length >= sizeof(line_one)) {
-        line_one_length = sizeof(line_one) - 1u;
-      }
-      memcpy(line_one, message, line_one_length);
-      line_one[line_one_length] = '\0';
-      snprintf(line_two, sizeof(line_two), "%s", line_break + 1);
-    } else {
-      snprintf(line_one, sizeof(line_one), "%s", message);
-    }
-  }
-
-  blocker_background = nk_style_item_color(nk_rgba(0, 0, 0, 96));
-  nk_style_push_style_item(ctx, &ctx->style.window.fixed_background,
-                           blocker_background);
-  if (nk_begin(ctx, "##modal_blocker##",
-               nk_rect(0.0f, 0.0f, (float)window_width, (float)window_height),
-               NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND)) {
-    nk_layout_row_dynamic(ctx, 1.0f, 1);
-    nk_label(ctx, "", NK_TEXT_LEFT);
-  }
-  nk_end(ctx);
-  nk_style_pop_style_item(ctx);
-
-  if (nk_begin(ctx, title && title[0] != '\0' ? title : "Modal", modal_bounds,
-               NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_TITLE)) {
-    nk_layout_row_dynamic(ctx, 22.0f, 1);
-    if (line_one[0] != '\0') {
-      nk_label(ctx, line_one, NK_TEXT_LEFT);
-    }
-    if (line_two[0] != '\0') {
-      nk_label(ctx, line_two, NK_TEXT_LEFT);
-    }
-
-    nk_layout_row_dynamic(ctx, 12.0f, 1);
-    nk_label(ctx, "", NK_TEXT_LEFT);
-
-    nk_layout_row_dynamic(ctx, 34.0f, 3);
-    if (nk_button_label(ctx, "Save")) {
-      workspace_confirm_pending_action_save(workspace);
-    }
-    if (nk_button_label(ctx, "Don't Save")) {
-      workspace_confirm_pending_action_discard(workspace);
-    }
-    if (nk_button_label(ctx, "Cancel")) {
-      workspace_confirm_pending_action_cancel(workspace);
-    }
-  }
-  nk_end(ctx);
 }
 
 UiSystem *ui_system_create(PlatformWindow *window) {

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -10,17 +10,17 @@
  * - Uses workspace/document/tools for editable UI actions.
  * - Cooperates with application input loop and theme subsystem.
  */
-#include <ui/ui_system.h>
 #include <ui/ui_menubar.h>
+#include <ui/ui_system.h>
 
-#include <app/workspace_actions.h>
 #include <app/workspace.h>
+#include <app/workspace_actions.h>
 #include <base/math2d.h>
 #include <canvas/canvas_view.h>
 #include <document/document.h>
 #include <document/history.h>
-#include <tools/tool_controller.h>
 #include <glad/glad.h>
+#include <tools/tool_controller.h>
 
 #define NK_INCLUDE_FIXED_TYPES
 #define NK_INCLUDE_STANDARD_IO
@@ -52,1054 +52,1062 @@
 #define UI_THEME_WATCH_INTERVAL_SECONDS 0.35
 
 struct UiSystem {
-    struct nk_glfw glfw;
-    struct nk_context* ctx;
-    GLFWwindow* window_handle;
-    UiMenuBar* menu_bar;
-    UiThemeTokens theme;
-    char active_theme_id[UI_THEME_ID_CAPACITY];
-    char theme_settings_path[260];
-    UiThemeDescriptor theme_descriptors_cache[UI_THEME_DESCRIPTOR_CACHE_MAX];
-    unsigned long long theme_directory_signature;
-    double theme_watch_last_check_seconds;
-    RectF appbar_bounds;
-    RectF rail_bounds;
-    RectF panel_bounds;
-    RectF status_bounds;
-    RectF content_bounds;
-    WorkspaceLayout layout_snapshot;
-    float inspector_anim_t;
-    int inspector_target_visible;
-    int inspector_anim_initialized;
-    int modal_active;
-    double last_frame_seconds;
+  struct nk_glfw glfw;
+  struct nk_context *ctx;
+  GLFWwindow *window_handle;
+  UiMenuBar *menu_bar;
+  UiThemeTokens theme;
+  char active_theme_id[UI_THEME_ID_CAPACITY];
+  char theme_settings_path[260];
+  UiThemeDescriptor theme_descriptors_cache[UI_THEME_DESCRIPTOR_CACHE_MAX];
+  unsigned long long theme_directory_signature;
+  double theme_watch_last_check_seconds;
+  RectF appbar_bounds;
+  RectF rail_bounds;
+  RectF panel_bounds;
+  RectF status_bounds;
+  RectF content_bounds;
+  WorkspaceLayout layout_snapshot;
+  float inspector_anim_t;
+  int inspector_target_visible;
+  int inspector_anim_initialized;
+  int modal_active;
+  double last_frame_seconds;
 };
 
 typedef enum UiThemeReloadReason {
-    UI_THEME_RELOAD_REASON_STARTUP = 0,
-    UI_THEME_RELOAD_REASON_AUTO,
-    UI_THEME_RELOAD_REASON_MANUAL
+  UI_THEME_RELOAD_REASON_STARTUP = 0,
+  UI_THEME_RELOAD_REASON_AUTO,
+  UI_THEME_RELOAD_REASON_MANUAL
 } UiThemeReloadReason;
 
-static float ui_clampf(float value, float min_value, float max_value)
-{
-    if (value < min_value) {
-        return min_value;
-    }
-    if (value > max_value) {
-        return max_value;
-    }
-    return value;
+static float ui_clampf(float value, float min_value, float max_value) {
+  if (value < min_value) {
+    return min_value;
+  }
+  if (value > max_value) {
+    return max_value;
+  }
+  return value;
 }
 
-static const char* ui_theme_reload_reason_label(UiThemeReloadReason reason)
-{
-    switch (reason) {
-    case UI_THEME_RELOAD_REASON_MANUAL:
-        return "manually";
-    case UI_THEME_RELOAD_REASON_AUTO:
-        return "auto";
-    case UI_THEME_RELOAD_REASON_STARTUP:
-    default:
-        return "startup";
-    }
+static const char *ui_theme_reload_reason_label(UiThemeReloadReason reason) {
+  switch (reason) {
+  case UI_THEME_RELOAD_REASON_MANUAL:
+    return "manually";
+  case UI_THEME_RELOAD_REASON_AUTO:
+    return "auto";
+  case UI_THEME_RELOAD_REASON_STARTUP:
+  default:
+    return "startup";
+  }
 }
 
-static void ui_system_sync_menubar_themes(UiSystem* ui)
-{
-    int theme_count = 0;
-    int active_theme_index = 0;
+static void ui_system_sync_menubar_themes(UiSystem *ui) {
+  int theme_count = 0;
+  int active_theme_index = 0;
 
-    if (!ui || !ui->menu_bar) {
-        return;
-    }
+  if (!ui || !ui->menu_bar) {
+    return;
+  }
 
-    theme_count = ui_theme_count();
-    if (theme_count < 0) {
-        theme_count = 0;
-    }
-    if (theme_count > UI_THEME_DESCRIPTOR_CACHE_MAX) {
-        theme_count = UI_THEME_DESCRIPTOR_CACHE_MAX;
-    }
+  theme_count = ui_theme_count();
+  if (theme_count < 0) {
+    theme_count = 0;
+  }
+  if (theme_count > UI_THEME_DESCRIPTOR_CACHE_MAX) {
+    theme_count = UI_THEME_DESCRIPTOR_CACHE_MAX;
+  }
 
-    for (int i = 0; i < theme_count; ++i) {
-        const UiThemeDescriptor* descriptor = ui_theme_descriptor_at(i);
-        ui->theme_descriptors_cache[i].id = descriptor ? descriptor->id : "";
-        ui->theme_descriptors_cache[i].label = descriptor ? descriptor->label : "";
-    }
+  for (int i = 0; i < theme_count; ++i) {
+    const UiThemeDescriptor *descriptor = ui_theme_descriptor_at(i);
+    ui->theme_descriptors_cache[i].id = descriptor ? descriptor->id : "";
+    ui->theme_descriptors_cache[i].label = descriptor ? descriptor->label : "";
+  }
 
-    ui_menubar_set_themes(ui->menu_bar, ui->theme_descriptors_cache, theme_count);
+  ui_menubar_set_themes(ui->menu_bar, ui->theme_descriptors_cache, theme_count);
 
-    active_theme_index = ui_theme_index_of_id(ui->active_theme_id);
-    if (active_theme_index < 0 || active_theme_index >= theme_count) {
-        active_theme_index = ui_theme_index_of_id(ui_theme_default_id());
-    }
-    if (active_theme_index < 0) {
-        active_theme_index = 0;
-    }
-    ui_menubar_set_active_theme_index(ui->menu_bar, active_theme_index);
+  active_theme_index = ui_theme_index_of_id(ui->active_theme_id);
+  if (active_theme_index < 0 || active_theme_index >= theme_count) {
+    active_theme_index = ui_theme_index_of_id(ui_theme_default_id());
+  }
+  if (active_theme_index < 0) {
+    active_theme_index = 0;
+  }
+  ui_menubar_set_active_theme_index(ui->menu_bar, active_theme_index);
 }
 
-static int ui_system_set_theme(UiSystem* ui, const char* theme_id, int persist_selection)
-{
-    int theme_index = -1;
-    const UiThemeDescriptor* descriptor = NULL;
+static int ui_system_set_theme(UiSystem *ui, const char *theme_id,
+                               int persist_selection) {
+  int theme_index = -1;
+  const UiThemeDescriptor *descriptor = NULL;
 
-    if (!ui || !ui->ctx) {
-        return 0;
-    }
+  if (!ui || !ui->ctx) {
+    return 0;
+  }
 
-    theme_index = ui_theme_index_of_id(theme_id);
-    if (theme_index < 0) {
-        theme_index = ui_theme_index_of_id(ui_theme_default_id());
-    }
-    descriptor = ui_theme_descriptor_at(theme_index);
-    if (!descriptor || !descriptor->id) {
-        return 0;
-    }
+  theme_index = ui_theme_index_of_id(theme_id);
+  if (theme_index < 0) {
+    theme_index = ui_theme_index_of_id(ui_theme_default_id());
+  }
+  descriptor = ui_theme_descriptor_at(theme_index);
+  if (!descriptor || !descriptor->id) {
+    return 0;
+  }
 
-    snprintf(ui->active_theme_id,
-             sizeof(ui->active_theme_id),
-             "%s",
-             descriptor->id);
+  snprintf(ui->active_theme_id, sizeof(ui->active_theme_id), "%s",
+           descriptor->id);
 
-    ui->theme = ui_theme_tokens_for_id(ui->active_theme_id);
-    ui_theme_apply(ui->ctx, &ui->theme);
+  ui->theme = ui_theme_tokens_for_id(ui->active_theme_id);
+  ui_theme_apply(ui->ctx, &ui->theme);
 
-    if (ui->menu_bar) {
-        ui_menubar_set_height(ui->menu_bar, ui->theme.menu_height);
-        ui_system_sync_menubar_themes(ui);
-    }
+  if (ui->menu_bar) {
+    ui_menubar_set_height(ui->menu_bar, ui->theme.menu_height);
+    ui_system_sync_menubar_themes(ui);
+  }
 
-    if (persist_selection) {
-        ui_theme_save_selected_id(ui->theme_settings_path, ui->active_theme_id);
-    }
+  if (persist_selection) {
+    ui_theme_save_selected_id(ui->theme_settings_path, ui->active_theme_id);
+  }
 
-    return 1;
+  return 1;
 }
 
-static void ui_system_reload_themes(UiSystem* ui,
-                                    Workspace* workspace,
+static void ui_system_reload_themes(UiSystem *ui, Workspace *workspace,
                                     int notify_status,
-                                    UiThemeReloadReason reason)
-{
-    char previous_theme_id[UI_THEME_ID_CAPACITY];
-    int custom_theme_count = 0;
-    int fallback_to_default = 0;
+                                    UiThemeReloadReason reason) {
+  char previous_theme_id[UI_THEME_ID_CAPACITY];
+  int custom_theme_count = 0;
+  int fallback_to_default = 0;
 
-    if (!ui) {
-        return;
-    }
+  if (!ui) {
+    return;
+  }
 
-    snprintf(previous_theme_id, sizeof(previous_theme_id), "%s", ui->active_theme_id);
-    custom_theme_count = ui_theme_reload_external(UI_THEME_DIRECTORY_PATH);
-    if (custom_theme_count < 0) {
-        ui->theme_directory_signature = ui_theme_external_signature(UI_THEME_DIRECTORY_PATH);
-        if (notify_status && workspace) {
-            const char* error_summary = ui_theme_last_reload_error();
-            snprintf(workspace->status_message,
-                     sizeof(workspace->status_message),
-                     "Theme reload failed: %s",
-                     (error_summary && error_summary[0] != '\0') ? error_summary : "invalid theme file");
-        }
-        return;
-    }
-
-    ui->theme_directory_signature = ui_theme_external_signature(UI_THEME_DIRECTORY_PATH);
-
-    /* Keep current theme id if still present; otherwise fall back through ui_system_set_theme. */
-    ui_system_set_theme(ui, previous_theme_id, 0);
-    fallback_to_default = (strcmp(previous_theme_id, ui->active_theme_id) != 0);
-
+  snprintf(previous_theme_id, sizeof(previous_theme_id), "%s",
+           ui->active_theme_id);
+  custom_theme_count = ui_theme_reload_external(UI_THEME_DIRECTORY_PATH);
+  if (custom_theme_count < 0) {
+    ui->theme_directory_signature =
+        ui_theme_external_signature(UI_THEME_DIRECTORY_PATH);
     if (notify_status && workspace) {
-        const char* reason_label = ui_theme_reload_reason_label(reason);
-        if (fallback_to_default) {
-            snprintf(workspace->status_message,
-                     sizeof(workspace->status_message),
-                     "Themes %s reloaded (%d custom), active theme missing -> fallback",
-                     reason_label,
-                     custom_theme_count);
-        } else {
-            snprintf(workspace->status_message,
-                     sizeof(workspace->status_message),
-                     "Themes %s reloaded (%d custom)",
-                     reason_label,
-                     custom_theme_count);
-        }
+      const char *error_summary = ui_theme_last_reload_error();
+      snprintf(workspace->status_message, sizeof(workspace->status_message),
+               "Theme reload failed: %s",
+               (error_summary && error_summary[0] != '\0')
+                   ? error_summary
+                   : "invalid theme file");
     }
-}
+    return;
+  }
 
-static void ui_system_load_theme_from_settings(UiSystem* ui)
-{
-    char loaded_theme_id[UI_THEME_ID_CAPACITY];
+  ui->theme_directory_signature =
+      ui_theme_external_signature(UI_THEME_DIRECTORY_PATH);
 
-    if (!ui) {
-        return;
-    }
+  /* Keep current theme id if still present; otherwise fall back through
+   * ui_system_set_theme. */
+  ui_system_set_theme(ui, previous_theme_id, 0);
+  fallback_to_default = (strcmp(previous_theme_id, ui->active_theme_id) != 0);
 
-    if (ui_theme_load_selected_id(ui->theme_settings_path,
-                                  loaded_theme_id,
-                                  sizeof(loaded_theme_id))) {
-        if (ui_system_set_theme(ui, loaded_theme_id, 0)) {
-            return;
-        }
-    }
-
-    ui_system_set_theme(ui, ui_theme_default_id(), 0);
-}
-
-static void ui_system_poll_theme_hot_reload(UiSystem* ui, Workspace* workspace, double now_seconds)
-{
-    unsigned long long signature = 0ull;
-
-    if (!ui) {
-        return;
-    }
-
-    if ((now_seconds - ui->theme_watch_last_check_seconds) < UI_THEME_WATCH_INTERVAL_SECONDS) {
-        return;
-    }
-    ui->theme_watch_last_check_seconds = now_seconds;
-
-    signature = ui_theme_external_signature(UI_THEME_DIRECTORY_PATH);
-    if (signature == ui->theme_directory_signature) {
-        return;
-    }
-
-    ui_system_reload_themes(ui, workspace, 1, UI_THEME_RELOAD_REASON_AUTO);
-}
-
-static float ui_smoothstep(float t)
-{
-    float clamped = ui_clampf(t, 0.0f, 1.0f);
-    return clamped * clamped * (3.0f - 2.0f * clamped);
-}
-
-static int ui_rectf_equals(RectF a, RectF b)
-{
-    const float eps = 1e-3f;
-    return fabsf(a.x - b.x) <= eps &&
-           fabsf(a.y - b.y) <= eps &&
-           fabsf(a.w - b.w) <= eps &&
-           fabsf(a.h - b.h) <= eps;
-}
-
-static RectF ui_clamp_rect_to_window(RectF rect, RectF window_bounds)
-{
-    float max_x = window_bounds.x + window_bounds.w;
-    float max_y = window_bounds.y + window_bounds.h;
-
-    if (rect.w < 0.0f) {
-        rect.w = 0.0f;
-    }
-    if (rect.h < 0.0f) {
-        rect.h = 0.0f;
-    }
-    if (rect.x < window_bounds.x) {
-        rect.w -= (window_bounds.x - rect.x);
-        rect.x = window_bounds.x;
-    }
-    if (rect.y < window_bounds.y) {
-        rect.h -= (window_bounds.y - rect.y);
-        rect.y = window_bounds.y;
-    }
-    if (rect.x > max_x) {
-        rect.x = max_x;
-    }
-    if (rect.y > max_y) {
-        rect.y = max_y;
-    }
-    if (rect.x + rect.w > max_x) {
-        rect.w = max_x - rect.x;
-    }
-    if (rect.y + rect.h > max_y) {
-        rect.h = max_y - rect.y;
-    }
-    if (rect.w < 0.0f) {
-        rect.w = 0.0f;
-    }
-    if (rect.h < 0.0f) {
-        rect.h = 0.0f;
-    }
-
-    return rect;
-}
-
-static void ui_publish_layout(UiSystem* ui, Workspace* workspace, int width, int height)
-{
-    WorkspaceLayout next_layout;
-    RectF window_bounds;
-    int changed = 0;
-
-    if (!ui || !workspace) {
-        return;
-    }
-
-    window_bounds.x = 0.0f;
-    window_bounds.y = 0.0f;
-    window_bounds.w = (float)width;
-    window_bounds.h = (float)height;
-
-    next_layout = workspace->layout;
-    next_layout.window_bounds = window_bounds;
-    next_layout.appbar_bounds = ui_clamp_rect_to_window(ui->appbar_bounds, window_bounds);
-    next_layout.rail_bounds = ui_clamp_rect_to_window(ui->rail_bounds, window_bounds);
-    next_layout.panel_bounds = ui_clamp_rect_to_window(ui->panel_bounds, window_bounds);
-    next_layout.status_bounds = ui_clamp_rect_to_window(ui->status_bounds, window_bounds);
-    next_layout.canvas_content_bounds = ui_clamp_rect_to_window(ui->content_bounds, window_bounds);
-
-    changed = !ui_rectf_equals(workspace->layout.window_bounds, next_layout.window_bounds) ||
-              !ui_rectf_equals(workspace->layout.appbar_bounds, next_layout.appbar_bounds) ||
-              !ui_rectf_equals(workspace->layout.rail_bounds, next_layout.rail_bounds) ||
-              !ui_rectf_equals(workspace->layout.panel_bounds, next_layout.panel_bounds) ||
-              !ui_rectf_equals(workspace->layout.status_bounds, next_layout.status_bounds) ||
-              !ui_rectf_equals(workspace->layout.canvas_content_bounds, next_layout.canvas_content_bounds);
-
-    if (changed) {
-        next_layout.layout_revision = workspace->layout.layout_revision + 1u;
-        workspace->layout = next_layout;
-    }
-
-    ui->layout_snapshot = workspace->layout;
-}
-
-static ToolContext ui_tool_context(Workspace* workspace)
-{
-    ToolContext context;
-    context.workspace = workspace;
-    context.document = &workspace->document;
-    context.history = &workspace->history;
-    context.canvas = &workspace->canvas;
-    return context;
-}
-
-static void ui_commit_scalar_edit(Workspace* workspace,
-                                  GraphicObject* object,
-                                  const char* key,
-                                  float before_value,
-                                  float after_value)
-{
-    unsigned int revision_before = 0;
-
-    if (!workspace || !object || !key || key[0] == '\0') {
-        return;
-    }
-    if (fabsf(after_value - before_value) <= 1e-6f) {
-        return;
-    }
-
-    revision_before = workspace->document.revision;
-    if (!object_set_scalar(object, key, after_value)) {
-        return;
-    }
-    if (!document_history_push_scalar_edit(&workspace->history,
-                                           &workspace->document,
-                                           object->id,
-                                           key,
-                                           before_value,
-                                           after_value,
-                                           revision_before,
-                                           workspace->document.revision)) {
-        /* Keep the edit even if history push fails; avoid rolling back UI interaction state. */
-    }
-
-    workspace_sync_document_dirty(workspace);
-}
-
-static void ui_apply_stroke_color(Workspace* workspace, GraphicObject* object, Color color)
-{
-    Color before;
-
-    if (!workspace || !object) {
-        return;
-    }
-
-    before = object->style.stroke_color;
-    if (fabsf(color.r - before.r) > 1e-6f) {
-        ui_commit_scalar_edit(workspace, object, "stroke_r", before.r, color.r);
-    }
-    if (fabsf(color.g - before.g) > 1e-6f) {
-        ui_commit_scalar_edit(workspace, object, "stroke_g", before.g, color.g);
-    }
-    if (fabsf(color.b - before.b) > 1e-6f) {
-        ui_commit_scalar_edit(workspace, object, "stroke_b", before.b, color.b);
-    }
-    if (fabsf(color.a - before.a) > 1e-6f) {
-        ui_commit_scalar_edit(workspace, object, "stroke_a", before.a, color.a);
-    }
-}
-
-static void ui_apply_stroke_width(Workspace* workspace, GraphicObject* object, float stroke_width)
-{
-    float before = 0.0f;
-
-    if (!workspace || !object) {
-        return;
-    }
-
-    before = object->style.stroke_width;
-    ui_commit_scalar_edit(workspace, object, "stroke_width", before, stroke_width);
-}
-
-static void ui_property_apply_float(struct nk_context* ctx,
-                                    Workspace* workspace,
-                                    GraphicObject* object,
-                                    const char* label,
-                                    const char* key,
-                                    float min_value,
-                                    float* value,
-                                    float max_value,
-                                    float step,
-                                    float inc_per_pixel)
-{
-    float before = *value;
-
-    nk_property_float(ctx, label, min_value, value, max_value, step, inc_per_pixel);
-    if (fabsf(*value - before) > 1e-6f) {
-        ui_commit_scalar_edit(workspace, object, key, before, *value);
-    }
-}
-
-static int ui_tool_button(UiSystem* ui, const char* label, int active, const char* tooltip)
-{
-    struct nk_context* ctx = ui->ctx;
-    struct nk_rect widget_bounds;
-    int pressed = 0;
-    int hovered = 0;
-
-    if (!ctx || !label) {
-        return 0;
-    }
-
-    if (active) {
-        struct nk_style_item active_bg = nk_style_item_color(ui->theme.primary);
-        nk_style_push_style_item(ctx, &ctx->style.button.normal, active_bg);
-        nk_style_push_style_item(ctx, &ctx->style.button.hover, active_bg);
-        nk_style_push_style_item(ctx, &ctx->style.button.active, active_bg);
-        nk_style_push_color(ctx, &ctx->style.button.text_normal, nk_rgba(255, 255, 255, 255));
-        nk_style_push_color(ctx, &ctx->style.button.text_hover, nk_rgba(255, 255, 255, 255));
-        nk_style_push_color(ctx, &ctx->style.button.text_active, nk_rgba(255, 255, 255, 255));
-    }
-
-    widget_bounds = nk_widget_bounds(ctx);
-    pressed = nk_button_label(ctx, label);
-    hovered = nk_input_is_mouse_hovering_rect(&ctx->input, widget_bounds);
-    if (tooltip && tooltip[0] != '\0' && hovered) {
-        nk_tooltip(ctx, tooltip);
-    }
-
-    if (active) {
-        nk_style_pop_color(ctx);
-        nk_style_pop_color(ctx);
-        nk_style_pop_color(ctx);
-        nk_style_pop_style_item(ctx);
-        nk_style_pop_style_item(ctx);
-        nk_style_pop_style_item(ctx);
-    }
-
-    return pressed;
-}
-
-static void ui_tool_rail(UiSystem* ui, Workspace* workspace, RectF bounds)
-{
-    struct nk_context* ctx = ui->ctx;
-    ToolContext context = ui_tool_context(workspace);
-    ToolKind active = workspace->tools.active_kind;
-
-    ui->rail_bounds = bounds;
-    if (bounds.w <= 0.0f || bounds.h <= 0.0f) {
-        return;
-    }
-
-    if (nk_begin(ctx, "Tool Rail",
-                 nk_rect(bounds.x, bounds.y, bounds.w, bounds.h),
-                 NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BORDER | NK_WINDOW_TITLE)) {
-        nk_layout_row_dynamic(ctx, ui->theme.row_height, 1);
-
-        if (ui_tool_button(ui, "Select (V)", active == TOOL_KIND_SELECT, "Select and edit objects")) {
-            tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_SELECT);
-        }
-        if (ui_tool_button(ui, "Hand (H)", active == TOOL_KIND_PAN, "Pan canvas view")) {
-            tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_PAN);
-        }
-        if (ui_tool_button(ui, "Line (L)", active == TOOL_KIND_LINE, "Draw line")) {
-            tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_LINE);
-        }
-        if (ui_tool_button(ui, "Rect (R)", active == TOOL_KIND_RECT, "Draw rectangle")) {
-            tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_RECT);
-        }
-        if (ui_tool_button(ui, "Ellipse (E)", active == TOOL_KIND_ELLIPSE, "Draw ellipse")) {
-            tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_ELLIPSE);
-        }
-
-        nk_layout_row_dynamic(ctx, ui->theme.row_height * 0.9f, 1);
-        nk_label(ctx, "", NK_TEXT_LEFT);
-        nk_labelf(ctx, NK_TEXT_LEFT, "Active:");
-        nk_label(ctx, tool_controller_active_label(&workspace->tools), NK_TEXT_LEFT);
-    }
-    nk_end(ctx);
-}
-
-static void ui_inspector_empty_hint(struct nk_context* ctx)
-{
-    nk_label(ctx, "No selection", NK_TEXT_LEFT);
-    nk_label(ctx, "Shortcuts: V H L R E", NK_TEXT_LEFT);
-    nk_label(ctx, "Document: Ctrl+S save, Ctrl+O load", NK_TEXT_LEFT);
-    nk_label(ctx, "Wheel zooms at cursor", NK_TEXT_LEFT);
-    nk_label(ctx, "Delete removes selection", NK_TEXT_LEFT);
-}
-
-static void ui_inspector_overview(struct nk_context* ctx, const Document* document, const GraphicObject* object)
-{
-    if (!ctx || !document || !object) {
-        return;
-    }
-
-    nk_layout_row_dynamic(ctx, 20.0f, 1);
-    nk_labelf(ctx, NK_TEXT_LEFT, "Type: %s", object_type_name(object->type));
-    nk_labelf(ctx, NK_TEXT_LEFT, "Selected: %d", document->selection.count);
-}
-
-static void ui_inspector_style(struct nk_context* ctx, Workspace* workspace, GraphicObject* object)
-{
-    Color stroke;
-    float stroke_width;
-
-    if (!ctx || !workspace || !object) {
-        return;
-    }
-
-    stroke = object->style.stroke_color;
-    stroke_width = object->style.stroke_width;
-
-    nk_layout_row_dynamic(ctx, 20.0f, 1);
-    nk_label(ctx, "Style", NK_TEXT_LEFT);
-    nk_layout_row_dynamic(ctx, 22.0f, 2);
-    nk_label(ctx, "Stroke R", NK_TEXT_LEFT);
-    if (nk_slider_float(ctx, 0.0f, &stroke.r, 1.0f, 0.01f)) ui_apply_stroke_color(workspace, object, stroke);
-    nk_label(ctx, "Stroke G", NK_TEXT_LEFT);
-    if (nk_slider_float(ctx, 0.0f, &stroke.g, 1.0f, 0.01f)) ui_apply_stroke_color(workspace, object, stroke);
-    nk_label(ctx, "Stroke B", NK_TEXT_LEFT);
-    if (nk_slider_float(ctx, 0.0f, &stroke.b, 1.0f, 0.01f)) ui_apply_stroke_color(workspace, object, stroke);
-    nk_label(ctx, "Stroke A", NK_TEXT_LEFT);
-    if (nk_slider_float(ctx, 0.1f, &stroke.a, 1.0f, 0.01f)) ui_apply_stroke_color(workspace, object, stroke);
-    nk_label(ctx, "Line Width", NK_TEXT_LEFT);
-    if (nk_slider_float(ctx, 1.0f, &stroke_width, 12.0f, 0.1f)) ui_apply_stroke_width(workspace, object, stroke_width);
-}
-
-static void ui_inspector_geometry(struct nk_context* ctx, Workspace* workspace, GraphicObject* object)
-{
-    if (!ctx || !workspace || !object) {
-        return;
-    }
-
-    if (object->type == GRAPHIC_OBJECT_LINE) {
-        float x1 = 0.0f, y1 = 0.0f, x2 = 0.0f, y2 = 0.0f;
-        object_get_scalar(object, "x1", &x1);
-        object_get_scalar(object, "y1", &y1);
-        object_get_scalar(object, "x2", &x2);
-        object_get_scalar(object, "y2", &y2);
-        nk_layout_row_dynamic(ctx, 20.0f, 1);
-        nk_label(ctx, "Geometry", NK_TEXT_LEFT);
-        nk_layout_row_dynamic(ctx, 24.0f, 1);
-        ui_property_apply_float(ctx, workspace, object, "#X1", "x1", -5000.0f, &x1, 5000.0f, 1.0f, 0.5f);
-        ui_property_apply_float(ctx, workspace, object, "#Y1", "y1", -5000.0f, &y1, 5000.0f, 1.0f, 0.5f);
-        ui_property_apply_float(ctx, workspace, object, "#X2", "x2", -5000.0f, &x2, 5000.0f, 1.0f, 0.5f);
-        ui_property_apply_float(ctx, workspace, object, "#Y2", "y2", -5000.0f, &y2, 5000.0f, 1.0f, 0.5f);
+  if (notify_status && workspace) {
+    const char *reason_label = ui_theme_reload_reason_label(reason);
+    if (fallback_to_default) {
+      snprintf(
+          workspace->status_message, sizeof(workspace->status_message),
+          "Themes %s reloaded (%d custom), active theme missing -> fallback",
+          reason_label, custom_theme_count);
     } else {
-        float x = 0.0f, y = 0.0f, width = 0.0f, height = 0.0f;
-        object_get_scalar(object, "x", &x);
-        object_get_scalar(object, "y", &y);
-        object_get_scalar(object, "width", &width);
-        object_get_scalar(object, "height", &height);
-        nk_layout_row_dynamic(ctx, 20.0f, 1);
-        nk_label(ctx, "Bounds", NK_TEXT_LEFT);
-        nk_layout_row_dynamic(ctx, 24.0f, 1);
-        ui_property_apply_float(ctx, workspace, object, "#X", "x", -5000.0f, &x, 5000.0f, 1.0f, 0.5f);
-        ui_property_apply_float(ctx, workspace, object, "#Y", "y", -5000.0f, &y, 5000.0f, 1.0f, 0.5f);
-        ui_property_apply_float(ctx, workspace, object, "#W", "width", 1.0f, &width, 5000.0f, 1.0f, 0.5f);
-        ui_property_apply_float(ctx, workspace, object, "#H", "height", 1.0f, &height, 5000.0f, 1.0f, 0.5f);
+      snprintf(workspace->status_message, sizeof(workspace->status_message),
+               "Themes %s reloaded (%d custom)", reason_label,
+               custom_theme_count);
     }
+  }
 }
 
-static void ui_selection_panel(UiSystem* ui, Workspace* workspace, RectF bounds)
-{
-    struct nk_context* ctx = ui->ctx;
-    Document* document = &workspace->document;
-    GraphicObject* object = document_primary_selection(document);
+static void ui_system_load_theme_from_settings(UiSystem *ui) {
+  char loaded_theme_id[UI_THEME_ID_CAPACITY];
 
-    ui->panel_bounds = bounds;
-    if (bounds.w <= 0.0f || bounds.h <= 0.0f) {
-        return;
-    }
+  if (!ui) {
+    return;
+  }
 
-    if (nk_begin(ctx, "Inspector",
-                 nk_rect(bounds.x, bounds.y, bounds.w, bounds.h),
-                 NK_WINDOW_BORDER | NK_WINDOW_TITLE | NK_WINDOW_SCROLL_AUTO_HIDE)) {
-        nk_layout_row_dynamic(ctx, 20.0f, 1);
-        if (!object) {
-            ui_inspector_empty_hint(ctx);
-        } else {
-            ui_inspector_overview(ctx, document, object);
-            ui_inspector_style(ctx, workspace, object);
-            ui_inspector_geometry(ctx, workspace, object);
-        }
+  if (ui_theme_load_selected_id(ui->theme_settings_path, loaded_theme_id,
+                                sizeof(loaded_theme_id))) {
+    if (ui_system_set_theme(ui, loaded_theme_id, 0)) {
+      return;
     }
-    nk_end(ctx);
+  }
+
+  ui_system_set_theme(ui, ui_theme_default_id(), 0);
 }
 
-static void ui_status_bar(UiSystem* ui, Workspace* workspace, int window_width, int window_height)
-{
-    struct nk_context* ctx = ui->ctx;
-    const float status_h = ui->theme.status_height;
-    const char* status_text = workspace->status_message[0] ? workspace->status_message : "Ready";
-    float status_row_h = ui->theme.row_height * 0.65f;
-    char zoom_text[24];
+static void ui_system_poll_theme_hot_reload(UiSystem *ui, Workspace *workspace,
+                                            double now_seconds) {
+  unsigned long long signature = 0ull;
 
-    ui->status_bounds.x = 0.0f;
-    ui->status_bounds.w = (float)window_width;
-    ui->status_bounds.h = status_h;
-    ui->status_bounds.y = (float)window_height - status_h;
+  if (!ui) {
+    return;
+  }
 
-    if (ui->status_bounds.w <= 32.0f || ui->status_bounds.h <= 14.0f) {
-        return;
+  if ((now_seconds - ui->theme_watch_last_check_seconds) <
+      UI_THEME_WATCH_INTERVAL_SECONDS) {
+    return;
+  }
+  ui->theme_watch_last_check_seconds = now_seconds;
+
+  signature = ui_theme_external_signature(UI_THEME_DIRECTORY_PATH);
+  if (signature == ui->theme_directory_signature) {
+    return;
+  }
+
+  ui_system_reload_themes(ui, workspace, 1, UI_THEME_RELOAD_REASON_AUTO);
+}
+
+static float ui_smoothstep(float t) {
+  float clamped = ui_clampf(t, 0.0f, 1.0f);
+  return clamped * clamped * (3.0f - 2.0f * clamped);
+}
+
+static int ui_rectf_equals(RectF a, RectF b) {
+  const float eps = 1e-3f;
+  return fabsf(a.x - b.x) <= eps && fabsf(a.y - b.y) <= eps &&
+         fabsf(a.w - b.w) <= eps && fabsf(a.h - b.h) <= eps;
+}
+
+static RectF ui_clamp_rect_to_window(RectF rect, RectF window_bounds) {
+  float max_x = window_bounds.x + window_bounds.w;
+  float max_y = window_bounds.y + window_bounds.h;
+
+  if (rect.w < 0.0f) {
+    rect.w = 0.0f;
+  }
+  if (rect.h < 0.0f) {
+    rect.h = 0.0f;
+  }
+  if (rect.x < window_bounds.x) {
+    rect.w -= (window_bounds.x - rect.x);
+    rect.x = window_bounds.x;
+  }
+  if (rect.y < window_bounds.y) {
+    rect.h -= (window_bounds.y - rect.y);
+    rect.y = window_bounds.y;
+  }
+  if (rect.x > max_x) {
+    rect.x = max_x;
+  }
+  if (rect.y > max_y) {
+    rect.y = max_y;
+  }
+  if (rect.x + rect.w > max_x) {
+    rect.w = max_x - rect.x;
+  }
+  if (rect.y + rect.h > max_y) {
+    rect.h = max_y - rect.y;
+  }
+  if (rect.w < 0.0f) {
+    rect.w = 0.0f;
+  }
+  if (rect.h < 0.0f) {
+    rect.h = 0.0f;
+  }
+
+  return rect;
+}
+
+static void ui_publish_layout(UiSystem *ui, Workspace *workspace, int width,
+                              int height) {
+  WorkspaceLayout next_layout;
+  RectF window_bounds;
+  int changed = 0;
+
+  if (!ui || !workspace) {
+    return;
+  }
+
+  window_bounds.x = 0.0f;
+  window_bounds.y = 0.0f;
+  window_bounds.w = (float)width;
+  window_bounds.h = (float)height;
+
+  next_layout = workspace->layout;
+  next_layout.window_bounds = window_bounds;
+  next_layout.appbar_bounds =
+      ui_clamp_rect_to_window(ui->appbar_bounds, window_bounds);
+  next_layout.rail_bounds =
+      ui_clamp_rect_to_window(ui->rail_bounds, window_bounds);
+  next_layout.panel_bounds =
+      ui_clamp_rect_to_window(ui->panel_bounds, window_bounds);
+  next_layout.status_bounds =
+      ui_clamp_rect_to_window(ui->status_bounds, window_bounds);
+  next_layout.canvas_content_bounds =
+      ui_clamp_rect_to_window(ui->content_bounds, window_bounds);
+
+  changed = !ui_rectf_equals(workspace->layout.window_bounds,
+                             next_layout.window_bounds) ||
+            !ui_rectf_equals(workspace->layout.appbar_bounds,
+                             next_layout.appbar_bounds) ||
+            !ui_rectf_equals(workspace->layout.rail_bounds,
+                             next_layout.rail_bounds) ||
+            !ui_rectf_equals(workspace->layout.panel_bounds,
+                             next_layout.panel_bounds) ||
+            !ui_rectf_equals(workspace->layout.status_bounds,
+                             next_layout.status_bounds) ||
+            !ui_rectf_equals(workspace->layout.canvas_content_bounds,
+                             next_layout.canvas_content_bounds);
+
+  if (changed) {
+    next_layout.layout_revision = workspace->layout.layout_revision + 1u;
+    workspace->layout = next_layout;
+  }
+
+  ui->layout_snapshot = workspace->layout;
+}
+
+static ToolContext ui_tool_context(Workspace *workspace) {
+  ToolContext context;
+  context.workspace = workspace;
+  context.document = &workspace->document;
+  context.history = &workspace->history;
+  context.canvas = &workspace->canvas;
+  return context;
+}
+
+static void ui_commit_scalar_edit(Workspace *workspace, GraphicObject *object,
+                                  const char *key, float before_value,
+                                  float after_value) {
+  unsigned int revision_before = 0;
+
+  if (!workspace || !object || !key || key[0] == '\0') {
+    return;
+  }
+  if (fabsf(after_value - before_value) <= 1e-6f) {
+    return;
+  }
+
+  revision_before = workspace->document.revision;
+  if (!object_set_scalar(object, key, after_value)) {
+    return;
+  }
+  if (!document_history_push_scalar_edit(
+          &workspace->history, &workspace->document, object->id, key,
+          before_value, after_value, revision_before,
+          workspace->document.revision)) {
+    /* Keep the edit even if history push fails; avoid rolling back UI
+     * interaction state. */
+  }
+
+  workspace_sync_document_dirty(workspace);
+}
+
+static void ui_apply_stroke_color(Workspace *workspace, GraphicObject *object,
+                                  Color color) {
+  Color before;
+
+  if (!workspace || !object) {
+    return;
+  }
+
+  before = object->style.stroke_color;
+  if (fabsf(color.r - before.r) > 1e-6f) {
+    ui_commit_scalar_edit(workspace, object, "stroke_r", before.r, color.r);
+  }
+  if (fabsf(color.g - before.g) > 1e-6f) {
+    ui_commit_scalar_edit(workspace, object, "stroke_g", before.g, color.g);
+  }
+  if (fabsf(color.b - before.b) > 1e-6f) {
+    ui_commit_scalar_edit(workspace, object, "stroke_b", before.b, color.b);
+  }
+  if (fabsf(color.a - before.a) > 1e-6f) {
+    ui_commit_scalar_edit(workspace, object, "stroke_a", before.a, color.a);
+  }
+}
+
+static void ui_apply_stroke_width(Workspace *workspace, GraphicObject *object,
+                                  float stroke_width) {
+  float before = 0.0f;
+
+  if (!workspace || !object) {
+    return;
+  }
+
+  before = object->style.stroke_width;
+  ui_commit_scalar_edit(workspace, object, "stroke_width", before,
+                        stroke_width);
+}
+
+static void ui_property_apply_float(struct nk_context *ctx,
+                                    Workspace *workspace, GraphicObject *object,
+                                    const char *label, const char *key,
+                                    float min_value, float *value,
+                                    float max_value, float step,
+                                    float inc_per_pixel) {
+  float before = *value;
+
+  nk_property_float(ctx, label, min_value, value, max_value, step,
+                    inc_per_pixel);
+  if (fabsf(*value - before) > 1e-6f) {
+    ui_commit_scalar_edit(workspace, object, key, before, *value);
+  }
+}
+
+static int ui_tool_button(UiSystem *ui, const char *label, int active,
+                          const char *tooltip) {
+  struct nk_context *ctx = ui->ctx;
+  struct nk_rect widget_bounds;
+  int pressed = 0;
+  int hovered = 0;
+
+  if (!ctx || !label) {
+    return 0;
+  }
+
+  if (active) {
+    struct nk_style_item active_bg = nk_style_item_color(ui->theme.primary);
+    nk_style_push_style_item(ctx, &ctx->style.button.normal, active_bg);
+    nk_style_push_style_item(ctx, &ctx->style.button.hover, active_bg);
+    nk_style_push_style_item(ctx, &ctx->style.button.active, active_bg);
+    nk_style_push_color(ctx, &ctx->style.button.text_normal,
+                        nk_rgba(255, 255, 255, 255));
+    nk_style_push_color(ctx, &ctx->style.button.text_hover,
+                        nk_rgba(255, 255, 255, 255));
+    nk_style_push_color(ctx, &ctx->style.button.text_active,
+                        nk_rgba(255, 255, 255, 255));
+  }
+
+  widget_bounds = nk_widget_bounds(ctx);
+  pressed = nk_button_label(ctx, label);
+  hovered = nk_input_is_mouse_hovering_rect(&ctx->input, widget_bounds);
+  if (tooltip && tooltip[0] != '\0' && hovered) {
+    nk_tooltip(ctx, tooltip);
+  }
+
+  if (active) {
+    nk_style_pop_color(ctx);
+    nk_style_pop_color(ctx);
+    nk_style_pop_color(ctx);
+    nk_style_pop_style_item(ctx);
+    nk_style_pop_style_item(ctx);
+    nk_style_pop_style_item(ctx);
+  }
+
+  return pressed;
+}
+
+static void ui_tool_rail(UiSystem *ui, Workspace *workspace, RectF bounds) {
+  struct nk_context *ctx = ui->ctx;
+  ToolContext context = ui_tool_context(workspace);
+  ToolKind active = workspace->tools.active_kind;
+
+  ui->rail_bounds = bounds;
+  if (bounds.w <= 0.0f || bounds.h <= 0.0f) {
+    return;
+  }
+
+  if (nk_begin(ctx, "Tool Rail",
+               nk_rect(bounds.x, bounds.y, bounds.w, bounds.h),
+               NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BORDER | NK_WINDOW_TITLE)) {
+    nk_layout_row_dynamic(ctx, ui->theme.row_height, 1);
+
+    if (ui_tool_button(ui, "Select (V)", active == TOOL_KIND_SELECT,
+                       "Select and edit objects")) {
+      tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_SELECT);
+    }
+    if (ui_tool_button(ui, "Hand (H)", active == TOOL_KIND_PAN,
+                       "Pan canvas view")) {
+      tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_PAN);
+    }
+    if (ui_tool_button(ui, "Line (L)", active == TOOL_KIND_LINE, "Draw line")) {
+      tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_LINE);
+    }
+    if (ui_tool_button(ui, "Rect (R)", active == TOOL_KIND_RECT,
+                       "Draw rectangle")) {
+      tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_RECT);
+    }
+    if (ui_tool_button(ui, "Ellipse (E)", active == TOOL_KIND_ELLIPSE,
+                       "Draw ellipse")) {
+      tool_controller_set_active(&workspace->tools, &context,
+                                 TOOL_KIND_ELLIPSE);
     }
 
-    snprintf(zoom_text, sizeof(zoom_text), "Zoom: %.0f%%", canvas_view_zoom(&workspace->canvas) * 100.0f);
+    nk_layout_row_dynamic(ctx, ui->theme.row_height * 0.9f, 1);
+    nk_label(ctx, "", NK_TEXT_LEFT);
+    nk_labelf(ctx, NK_TEXT_LEFT, "Active:");
+    nk_label(ctx, tool_controller_active_label(&workspace->tools),
+             NK_TEXT_LEFT);
+  }
+  nk_end(ctx);
+}
 
-    if (nk_begin(ctx, "Status",
-                 nk_rect(ui->status_bounds.x, ui->status_bounds.y, ui->status_bounds.w, ui->status_bounds.h),
-                 NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BORDER)) {
-        nk_layout_row_begin(ctx, NK_DYNAMIC, status_row_h, 5);
-        nk_layout_row_push(ctx, 0.12f);
-        nk_labelf(ctx, NK_TEXT_LEFT, "Objects: %d", workspace->document.count);
-        nk_layout_row_push(ctx, 0.13f);
-        nk_label(ctx, zoom_text, NK_TEXT_LEFT);
-        nk_layout_row_push(ctx, 0.35f);
-        nk_labelf(ctx, NK_TEXT_LEFT, "File: %s%s",
-                  workspace->current_document_path[0] ? workspace->current_document_path : "(default)",
-                  workspace->document_dirty ? " *" : "");
-        nk_layout_row_push(ctx, 0.18f);
-        nk_labelf(ctx, NK_TEXT_LEFT, "Undo:%d Redo:%d", workspace->history.undo_count, workspace->history.redo_count);
-        nk_layout_row_push(ctx, 0.22f);
-        nk_label(ctx, status_text, NK_TEXT_RIGHT);
-        nk_layout_row_end(ctx);
+static void ui_inspector_empty_hint(struct nk_context *ctx) {
+  nk_label(ctx, "No selection", NK_TEXT_LEFT);
+  nk_label(ctx, "Shortcuts: V H L R E", NK_TEXT_LEFT);
+  nk_label(ctx, "Document: Ctrl+S save, Ctrl+O load", NK_TEXT_LEFT);
+  nk_label(ctx, "Wheel zooms at cursor", NK_TEXT_LEFT);
+  nk_label(ctx, "Delete removes selection", NK_TEXT_LEFT);
+}
+
+static void ui_inspector_overview(struct nk_context *ctx,
+                                  const Document *document,
+                                  const GraphicObject *object) {
+  if (!ctx || !document || !object) {
+    return;
+  }
+
+  nk_layout_row_dynamic(ctx, 20.0f, 1);
+  nk_labelf(ctx, NK_TEXT_LEFT, "Type: %s", object_type_name(object->type));
+  nk_labelf(ctx, NK_TEXT_LEFT, "Selected: %d", document->selection.count);
+}
+
+static void ui_inspector_style(struct nk_context *ctx, Workspace *workspace,
+                               GraphicObject *object) {
+  Color stroke;
+  float stroke_width;
+
+  if (!ctx || !workspace || !object) {
+    return;
+  }
+
+  stroke = object->style.stroke_color;
+  stroke_width = object->style.stroke_width;
+
+  nk_layout_row_dynamic(ctx, 20.0f, 1);
+  nk_label(ctx, "Style", NK_TEXT_LEFT);
+  nk_layout_row_dynamic(ctx, 22.0f, 2);
+  nk_label(ctx, "Stroke R", NK_TEXT_LEFT);
+  if (nk_slider_float(ctx, 0.0f, &stroke.r, 1.0f, 0.01f))
+    ui_apply_stroke_color(workspace, object, stroke);
+  nk_label(ctx, "Stroke G", NK_TEXT_LEFT);
+  if (nk_slider_float(ctx, 0.0f, &stroke.g, 1.0f, 0.01f))
+    ui_apply_stroke_color(workspace, object, stroke);
+  nk_label(ctx, "Stroke B", NK_TEXT_LEFT);
+  if (nk_slider_float(ctx, 0.0f, &stroke.b, 1.0f, 0.01f))
+    ui_apply_stroke_color(workspace, object, stroke);
+  nk_label(ctx, "Stroke A", NK_TEXT_LEFT);
+  if (nk_slider_float(ctx, 0.1f, &stroke.a, 1.0f, 0.01f))
+    ui_apply_stroke_color(workspace, object, stroke);
+  nk_label(ctx, "Line Width", NK_TEXT_LEFT);
+  if (nk_slider_float(ctx, 1.0f, &stroke_width, 12.0f, 0.1f))
+    ui_apply_stroke_width(workspace, object, stroke_width);
+}
+
+static void ui_inspector_geometry(struct nk_context *ctx, Workspace *workspace,
+                                  GraphicObject *object) {
+  if (!ctx || !workspace || !object) {
+    return;
+  }
+
+  if (object->type == GRAPHIC_OBJECT_LINE) {
+    float x1 = 0.0f, y1 = 0.0f, x2 = 0.0f, y2 = 0.0f;
+    object_get_scalar(object, "x1", &x1);
+    object_get_scalar(object, "y1", &y1);
+    object_get_scalar(object, "x2", &x2);
+    object_get_scalar(object, "y2", &y2);
+    nk_layout_row_dynamic(ctx, 20.0f, 1);
+    nk_label(ctx, "Geometry", NK_TEXT_LEFT);
+    nk_layout_row_dynamic(ctx, 24.0f, 1);
+    ui_property_apply_float(ctx, workspace, object, "#X1", "x1", -5000.0f, &x1,
+                            5000.0f, 1.0f, 0.5f);
+    ui_property_apply_float(ctx, workspace, object, "#Y1", "y1", -5000.0f, &y1,
+                            5000.0f, 1.0f, 0.5f);
+    ui_property_apply_float(ctx, workspace, object, "#X2", "x2", -5000.0f, &x2,
+                            5000.0f, 1.0f, 0.5f);
+    ui_property_apply_float(ctx, workspace, object, "#Y2", "y2", -5000.0f, &y2,
+                            5000.0f, 1.0f, 0.5f);
+  } else {
+    float x = 0.0f, y = 0.0f, width = 0.0f, height = 0.0f;
+    object_get_scalar(object, "x", &x);
+    object_get_scalar(object, "y", &y);
+    object_get_scalar(object, "width", &width);
+    object_get_scalar(object, "height", &height);
+    nk_layout_row_dynamic(ctx, 20.0f, 1);
+    nk_label(ctx, "Bounds", NK_TEXT_LEFT);
+    nk_layout_row_dynamic(ctx, 24.0f, 1);
+    ui_property_apply_float(ctx, workspace, object, "#X", "x", -5000.0f, &x,
+                            5000.0f, 1.0f, 0.5f);
+    ui_property_apply_float(ctx, workspace, object, "#Y", "y", -5000.0f, &y,
+                            5000.0f, 1.0f, 0.5f);
+    ui_property_apply_float(ctx, workspace, object, "#W", "width", 1.0f, &width,
+                            5000.0f, 1.0f, 0.5f);
+    ui_property_apply_float(ctx, workspace, object, "#H", "height", 1.0f,
+                            &height, 5000.0f, 1.0f, 0.5f);
+  }
+}
+
+static void ui_selection_panel(UiSystem *ui, Workspace *workspace,
+                               RectF bounds) {
+  struct nk_context *ctx = ui->ctx;
+  Document *document = &workspace->document;
+  GraphicObject *object = document_primary_selection(document);
+
+  ui->panel_bounds = bounds;
+  if (bounds.w <= 0.0f || bounds.h <= 0.0f) {
+    return;
+  }
+
+  if (nk_begin(
+          ctx, "Inspector", nk_rect(bounds.x, bounds.y, bounds.w, bounds.h),
+          NK_WINDOW_BORDER | NK_WINDOW_TITLE | NK_WINDOW_SCROLL_AUTO_HIDE)) {
+    nk_layout_row_dynamic(ctx, 20.0f, 1);
+    if (!object) {
+      ui_inspector_empty_hint(ctx);
+    } else {
+      ui_inspector_overview(ctx, document, object);
+      ui_inspector_style(ctx, workspace, object);
+      ui_inspector_geometry(ctx, workspace, object);
     }
-    nk_end(ctx);
+  }
+  nk_end(ctx);
+}
+
+static void ui_status_bar(UiSystem *ui, Workspace *workspace, int window_width,
+                          int window_height) {
+  struct nk_context *ctx = ui->ctx;
+  const float status_h = ui->theme.status_height;
+  const char *status_text =
+      workspace->status_message[0] ? workspace->status_message : "Ready";
+  float status_row_h = ui->theme.row_height * 0.65f;
+  char zoom_text[24];
+
+  ui->status_bounds.x = 0.0f;
+  ui->status_bounds.w = (float)window_width;
+  ui->status_bounds.h = status_h;
+  ui->status_bounds.y = (float)window_height - status_h;
+
+  if (ui->status_bounds.w <= 32.0f || ui->status_bounds.h <= 14.0f) {
+    return;
+  }
+
+  snprintf(zoom_text, sizeof(zoom_text), "Zoom: %.0f%%",
+           canvas_view_zoom(&workspace->canvas) * 100.0f);
+
+  if (nk_begin(ctx, "Status",
+               nk_rect(ui->status_bounds.x, ui->status_bounds.y,
+                       ui->status_bounds.w, ui->status_bounds.h),
+               NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BORDER)) {
+    nk_layout_row_begin(ctx, NK_DYNAMIC, status_row_h, 5);
+    nk_layout_row_push(ctx, 0.12f);
+    nk_labelf(ctx, NK_TEXT_LEFT, "Objects: %d", workspace->document.count);
+    nk_layout_row_push(ctx, 0.13f);
+    nk_label(ctx, zoom_text, NK_TEXT_LEFT);
+    nk_layout_row_push(ctx, 0.35f);
+    nk_labelf(ctx, NK_TEXT_LEFT, "File: %s%s",
+              workspace->current_document_path[0]
+                  ? workspace->current_document_path
+                  : "(default)",
+              workspace->document_dirty ? " *" : "");
+    nk_layout_row_push(ctx, 0.18f);
+    nk_labelf(ctx, NK_TEXT_LEFT, "Undo:%d Redo:%d",
+              workspace->history.undo_count, workspace->history.redo_count);
+    nk_layout_row_push(ctx, 0.22f);
+    nk_label(ctx, status_text, NK_TEXT_RIGHT);
+    nk_layout_row_end(ctx);
+  }
+  nk_end(ctx);
 }
 
 /** Render a centered modal dialog for active workspace confirmation flows. */
-static void ui_modal_dialogs(UiSystem* ui, Workspace* workspace, int window_width, int window_height)
-{
-    struct nk_context* ctx = NULL;
-    struct nk_style_item blocker_background;
-    struct nk_rect modal_bounds;
-    float modal_width = 360.0f;
-    float modal_height = 170.0f;
-    const char* title = NULL;
-    const char* message = NULL;
-    const char* line_break = NULL;
-    char line_one[128];
-    char line_two[128];
-    size_t line_one_length = 0u;
+static void ui_modal_dialogs(UiSystem *ui, Workspace *workspace,
+                             int window_width, int window_height) {
+  struct nk_context *ctx = NULL;
+  struct nk_style_item blocker_background;
+  struct nk_rect modal_bounds;
+  float modal_width = 360.0f;
+  float modal_height = 170.0f;
+  const char *title = NULL;
+  const char *message = NULL;
+  const char *line_break = NULL;
+  char line_one[128];
+  char line_two[128];
+  size_t line_one_length = 0u;
 
-    if (!ui || !workspace || !workspace_modal_is_active(workspace)) {
-        return;
+  if (!ui || !workspace || !workspace_modal_is_active(workspace)) {
+    return;
+  }
+
+  ctx = ui->ctx;
+  if (!ctx) {
+    return;
+  }
+
+  if ((float)window_width < modal_width + 24.0f) {
+    modal_width = (float)window_width - 24.0f;
+  }
+  if ((float)window_height < modal_height + 24.0f) {
+    modal_height = (float)window_height - 24.0f;
+  }
+  if (modal_width < 240.0f) {
+    modal_width = 240.0f;
+  }
+  if (modal_height < 140.0f) {
+    modal_height = 140.0f;
+  }
+
+  modal_bounds = nk_rect(((float)window_width - modal_width) * 0.5f,
+                         ((float)window_height - modal_height) * 0.5f,
+                         modal_width, modal_height);
+
+  title = workspace_modal_title(workspace);
+  message = workspace_modal_message(workspace);
+  line_one[0] = '\0';
+  line_two[0] = '\0';
+
+  if (message) {
+    line_break = strchr(message, '\n');
+    if (line_break) {
+      line_one_length = (size_t)(line_break - message);
+      if (line_one_length >= sizeof(line_one)) {
+        line_one_length = sizeof(line_one) - 1u;
+      }
+      memcpy(line_one, message, line_one_length);
+      line_one[line_one_length] = '\0';
+      snprintf(line_two, sizeof(line_two), "%s", line_break + 1);
+    } else {
+      snprintf(line_one, sizeof(line_one), "%s", message);
+    }
+  }
+
+  blocker_background = nk_style_item_color(nk_rgba(0, 0, 0, 96));
+  nk_style_push_style_item(ctx, &ctx->style.window.fixed_background,
+                           blocker_background);
+  if (nk_begin(ctx, "##modal_blocker##",
+               nk_rect(0.0f, 0.0f, (float)window_width, (float)window_height),
+               NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND)) {
+    nk_layout_row_dynamic(ctx, 1.0f, 1);
+    nk_label(ctx, "", NK_TEXT_LEFT);
+  }
+  nk_end(ctx);
+  nk_style_pop_style_item(ctx);
+
+  if (nk_begin(ctx, title && title[0] != '\0' ? title : "Modal", modal_bounds,
+               NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_TITLE)) {
+    nk_layout_row_dynamic(ctx, 22.0f, 1);
+    if (line_one[0] != '\0') {
+      nk_label(ctx, line_one, NK_TEXT_LEFT);
+    }
+    if (line_two[0] != '\0') {
+      nk_label(ctx, line_two, NK_TEXT_LEFT);
     }
 
-    ctx = ui->ctx;
-    if (!ctx) {
-        return;
-    }
+    nk_layout_row_dynamic(ctx, 12.0f, 1);
+    nk_label(ctx, "", NK_TEXT_LEFT);
 
-    if ((float)window_width < modal_width + 24.0f) {
-        modal_width = (float)window_width - 24.0f;
+    nk_layout_row_dynamic(ctx, 34.0f, 3);
+    if (nk_button_label(ctx, "Save")) {
+      workspace_confirm_pending_action_save(workspace);
     }
-    if ((float)window_height < modal_height + 24.0f) {
-        modal_height = (float)window_height - 24.0f;
+    if (nk_button_label(ctx, "Don't Save")) {
+      workspace_confirm_pending_action_discard(workspace);
     }
-    if (modal_width < 240.0f) {
-        modal_width = 240.0f;
+    if (nk_button_label(ctx, "Cancel")) {
+      workspace_confirm_pending_action_cancel(workspace);
     }
-    if (modal_height < 140.0f) {
-        modal_height = 140.0f;
-    }
-
-    modal_bounds = nk_rect(((float)window_width - modal_width) * 0.5f,
-                           ((float)window_height - modal_height) * 0.5f,
-                           modal_width,
-                           modal_height);
-
-    title = workspace_modal_title(workspace);
-    message = workspace_modal_message(workspace);
-    line_one[0] = '\0';
-    line_two[0] = '\0';
-
-    if (message) {
-        line_break = strchr(message, '\n');
-        if (line_break) {
-            line_one_length = (size_t)(line_break - message);
-            if (line_one_length >= sizeof(line_one)) {
-                line_one_length = sizeof(line_one) - 1u;
-            }
-            memcpy(line_one, message, line_one_length);
-            line_one[line_one_length] = '\0';
-            snprintf(line_two, sizeof(line_two), "%s", line_break + 1);
-        } else {
-            snprintf(line_one, sizeof(line_one), "%s", message);
-        }
-    }
-
-    blocker_background = nk_style_item_color(nk_rgba(0, 0, 0, 96));
-    nk_style_push_style_item(ctx, &ctx->style.window.fixed_background, blocker_background);
-    if (nk_begin(ctx,
-                 "##modal_blocker##",
-                 nk_rect(0.0f, 0.0f, (float)window_width, (float)window_height),
-                 NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND)) {
-        nk_layout_row_dynamic(ctx, 1.0f, 1);
-        nk_label(ctx, "", NK_TEXT_LEFT);
-    }
-    nk_end(ctx);
-    nk_style_pop_style_item(ctx);
-
-    if (nk_begin(ctx,
-                 title && title[0] != '\0' ? title : "Modal",
-                 modal_bounds,
-                 NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_TITLE)) {
-        nk_layout_row_dynamic(ctx, 22.0f, 1);
-        if (line_one[0] != '\0') {
-            nk_label(ctx, line_one, NK_TEXT_LEFT);
-        }
-        if (line_two[0] != '\0') {
-            nk_label(ctx, line_two, NK_TEXT_LEFT);
-        }
-
-        nk_layout_row_dynamic(ctx, 12.0f, 1);
-        nk_label(ctx, "", NK_TEXT_LEFT);
-
-        nk_layout_row_dynamic(ctx, 34.0f, 3);
-        if (nk_button_label(ctx, "Save")) {
-            workspace_confirm_pending_action_save(workspace);
-        }
-        if (nk_button_label(ctx, "Don't Save")) {
-            workspace_confirm_pending_action_discard(workspace);
-        }
-        if (nk_button_label(ctx, "Cancel")) {
-            workspace_confirm_pending_action_cancel(workspace);
-        }
-    }
-    nk_end(ctx);
+  }
+  nk_end(ctx);
 }
 
-UiSystem* ui_system_create(PlatformWindow* window)
-{
-    UiSystem* ui = (UiSystem*)calloc(1, sizeof(*ui));
-    struct nk_font_atlas* atlas = NULL;
+UiSystem *ui_system_create(PlatformWindow *window) {
+  UiSystem *ui = (UiSystem *)calloc(1, sizeof(*ui));
+  struct nk_font_atlas *atlas = NULL;
 
-    if (!ui) {
-        return NULL;
-    }
+  if (!ui) {
+    return NULL;
+  }
 
-    ui->ctx = nk_glfw3_init(&ui->glfw, window->handle, 0);
-    if (!ui->ctx) {
-        free(ui);
-        return NULL;
-    }
-
-    nk_glfw3_font_stash_begin(&ui->glfw, &atlas);
-    nk_glfw3_font_stash_end(&ui->glfw);
-
-    snprintf(ui->theme_settings_path,
-             sizeof(ui->theme_settings_path),
-             "%s",
-             UI_THEME_SETTINGS_PATH);
-
-    ui_system_reload_themes(ui, NULL, 0, UI_THEME_RELOAD_REASON_STARTUP);
-    ui->theme_watch_last_check_seconds = glfwGetTime();
-
-    ui->menu_bar = ui_menubar_create(ui->ctx);
-    if (ui->menu_bar) {
-        ui_system_sync_menubar_themes(ui);
-    }
-    ui_system_load_theme_from_settings(ui);
-
-    ui->inspector_anim_t = 1.0f;
-    ui->inspector_target_visible = 1;
-    ui->inspector_anim_initialized = 0;
-    ui->last_frame_seconds = glfwGetTime();
-    ui->window_handle = window->handle;
-
-    return ui;
-}
-
-void ui_system_destroy(UiSystem* ui)
-{
-    if (!ui) {
-        return;
-    }
-    if (ui->menu_bar) {
-        ui_menubar_destroy(ui->menu_bar);
-        ui->menu_bar = NULL;
-    }
-    nk_glfw3_shutdown(&ui->glfw);
+  ui->ctx = nk_glfw3_init(&ui->glfw, window->handle, 0);
+  if (!ui->ctx) {
     free(ui);
+    return NULL;
+  }
+
+  nk_glfw3_font_stash_begin(&ui->glfw, &atlas);
+  nk_glfw3_font_stash_end(&ui->glfw);
+
+  snprintf(ui->theme_settings_path, sizeof(ui->theme_settings_path), "%s",
+           UI_THEME_SETTINGS_PATH);
+
+  ui_system_reload_themes(ui, NULL, 0, UI_THEME_RELOAD_REASON_STARTUP);
+  ui->theme_watch_last_check_seconds = glfwGetTime();
+
+  ui->menu_bar = ui_menubar_create(ui->ctx);
+  if (ui->menu_bar) {
+    ui_system_sync_menubar_themes(ui);
+  }
+  ui_system_load_theme_from_settings(ui);
+
+  ui->inspector_anim_t = 1.0f;
+  ui->inspector_target_visible = 1;
+  ui->inspector_anim_initialized = 0;
+  ui->last_frame_seconds = glfwGetTime();
+  ui->window_handle = window->handle;
+
+  return ui;
 }
 
-void ui_system_begin_frame(UiSystem* ui)
-{
-    if (ui) {
-        nk_glfw3_new_frame(&ui->glfw);
-    }
+void ui_system_destroy(UiSystem *ui) {
+  if (!ui) {
+    return;
+  }
+  if (ui->menu_bar) {
+    ui_menubar_destroy(ui->menu_bar);
+    ui->menu_bar = NULL;
+  }
+  nk_glfw3_shutdown(&ui->glfw);
+  free(ui);
 }
 
-void ui_system_build(UiSystem* ui, Workspace* workspace)
-{
-    int width = 0;
-    int height = 0;
-    float content_top = 0.0f;
-    float content_bottom = 0.0f;
-    float content_height = 0.0f;
-    float needed_width = 0.0f;
-    int inspector_requested = 0;
-    int inspector_target_visible = 0;
-    int inspector_render_visible = 0;
-    RectF rail_bounds = {0};
-    RectF inspector_bounds = {0};
-    double now_seconds;
-    float dt_seconds;
-    float anim_step;
-    float inspector_eased_t;
-    float inspector_hidden_x;
-    float inspector_shown_x;
+void ui_system_begin_frame(UiSystem *ui) {
+  if (ui) {
+    nk_glfw3_new_frame(&ui->glfw);
+  }
+}
 
-    if (!ui || !workspace) {
-        return;
+void ui_system_build(UiSystem *ui, Workspace *workspace) {
+  int width = 0;
+  int height = 0;
+  float content_top = 0.0f;
+  float content_bottom = 0.0f;
+  float content_height = 0.0f;
+  float needed_width = 0.0f;
+  int inspector_requested = 0;
+  int inspector_target_visible = 0;
+  int inspector_render_visible = 0;
+  RectF rail_bounds = {0};
+  RectF inspector_bounds = {0};
+  double now_seconds;
+  float dt_seconds;
+  float anim_step;
+  float inspector_eased_t;
+  float inspector_hidden_x;
+  float inspector_shown_x;
+
+  if (!ui || !workspace) {
+    return;
+  }
+
+  ui->modal_active = workspace_modal_is_active(workspace);
+
+  if (ui->window_handle) {
+    glfwGetWindowSize(ui->window_handle, &width, &height);
+  }
+  if (width <= 0 || height <= 0) {
+    GLFWwindow *current_context = glfwGetCurrentContext();
+    if (current_context) {
+      glfwGetWindowSize(current_context, &width, &height);
+    }
+  }
+
+  if (width <= 0 || height <= 0) {
+    if (workspace) {
+      ui_publish_layout(ui, workspace, 1, 1);
+    }
+    return;
+  }
+  now_seconds = glfwGetTime();
+  dt_seconds = (float)(now_seconds - ui->last_frame_seconds);
+  ui->last_frame_seconds = now_seconds;
+  dt_seconds = ui_clampf(dt_seconds, 0.0f, 0.10f);
+  ui_system_poll_theme_hot_reload(ui, workspace, now_seconds);
+
+  if (ui->menu_bar && !ui->modal_active) {
+    int requested_theme_index = -1;
+    int requested_theme_reload = 0;
+    const UiThemeDescriptor *requested_theme = NULL;
+
+    ui_menubar_set_height(ui->menu_bar, ui->theme.menu_height);
+    ui_menubar_build(ui->menu_bar, workspace, width);
+
+    requested_theme_reload = ui_menubar_take_theme_reload_request(ui->menu_bar);
+    if (requested_theme_reload) {
+      ui_system_reload_themes(ui, workspace, 1, UI_THEME_RELOAD_REASON_MANUAL);
     }
 
-    ui->modal_active = workspace_modal_is_active(workspace);
-
-    if (ui->window_handle) {
-        glfwGetWindowSize(ui->window_handle, &width, &height);
+    requested_theme_index = ui_menubar_take_theme_request(ui->menu_bar);
+    if (requested_theme_index >= 0) {
+      requested_theme = ui_theme_descriptor_at(requested_theme_index);
+      if (requested_theme && ui_system_set_theme(ui, requested_theme->id, 1)) {
+        snprintf(workspace->status_message, sizeof(workspace->status_message),
+                 "Theme: %s",
+                 requested_theme->label ? requested_theme->label
+                                        : requested_theme->id);
+      }
     }
-    if (width <= 0 || height <= 0) {
-        GLFWwindow* current_context = glfwGetCurrentContext();
-        if (current_context) {
-            glfwGetWindowSize(current_context, &width, &height);
-        }
+  }
+
+  ui->appbar_bounds.x = 0.0f;
+  ui->appbar_bounds.y = 0.0f;
+  ui->appbar_bounds.w = (float)width;
+  ui->appbar_bounds.h = ui_menubar_height(ui->menu_bar);
+
+  content_top = ui->appbar_bounds.h;
+  content_bottom = (float)height - ui->theme.status_height;
+  content_height = content_bottom - content_top;
+  if (content_height < 1.0f) {
+    content_height = 1.0f;
+  }
+
+  rail_bounds.x = 0.0f;
+  rail_bounds.y = content_top;
+  rail_bounds.w = ui->theme.tool_rail_width;
+  rail_bounds.h = content_height;
+  ui->rail_bounds = rail_bounds;
+  if (!ui->modal_active) {
+    ui_tool_rail(ui, workspace, rail_bounds);
+  }
+
+  inspector_requested = ui_menubar_inspector_visible(ui->menu_bar);
+  needed_width = ui->theme.tool_rail_width + UI_MIN_CANVAS_WIDTH;
+  if (inspector_requested) {
+    needed_width += ui->theme.panel_width;
+  }
+  inspector_target_visible =
+      inspector_requested && ((float)width >= needed_width);
+  ui->inspector_target_visible = inspector_target_visible;
+
+  if (!ui->inspector_anim_initialized) {
+    ui->inspector_anim_t = inspector_target_visible ? 1.0f : 0.0f;
+    ui->inspector_anim_initialized = 1;
+  } else if (!ui->theme.enable_transitions ||
+             ui->theme.transition_duration <= 1e-4f) {
+    ui->inspector_anim_t = inspector_target_visible ? 1.0f : 0.0f;
+  } else {
+    anim_step = dt_seconds / ui->theme.transition_duration;
+    if (ui->inspector_target_visible) {
+      ui->inspector_anim_t =
+          ui_clampf(ui->inspector_anim_t + anim_step, 0.0f, 1.0f);
+    } else {
+      ui->inspector_anim_t =
+          ui_clampf(ui->inspector_anim_t - anim_step, 0.0f, 1.0f);
     }
+  }
 
-    if (width <= 0 || height <= 0) {
-        if (workspace) {
-            ui_publish_layout(ui, workspace, 1, 1);
-        }
-        return;
-    }
-    now_seconds = glfwGetTime();
-    dt_seconds = (float)(now_seconds - ui->last_frame_seconds);
-    ui->last_frame_seconds = now_seconds;
-    dt_seconds = ui_clampf(dt_seconds, 0.0f, 0.10f);
-    ui_system_poll_theme_hot_reload(ui, workspace, now_seconds);
-
-    if (ui->menu_bar && !ui->modal_active) {
-        int requested_theme_index = -1;
-        int requested_theme_reload = 0;
-        const UiThemeDescriptor* requested_theme = NULL;
-
-        ui_menubar_set_height(ui->menu_bar, ui->theme.menu_height);
-        ui_menubar_build(ui->menu_bar, workspace, width);
-
-        requested_theme_reload = ui_menubar_take_theme_reload_request(ui->menu_bar);
-        if (requested_theme_reload) {
-            ui_system_reload_themes(ui, workspace, 1, UI_THEME_RELOAD_REASON_MANUAL);
-        }
-
-        requested_theme_index = ui_menubar_take_theme_request(ui->menu_bar);
-        if (requested_theme_index >= 0) {
-            requested_theme = ui_theme_descriptor_at(requested_theme_index);
-            if (requested_theme && ui_system_set_theme(ui, requested_theme->id, 1)) {
-                snprintf(workspace->status_message,
-                         sizeof(workspace->status_message),
-                         "Theme: %s",
-                         requested_theme->label ? requested_theme->label : requested_theme->id);
-            }
-        }
-    }
-
-    ui->appbar_bounds.x = 0.0f;
-    ui->appbar_bounds.y = 0.0f;
-    ui->appbar_bounds.w = (float)width;
-    ui->appbar_bounds.h = ui_menubar_height(ui->menu_bar);
-
-    content_top = ui->appbar_bounds.h;
-    content_bottom = (float)height - ui->theme.status_height;
-    content_height = content_bottom - content_top;
-    if (content_height < 1.0f) {
-        content_height = 1.0f;
-    }
-
-    rail_bounds.x = 0.0f;
-    rail_bounds.y = content_top;
-    rail_bounds.w = ui->theme.tool_rail_width;
-    rail_bounds.h = content_height;
-    ui->rail_bounds = rail_bounds;
+  inspector_render_visible = (ui->inspector_anim_t > 1e-3f);
+  if (inspector_render_visible) {
+    inspector_eased_t = ui_smoothstep(ui->inspector_anim_t);
+    inspector_bounds.w = ui->theme.panel_width;
+    inspector_bounds.h = content_height;
+    inspector_hidden_x = (float)width;
+    inspector_shown_x = (float)width - inspector_bounds.w;
+    inspector_bounds.x =
+        inspector_hidden_x +
+        (inspector_shown_x - inspector_hidden_x) * inspector_eased_t;
+    inspector_bounds.y = content_top;
+    ui->panel_bounds = inspector_bounds;
     if (!ui->modal_active) {
-        ui_tool_rail(ui, workspace, rail_bounds);
+      ui_selection_panel(ui, workspace, inspector_bounds);
     }
+  } else {
+    ui->panel_bounds.x = 0.0f;
+    ui->panel_bounds.y = 0.0f;
+    ui->panel_bounds.w = 0.0f;
+    ui->panel_bounds.h = 0.0f;
+  }
 
-    inspector_requested = ui_menubar_inspector_visible(ui->menu_bar);
-    needed_width = ui->theme.tool_rail_width + UI_MIN_CANVAS_WIDTH;
-    if (inspector_requested) {
-        needed_width += ui->theme.panel_width;
-    }
-    inspector_target_visible = inspector_requested && ((float)width >= needed_width);
-    ui->inspector_target_visible = inspector_target_visible;
+  ui_status_bar(ui, workspace, width, height);
+  ui_modal_dialogs(ui, workspace, width, height);
 
-    if (!ui->inspector_anim_initialized) {
-        ui->inspector_anim_t = inspector_target_visible ? 1.0f : 0.0f;
-        ui->inspector_anim_initialized = 1;
-    } else if (!ui->theme.enable_transitions || ui->theme.transition_duration <= 1e-4f) {
-        ui->inspector_anim_t = inspector_target_visible ? 1.0f : 0.0f;
-    } else {
-        anim_step = dt_seconds / ui->theme.transition_duration;
-        if (ui->inspector_target_visible) {
-            ui->inspector_anim_t = ui_clampf(ui->inspector_anim_t + anim_step, 0.0f, 1.0f);
-        } else {
-            ui->inspector_anim_t = ui_clampf(ui->inspector_anim_t - anim_step, 0.0f, 1.0f);
-        }
-    }
+  ui->content_bounds.x = ui->rail_bounds.x + ui->rail_bounds.w;
+  ui->content_bounds.y = ui->appbar_bounds.y + ui->appbar_bounds.h;
+  if (ui->panel_bounds.w > 1e-3f) {
+    ui->content_bounds.w = ui->panel_bounds.x - ui->content_bounds.x;
+  } else {
+    ui->content_bounds.w = (float)width - ui->content_bounds.x;
+  }
+  ui->content_bounds.h = ui->status_bounds.y - ui->content_bounds.y;
 
-    inspector_render_visible = (ui->inspector_anim_t > 1e-3f);
-    if (inspector_render_visible) {
-        inspector_eased_t = ui_smoothstep(ui->inspector_anim_t);
-        inspector_bounds.w = ui->theme.panel_width;
-        inspector_bounds.h = content_height;
-        inspector_hidden_x = (float)width;
-        inspector_shown_x = (float)width - inspector_bounds.w;
-        inspector_bounds.x = inspector_hidden_x + (inspector_shown_x - inspector_hidden_x) * inspector_eased_t;
-        inspector_bounds.y = content_top;
-        ui->panel_bounds = inspector_bounds;
-        if (!ui->modal_active) {
-            ui_selection_panel(ui, workspace, inspector_bounds);
-        }
-    } else {
-        ui->panel_bounds.x = 0.0f;
-        ui->panel_bounds.y = 0.0f;
-        ui->panel_bounds.w = 0.0f;
-        ui->panel_bounds.h = 0.0f;
-    }
+  if (ui->content_bounds.w < 1.0f) {
+    ui->content_bounds.w = 1.0f;
+  }
+  if (ui->content_bounds.h < 1.0f) {
+    ui->content_bounds.h = 1.0f;
+  }
 
-    ui_status_bar(ui, workspace, width, height);
-    ui_modal_dialogs(ui, workspace, width, height);
-
-    ui->content_bounds.x = ui->rail_bounds.x + ui->rail_bounds.w;
-    ui->content_bounds.y = ui->appbar_bounds.y + ui->appbar_bounds.h;
-    if (ui->panel_bounds.w > 1e-3f) {
-        ui->content_bounds.w = ui->panel_bounds.x - ui->content_bounds.x;
-    } else {
-        ui->content_bounds.w = (float)width - ui->content_bounds.x;
-    }
-    ui->content_bounds.h = ui->status_bounds.y - ui->content_bounds.y;
-
-    if (ui->content_bounds.w < 1.0f) {
-        ui->content_bounds.w = 1.0f;
-    }
-    if (ui->content_bounds.h < 1.0f) {
-        ui->content_bounds.h = 1.0f;
-    }
-
-    ui_publish_layout(ui, workspace, width, height);
+  ui_publish_layout(ui, workspace, width, height);
 }
 
-void ui_system_render(UiSystem* ui)
-{
-    if (!ui) {
-        return;
-    }
-    nk_glfw3_render(&ui->glfw, NK_ANTI_ALIASING_ON, UI_MAX_VERTEX_BUFFER, UI_MAX_ELEMENT_BUFFER);
+void ui_system_render(UiSystem *ui) {
+  if (!ui) {
+    return;
+  }
+  nk_glfw3_render(&ui->glfw, NK_ANTI_ALIASING_ON, UI_MAX_VERTEX_BUFFER,
+                  UI_MAX_ELEMENT_BUFFER);
 }
 
-int ui_system_has_active_interaction(const UiSystem* ui)
-{
-    if (!ui || !ui->ctx) {
-        return 0;
-    }
+int ui_system_has_active_interaction(const UiSystem *ui) {
+  if (!ui || !ui->ctx) {
+    return 0;
+  }
 
-    return nk_item_is_any_active(ui->ctx);
+  return nk_item_is_any_active(ui->ctx);
 }
 
-int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos)
-{
-    if (!ui || !ui->ctx) {
-        return 0;
-    }
+int ui_system_blocks_pointer(const UiSystem *ui, Vec2 screen_pos) {
+  if (!ui || !ui->ctx) {
+    return 0;
+  }
 
-    if (ui->modal_active) {
-        (void)screen_pos;
-        return 1;
-    }
+  if (ui->modal_active) {
+    (void)screen_pos;
+    return 1;
+  }
 
-    if (ui_system_has_active_interaction(ui)) {
-        return 1;
-    }
+  if (ui_system_has_active_interaction(ui)) {
+    return 1;
+  }
 
-    return rectf_contains_point(&ui->layout_snapshot.appbar_bounds, screen_pos) ||
-           rectf_contains_point(&ui->layout_snapshot.rail_bounds, screen_pos) ||
-           rectf_contains_point(&ui->layout_snapshot.panel_bounds, screen_pos) ||
-           rectf_contains_point(&ui->layout_snapshot.status_bounds, screen_pos);
+  return rectf_contains_point(&ui->layout_snapshot.appbar_bounds, screen_pos) ||
+         rectf_contains_point(&ui->layout_snapshot.rail_bounds, screen_pos) ||
+         rectf_contains_point(&ui->layout_snapshot.panel_bounds, screen_pos) ||
+         rectf_contains_point(&ui->layout_snapshot.status_bounds, screen_pos);
 }
 
-RectF ui_system_window_bounds(const UiSystem* ui)
-{
-    RectF bounds = {0.0f, 0.0f, 1.0f, 1.0f};
+RectF ui_system_window_bounds(const UiSystem *ui) {
+  RectF bounds = {0.0f, 0.0f, 1.0f, 1.0f};
 
-    if (!ui) {
-        return bounds;
-    }
-
-    bounds = ui->layout_snapshot.window_bounds;
-    if (bounds.w < 1.0f) {
-        bounds.w = 1.0f;
-    }
-    if (bounds.h < 1.0f) {
-        bounds.h = 1.0f;
-    }
+  if (!ui) {
     return bounds;
+  }
+
+  bounds = ui->layout_snapshot.window_bounds;
+  if (bounds.w < 1.0f) {
+    bounds.w = 1.0f;
+  }
+  if (bounds.h < 1.0f) {
+    bounds.h = 1.0f;
+  }
+  return bounds;
 }
 
-RectF ui_system_content_bounds(const UiSystem* ui)
-{
-    RectF bounds = {0.0f, 0.0f, 0.0f, 0.0f};
+RectF ui_system_content_bounds(const UiSystem *ui) {
+  RectF bounds = {0.0f, 0.0f, 0.0f, 0.0f};
 
-    if (!ui) {
-        return bounds;
-    }
+  if (!ui) {
+    return bounds;
+  }
 
-    return ui->layout_snapshot.canvas_content_bounds;
+  return ui->layout_snapshot.canvas_content_bounds;
 }
 
-int ui_system_point_in_canvas(const UiSystem* ui, Vec2 screen_pos)
-{
-    RectF canvas_bounds = ui_system_content_bounds(ui);
-    RectF window_bounds = ui_system_window_bounds(ui);
+int ui_system_point_in_canvas(const UiSystem *ui, Vec2 screen_pos) {
+  RectF canvas_bounds = ui_system_content_bounds(ui);
+  RectF window_bounds = ui_system_window_bounds(ui);
 
-    if (canvas_bounds.w <= 1.0f || canvas_bounds.h <= 1.0f) {
-        canvas_bounds = window_bounds;
-    }
+  if (canvas_bounds.w <= 1.0f || canvas_bounds.h <= 1.0f) {
+    canvas_bounds = window_bounds;
+  }
 
-    return rectf_contains_point(&canvas_bounds, screen_pos);
+  return rectf_contains_point(&canvas_bounds, screen_pos);
 }
 
-Color ui_system_canvas_background(const UiSystem* ui)
-{
-    Color background = {0.11f, 0.12f, 0.14f, 1.0f};
+Color ui_system_canvas_background(const UiSystem *ui) {
+  Color background = {0.11f, 0.12f, 0.14f, 1.0f};
 
-    if (!ui) {
-        return background;
-    }
-
-    background.r = (float)ui->theme.canvas_background.r / 255.0f;
-    background.g = (float)ui->theme.canvas_background.g / 255.0f;
-    background.b = (float)ui->theme.canvas_background.b / 255.0f;
-    background.a = (float)ui->theme.canvas_background.a / 255.0f;
+  if (!ui) {
     return background;
+  }
+
+  background.r = (float)ui->theme.canvas_background.r / 255.0f;
+  background.g = (float)ui->theme.canvas_background.g / 255.0f;
+  background.b = (float)ui->theme.canvas_background.b / 255.0f;
+  background.a = (float)ui->theme.canvas_background.a / 255.0f;
+  return background;
 }

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -13,6 +13,7 @@
 #include <ui/ui_system.h>
 #include <ui/ui_menubar.h>
 
+#include <app/workspace_actions.h>
 #include <app/workspace.h>
 #include <base/math2d.h>
 #include <canvas/canvas_view.h>
@@ -70,6 +71,7 @@ struct UiSystem {
     float inspector_anim_t;
     int inspector_target_visible;
     int inspector_anim_initialized;
+    int modal_active;
     double last_frame_seconds;
 };
 
@@ -686,6 +688,109 @@ static void ui_status_bar(UiSystem* ui, Workspace* workspace, int window_width, 
     nk_end(ctx);
 }
 
+/** Render a centered modal dialog for active workspace confirmation flows. */
+static void ui_modal_dialogs(UiSystem* ui, Workspace* workspace, int window_width, int window_height)
+{
+    struct nk_context* ctx = NULL;
+    struct nk_style_item blocker_background;
+    struct nk_rect modal_bounds;
+    float modal_width = 360.0f;
+    float modal_height = 170.0f;
+    const char* title = NULL;
+    const char* message = NULL;
+    const char* line_break = NULL;
+    char line_one[128];
+    char line_two[128];
+    size_t line_one_length = 0u;
+
+    if (!ui || !workspace || !workspace_modal_is_active(workspace)) {
+        return;
+    }
+
+    ctx = ui->ctx;
+    if (!ctx) {
+        return;
+    }
+
+    if ((float)window_width < modal_width + 24.0f) {
+        modal_width = (float)window_width - 24.0f;
+    }
+    if ((float)window_height < modal_height + 24.0f) {
+        modal_height = (float)window_height - 24.0f;
+    }
+    if (modal_width < 240.0f) {
+        modal_width = 240.0f;
+    }
+    if (modal_height < 140.0f) {
+        modal_height = 140.0f;
+    }
+
+    modal_bounds = nk_rect(((float)window_width - modal_width) * 0.5f,
+                           ((float)window_height - modal_height) * 0.5f,
+                           modal_width,
+                           modal_height);
+
+    title = workspace_modal_title(workspace);
+    message = workspace_modal_message(workspace);
+    line_one[0] = '\0';
+    line_two[0] = '\0';
+
+    if (message) {
+        line_break = strchr(message, '\n');
+        if (line_break) {
+            line_one_length = (size_t)(line_break - message);
+            if (line_one_length >= sizeof(line_one)) {
+                line_one_length = sizeof(line_one) - 1u;
+            }
+            memcpy(line_one, message, line_one_length);
+            line_one[line_one_length] = '\0';
+            snprintf(line_two, sizeof(line_two), "%s", line_break + 1);
+        } else {
+            snprintf(line_one, sizeof(line_one), "%s", message);
+        }
+    }
+
+    blocker_background = nk_style_item_color(nk_rgba(0, 0, 0, 96));
+    nk_style_push_style_item(ctx, &ctx->style.window.fixed_background, blocker_background);
+    if (nk_begin(ctx,
+                 "##modal_blocker##",
+                 nk_rect(0.0f, 0.0f, (float)window_width, (float)window_height),
+                 NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND)) {
+        nk_layout_row_dynamic(ctx, 1.0f, 1);
+        nk_label(ctx, "", NK_TEXT_LEFT);
+    }
+    nk_end(ctx);
+    nk_style_pop_style_item(ctx);
+
+    if (nk_begin(ctx,
+                 title && title[0] != '\0' ? title : "Modal",
+                 modal_bounds,
+                 NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_TITLE)) {
+        nk_layout_row_dynamic(ctx, 22.0f, 1);
+        if (line_one[0] != '\0') {
+            nk_label(ctx, line_one, NK_TEXT_LEFT);
+        }
+        if (line_two[0] != '\0') {
+            nk_label(ctx, line_two, NK_TEXT_LEFT);
+        }
+
+        nk_layout_row_dynamic(ctx, 12.0f, 1);
+        nk_label(ctx, "", NK_TEXT_LEFT);
+
+        nk_layout_row_dynamic(ctx, 34.0f, 3);
+        if (nk_button_label(ctx, "Save")) {
+            workspace_confirm_pending_action_save(workspace);
+        }
+        if (nk_button_label(ctx, "Don't Save")) {
+            workspace_confirm_pending_action_discard(workspace);
+        }
+        if (nk_button_label(ctx, "Cancel")) {
+            workspace_confirm_pending_action_cancel(workspace);
+        }
+    }
+    nk_end(ctx);
+}
+
 UiSystem* ui_system_create(PlatformWindow* window)
 {
     UiSystem* ui = (UiSystem*)calloc(1, sizeof(*ui));
@@ -771,6 +876,8 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
         return;
     }
 
+    ui->modal_active = workspace_modal_is_active(workspace);
+
     if (ui->window_handle) {
         glfwGetWindowSize(ui->window_handle, &width, &height);
     }
@@ -793,7 +900,7 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
     dt_seconds = ui_clampf(dt_seconds, 0.0f, 0.10f);
     ui_system_poll_theme_hot_reload(ui, workspace, now_seconds);
 
-    if (ui->menu_bar) {
+    if (ui->menu_bar && !ui->modal_active) {
         int requested_theme_index = -1;
         int requested_theme_reload = 0;
         const UiThemeDescriptor* requested_theme = NULL;
@@ -834,7 +941,10 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
     rail_bounds.y = content_top;
     rail_bounds.w = ui->theme.tool_rail_width;
     rail_bounds.h = content_height;
-    ui_tool_rail(ui, workspace, rail_bounds);
+    ui->rail_bounds = rail_bounds;
+    if (!ui->modal_active) {
+        ui_tool_rail(ui, workspace, rail_bounds);
+    }
 
     inspector_requested = ui_menubar_inspector_visible(ui->menu_bar);
     needed_width = ui->theme.tool_rail_width + UI_MIN_CANVAS_WIDTH;
@@ -867,7 +977,10 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
         inspector_shown_x = (float)width - inspector_bounds.w;
         inspector_bounds.x = inspector_hidden_x + (inspector_shown_x - inspector_hidden_x) * inspector_eased_t;
         inspector_bounds.y = content_top;
-        ui_selection_panel(ui, workspace, inspector_bounds);
+        ui->panel_bounds = inspector_bounds;
+        if (!ui->modal_active) {
+            ui_selection_panel(ui, workspace, inspector_bounds);
+        }
     } else {
         ui->panel_bounds.x = 0.0f;
         ui->panel_bounds.y = 0.0f;
@@ -876,6 +989,7 @@ void ui_system_build(UiSystem* ui, Workspace* workspace)
     }
 
     ui_status_bar(ui, workspace, width, height);
+    ui_modal_dialogs(ui, workspace, width, height);
 
     ui->content_bounds.x = ui->rail_bounds.x + ui->rail_bounds.w;
     ui->content_bounds.y = ui->appbar_bounds.y + ui->appbar_bounds.h;
@@ -917,6 +1031,11 @@ int ui_system_blocks_pointer(const UiSystem* ui, Vec2 screen_pos)
 {
     if (!ui || !ui->ctx) {
         return 0;
+    }
+
+    if (ui->modal_active) {
+        (void)screen_pos;
+        return 1;
     }
 
     if (ui_system_has_active_interaction(ui)) {


### PR DESCRIPTION
Closes #25

## Summary
- refactor keyboard input around command-driven routing and centralized keymap ownership
- extract reusable workspace dialog definitions, templates, and resolvers
- move the unsaved-changes confirmation flow onto the reusable dialog foundation

## Testing
- GitHub Actions build checks passed at merge