### PR TITLE
fix: Align conflicted comments with main for PR #47 follow-up

### DIFF
--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -1,14 +1,6 @@
 /**
  * @file workspace.h
- * @brief Shared editor state hub used across runtime systems.
- *
- * Role in project:
- * - Aggregates document, history, canvas, tools, and UI layout state.
- * - Provides function hooks for save/load commands.
- *
- * Module relationships:
- * - Owned by `application.c`.
- * - Referenced by tools and UI for coordinated document operations.
+ * @brief Editor runtime shared workspace definition.
  */
 #ifndef GLDRAW_APP_WORKSPACE_H
 #define GLDRAW_APP_WORKSPACE_H
@@ -20,10 +12,20 @@
 #include <tools/tool_controller.h>
 
 struct Workspace;
-/** Callback signature for workspace-level commands (save/load). */
+
+/**
+ * @typedef WorkspaceCommandFn
+ * @brief Workspace command callback signature (e.g., save/load).
+ * @param workspace Target workspace.
+ * @param user_data Caller-supplied context passed through.
+ * @return Non-zero on success, zero on failure.
+ */
 typedef int (*WorkspaceCommandFn)(struct Workspace* workspace, void* user_data);
 
-/** Destructive editor actions that may need unsaved-change confirmation. */
+/**
+ * @enum WorkspaceActionType
+ * @brief Destructive workspace actions that may require deferred confirmation.
+ */
 typedef enum WorkspaceActionType {
     WORKSPACE_ACTION_NONE = 0,
     WORKSPACE_ACTION_NEW_DOCUMENT,
@@ -31,19 +33,28 @@ typedef enum WorkspaceActionType {
     WORKSPACE_ACTION_EXIT_APPLICATION
 } WorkspaceActionType;
 
-/** Top-level UI request kinds owned by the workspace. */
+/**
+ * @enum UiRequestType
+ * @brief Top-level UI request kinds owned by the workspace.
+ */
 typedef enum UiRequestType {
     UI_REQUEST_NONE = 0,
     UI_REQUEST_DIALOG
 } UiRequestType;
 
-/** Stable dialog kinds used to route dialog results back into business state. */
+/**
+ * @enum UiDialogKind
+ * @brief Stable dialog kinds used to resolve reusable dialog flows.
+ */
 typedef enum UiDialogKind {
     UI_DIALOG_NONE = 0,
     UI_DIALOG_CONFIRM_UNSAVED
 } UiDialogKind;
 
-/** Standard dialog button outcomes returned by reusable UI components. */
+/**
+ * @enum UiDialogResult
+ * @brief Standard dialog outcomes returned by reusable UI components.
+ */
 typedef enum UiDialogResult {
     UI_DIALOG_RESULT_NONE = 0,
     UI_DIALOG_RESULT_PRIMARY,
@@ -51,20 +62,46 @@ typedef enum UiDialogResult {
     UI_DIALOG_RESULT_CANCEL
 } UiDialogResult;
 
-/** Small reusable payload block reserved for future dialog-specific data. */
+/**
+ * @struct UiDialogPayload
+ * @brief Small reusable payload block reserved for future dialog-specific data.
+ *
+ * @member int_values Integer payload slots.
+ * @member text Text payload buffer.
+ */
 typedef struct UiDialogPayload {
     int int_values[4];
     char text[128];
 } UiDialogPayload;
 
-/** Static button description used by generic dialog rendering. */
+/**
+ * @struct UiDialogButtonSpec
+ * @brief Static button description used by generic dialog rendering.
+ *
+ * @member label Button label text.
+ * @member result Result emitted when the button is selected.
+ * @member is_default Non-zero when this button is the default action.
+ */
 typedef struct UiDialogButtonSpec {
     char label[24];
     UiDialogResult result;
     int is_default;
 } UiDialogButtonSpec;
 
-/** Complete dialog state model owned by the workspace and rendered by UI components. */
+/**
+ * @struct UiDialogState
+ * @brief Complete dialog state model owned by the workspace and rendered by UI components.
+ *
+ * @member kind Stable dialog kind used by business logic.
+ * @member title Dialog title.
+ * @member message Dialog body text.
+ * @member payload Reserved dialog payload.
+ * @member buttons Button specifications.
+ * @member button_count Number of active buttons in `buttons`.
+ * @member width Preferred dialog width.
+ * @member height Preferred dialog height.
+ * @member modal Non-zero when the dialog blocks background interaction.
+ */
 typedef struct UiDialogState {
     UiDialogKind kind;
     char title[64];
@@ -77,12 +114,30 @@ typedef struct UiDialogState {
     int modal;
 } UiDialogState;
 
-/** Callback signature for application-owned workspace action execution. */
+/**
+ * @typedef WorkspaceActionExecutorFn
+ * @brief Application-owned executor for deferred workspace actions.
+ * @param workspace Target workspace.
+ * @param action Requested action.
+ * @param user_data Caller-supplied context passed through.
+ * @return Non-zero on success, zero on failure.
+ */
 typedef int (*WorkspaceActionExecutorFn)(struct Workspace* workspace,
                                          WorkspaceActionType action,
                                          void* user_data);
 
-/** UI-computed layout snapshot shared with input/canvas subsystems. */
+/**
+ * @struct WorkspaceLayout
+ * @brief Layout snapshot computed by the UI.
+ *
+ * @member window_bounds Window boundary.
+ * @member canvas_content_bounds Available canvas content area.
+ * @member appbar_bounds Top toolbar area.
+ * @member rail_bounds Left tool rail area.
+ * @member panel_bounds Right panel area.
+ * @member status_bounds Bottom status bar area.
+ * @member layout_revision Layout version number (used for cross-system sync).
+ */
 typedef struct WorkspaceLayout {
     RectF window_bounds;
     RectF canvas_content_bounds;
@@ -94,43 +149,49 @@ typedef struct WorkspaceLayout {
 } WorkspaceLayout;
 
 /**
- * @brief Central runtime state passed between systems.
+ * @struct Workspace
+ * @brief Runtime core state container.
  *
- * Memory ownership notes:
- * - `document`, `history`, `canvas`, and `tools` are embedded values (no extra indirection).
- * - `save_document`/`load_document` are callbacks owned by the application layer.
- *
- * Concurrency note:
- * - This struct is not thread-safe; all access must be serialized by the caller.
+ * @member document Current document object and selection state.
+ * @member history Undo/redo history.
+ * @member canvas Canvas view state.
+ * @member tools Tool controller.
+ * @member keymap Effective keyboard mapping state.
+ * @member layout UI layout information.
+ * @member current_document_path Current document path (empty string means unnamed).
+ * @member status_message Status bar message.
+ * @member saved_revision Document revision corresponding to the last save.
+ * @member document_dirty Whether the document is dirty (non-zero means unsaved changes).
+ * @member active_request_type Active top-level UI request type.
+ * @member active_dialog Active reusable dialog state.
+ * @member save_document Save callback.
+ * @member load_document Load callback.
+ * @member execute_action Deferred workspace action executor.
+ * @member command_user_data Callback context.
  */
 typedef struct Workspace {
-    Document document;              /**< In-memory document with objects and selection */
-    DocumentHistory history;        /**< Undo/redo stacks */
-    CanvasView canvas;              /**< Viewport, zoom, pan, and coordinate transforms */
-    ToolController tools;           /**< Active tool and its runtime state */
-    EditorKeymap keymap;            /**< Effective keyboard mapping state */
-    WorkspaceLayout layout;        /**< UI-computed layout rectangles (set by UI system) */
-    char current_document_path[260]; /**< Active file path (empty for new documents) */
-    char status_message[256];       /**< Current status bar message */
-    unsigned int saved_revision;     /**< Document revision last marked as saved */
-    int document_dirty;             /**< Non-zero when current revision differs from saved_revision */
-    UiRequestType active_request_type; /**< Active UI request type owned by the workspace */
-    UiDialogState active_dialog;    /**< Active reusable dialog state */
-    WorkspaceCommandFn save_document; /**< Workspace-level save callback */
-    WorkspaceCommandFn load_document; /**< Workspace-level load callback */
-    WorkspaceActionExecutorFn execute_action; /**< Application-owned action executor */
-    void* command_user_data;        /**< Caller-supplied context for command callbacks */
+    Document document;
+    DocumentHistory history;
+    CanvasView canvas;
+    ToolController tools;
+    EditorKeymap keymap;
+    WorkspaceLayout layout;
+    char current_document_path[260];
+    char status_message[256];
+    unsigned int saved_revision;
+    int document_dirty;
+    UiRequestType active_request_type;
+    UiDialogState active_dialog;
+    WorkspaceCommandFn save_document;
+    WorkspaceCommandFn load_document;
+    WorkspaceActionExecutorFn execute_action;
+    void* command_user_data;
 } Workspace;
 
 /**
- * @brief Mark the current document revision as persisted.
- * @param workspace [in,out] Target workspace; ignored when `NULL`.
- * @return None.
- *
- * Edge cases:
- * - Safe no-op for `NULL`.
- *
- * Time complexity: `O(1)`.
+ * @brief Mark the current document revision as saved.
+ * @param workspace Target workspace; no-op if `NULL`.
+ * @return No return value.
  */
 static inline void workspace_mark_saved(Workspace* workspace)
 {
@@ -143,14 +204,9 @@ static inline void workspace_mark_saved(Workspace* workspace)
 }
 
 /**
- * @brief Recompute dirty flag from saved revision and current revision.
- * @param workspace [in,out] Target workspace; ignored when `NULL`.
- * @return None.
- *
- * Edge cases:
- * - Safe no-op for `NULL`.
- *
- * Time complexity: `O(1)`.
+ * @brief Sync the dirty flag based on `saved_revision` and the current revision.
+ * @param workspace Target workspace; no-op if `NULL`.
+ * @return No return value.
  */
 static inline void workspace_sync_document_dirty(Workspace* workspace)
 {

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -8,8 +8,7 @@
  *
  * Module relationships:
  * - Uses workspace as central state container.
- * - Coordinates platform window, render system, UI system, tools, and
- * persistence.
+ * - Coordinates platform window, render system, UI system, tools, and persistence.
  */
 #include <app/application.h>
 
@@ -77,8 +76,11 @@ static void app_set_status(Application *app, const char *fmt, ...) {
   va_end(args);
 }
 
-/** Check if file exists by opening it in read-binary mode. Complexity: `O(1)`
- * (metadata + open). */
+/**
+ * @brief Check if a file exists at the given path.
+ * @param path File path string.
+ * @return `1` if the file exists, `0` otherwise.
+ */
 static int app_file_exists(const char *path) {
   FILE *file = NULL;
 
@@ -95,12 +97,17 @@ static int app_file_exists(const char *path) {
   return 1;
 }
 
-/** Return fallback document path used when workspace path is empty. Complexity:
- * `O(1)`. */
+/**
+ * @brief Get the default document path.
+ * @return Default document path string.
+ */
 static const char *app_default_document_path(void) { return "document.json"; }
 
-/** Resolve active document path (workspace path or default). Complexity:
- * `O(1)`. */
+/**
+ * @brief Get the current document path from workspace state.
+ * @param app Application instance.
+ * @return Current document path string.
+ */
 static const char *app_current_document_path(const Application *app) {
   if (app->workspace.current_document_path[0] != '\0') {
     return app->workspace.current_document_path;
@@ -130,8 +137,11 @@ static void app_set_document_path(Application *app, const char *path) {
                              1u] = '\0';
 }
 
-/** Reset tool controller runtime state after major document changes.
- * Complexity: `O(tool_count)`. */
+/**
+ * @brief Reset tool controller state.
+ * @param app Application instance.
+ * @return No return value.
+ */
 static void app_reset_tool_state(Application *app) {
   if (!app) {
     return;
@@ -242,13 +252,23 @@ static int app_exit_application(Application *app) {
   return 1;
 }
 
-/** Workspace save callback adapter. Complexity: same as `app_save_document`. */
+/**
+ * @brief Workspace save callback.
+ * @param workspace Workspace (unused, accessed via user_data).
+ * @param user_data Application instance.
+ * @return `1` on success, `0` on failure.
+ */
 static int app_workspace_save(Workspace *workspace, void *user_data) {
   (void)workspace;
   return app_save_document((Application *)user_data);
 }
 
-/** Workspace load callback adapter. Complexity: same as `app_load_document`. */
+/**
+ * @brief Workspace load callback.
+ * @param workspace Workspace (unused, accessed via user_data).
+ * @param user_data Application instance.
+ * @return `1` on success, `0` on failure.
+ */
 static int app_workspace_load(Workspace *workspace, void *user_data) {
   (void)workspace;
   return app_load_document((Application *)user_data);
@@ -273,8 +293,11 @@ static int app_workspace_execute_action(Workspace *workspace,
   }
 }
 
-/** Load startup document if present; otherwise keep empty document. Complexity:
- * `O(file_size)` when file exists. */
+/**
+ * @brief Open the startup document if it exists.
+ * @param app Application instance.
+ * @return No return value.
+ */
 static void app_open_startup_document(Application *app) {
   const char *path = app_current_document_path(app);
 
@@ -292,8 +315,11 @@ static void app_open_startup_document(Application *app) {
   app_set_status(app, "New empty document");
 }
 
-/** Build tool context struct from application-owned workspace pointers.
- * Complexity: `O(1)`. */
+/**
+ * @brief Build a tool context from application-owned workspace pointers.
+ * @param app Application instance.
+ * @return Tool context value.
+ */
 static ToolContext app_tool_context(Application *app) {
   ToolContext context;
   context.workspace = &app->workspace;
@@ -310,8 +336,6 @@ static ToolContext app_tool_context(Application *app) {
  *
  * Why:
  * - Prevents accidental drawing/selection while interacting with UI widgets.
- *
- * Complexity: `O(1)`.
  */
 static int app_pointer_blocks_canvas(const Application *app, Vec2 screen_pos) {
   if (!app) {
@@ -325,8 +349,11 @@ static int app_pointer_blocks_canvas(const Application *app, Vec2 screen_pos) {
   return app->ui && !ui_system_point_in_canvas(app->ui, screen_pos);
 }
 
-/** Sync tool controller's last pointer anchor with current cursor state.
- * Complexity: `O(1)`. */
+/**
+ * @brief Sync the tool controller pointer anchor with current cursor state.
+ * @param app Application instance.
+ * @return No return value.
+ */
 static void app_sync_tool_pointer_anchor(Application *app) {
   if (!app) {
     return;
@@ -337,8 +364,11 @@ static void app_sync_tool_pointer_anchor(Application *app) {
       canvas_view_screen_to_world(&app->workspace.canvas, app->cursor_screen);
 }
 
-/** Refresh cursor-in-canvas flag for uncaptured pointer movement. Complexity:
- * `O(1)`. */
+/**
+ * @brief Refresh whether the cursor is inside the canvas area.
+ * @param app Application instance.
+ * @return No return value.
+ */
 static void app_sync_canvas_boundary(Application *app) {
   int inside_canvas = 0;
 
@@ -354,8 +384,11 @@ static void app_sync_canvas_boundary(Application *app) {
   }
 }
 
-/** Update canvas viewport and theme background from latest UI layout.
- * Complexity: `O(1)`. */
+/**
+ * @brief Update the canvas viewport from the latest UI layout snapshot.
+ * @param app Application instance.
+ * @return No return value.
+ */
 static void update_canvas_viewport(Application *app) {
   RectF viewport;
   RectF fallback_window = {0.0f, 0.0f, 1.0f, 1.0f};
@@ -391,8 +424,14 @@ static void update_canvas_viewport(Application *app) {
   app_sync_canvas_boundary(app);
 }
 
-/** Build a `ToolEvent` from current cursor and previous anchor state.
- * Complexity: `O(1)`. */
+/**
+ * @brief Build a `ToolEvent` from the current cursor and previous pointer anchor.
+ * @param app Application instance.
+ * @param button Mouse button code.
+ * @param mods Modifier key flags.
+ * @param wheel_y Scroll delta.
+ * @return Tool event value.
+ */
 static ToolEvent make_tool_event(Application *app, int button, int mods,
                                  float wheel_y) {
   ToolEvent event;
@@ -409,7 +448,12 @@ static ToolEvent make_tool_event(Application *app, int button, int mods,
   return event;
 }
 
-/** GLFW framebuffer resize callback: update viewport and renderer dimensions.
+/**
+ * @brief GLFW framebuffer resize callback.
+ * @param handle GLFW window handle.
+ * @param width New framebuffer width.
+ * @param height New framebuffer height.
+ * @return No return value.
  */
 static void framebuffer_size_callback(GLFWwindow *handle, int width,
                                       int height) {
@@ -423,8 +467,13 @@ static void framebuffer_size_callback(GLFWwindow *handle, int width,
   render_system_resize(app->renderer, width, height);
 }
 
-/** GLFW cursor callback: route pointer-move to active tool when canvas is
- * interactive. */
+/**
+ * @brief GLFW cursor movement callback.
+ * @param handle GLFW window handle.
+ * @param xpos Cursor x position in screen coordinates.
+ * @param ypos Cursor y position in screen coordinates.
+ * @return No return value.
+ */
 static void cursor_pos_callback(GLFWwindow *handle, double xpos, double ypos) {
   Application *app = (Application *)glfwGetWindowUserPointer(handle);
   ToolContext context;
@@ -448,7 +497,14 @@ static void cursor_pos_callback(GLFWwindow *handle, double xpos, double ypos) {
   tool_controller_pointer_move(&app->workspace.tools, &context, &event);
 }
 
-/** GLFW mouse callback: route press/release with pointer capture semantics. */
+/**
+ * @brief GLFW mouse button callback.
+ * @param handle GLFW window handle.
+ * @param button Mouse button code.
+ * @param action Press/release action.
+ * @param mods Modifier key flags.
+ * @return No return value.
+ */
 static void mouse_button_callback(GLFWwindow *handle, int button, int action,
                                   int mods) {
   Application *app = (Application *)glfwGetWindowUserPointer(handle);
@@ -519,7 +575,13 @@ static void key_callback(GLFWwindow *handle, int key, int scancode, int action,
   input_router_handle_key(&router_context, &event);
 }
 
-/** GLFW scroll callback: zoom canvas at cursor unless blocked by UI. */
+/**
+ * @brief GLFW scroll callback.
+ * @param handle GLFW window handle.
+ * @param xoffset Horizontal scroll delta (unused).
+ * @param yoffset Vertical scroll delta.
+ * @return No return value.
+ */
 static void scroll_callback(GLFWwindow *handle, double xoffset,
                             double yoffset) {
   Application *app = (Application *)glfwGetWindowUserPointer(handle);

--- a/src/tools/tool_controller.c
+++ b/src/tools/tool_controller.c
@@ -47,14 +47,22 @@ typedef struct {
     Vec2 current;
 } ShapeToolState;
 
-/** Free and re-init snapshot for reuse. */
+/**
+ * @brief Resets a snapshot.
+ * @param snapshot Snapshot to reset.
+ * @return None.
+ */
 static void snapshot_reset(DocumentSnapshot* snapshot)
 {
     document_snapshot_free(snapshot);
     document_snapshot_init(snapshot);
 }
 
-/** Destroy active overlay object preview if present. */
+/**
+ * @brief Destroys a tool's overlay object.
+ * @param tool Tool instance.
+ * @return None.
+ */
 static void destroy_overlay(Tool* tool)
 {
     if (tool && tool->overlay_object) {
@@ -63,7 +71,12 @@ static void destroy_overlay(Tool* tool)
     }
 }
 
-/** Build axis-aligned rect from two arbitrary points. */
+/**
+ * @brief Creates a rectangle from two points.
+ * @param a First point.
+ * @param b Second point.
+ * @return Rectangle bounds.
+ */
 static RectF rect_from_points(Vec2 a, Vec2 b)
 {
     RectF rect;
@@ -74,7 +87,14 @@ static RectF rect_from_points(Vec2 a, Vec2 b)
     return rect;
 }
 
-/** Create shape object for current shape tool kind. */
+/**
+ * @brief Builds a shape object from tool kind.
+ * @param kind Shape tool kind.
+ * @param anchor Anchor point.
+ * @param current Current point.
+ * @param style Graphic style.
+ * @return New shape object or NULL.
+ */
 static GraphicObject* build_shape_object(ToolKind kind, Vec2 anchor, Vec2 current, GraphicStyle style)
 {
     if (kind == TOOL_KIND_LINE) {
@@ -89,7 +109,12 @@ static GraphicObject* build_shape_object(ToolKind kind, Vec2 anchor, Vec2 curren
     return NULL;
 }
 
-/** Compare document selection against snapshot selection (order-sensitive). */
+/**
+ * @brief Checks if selection matches a snapshot.
+ * @param document Document instance.
+ * @param snapshot Snapshot to compare.
+ * @return 1 if matches, 0 otherwise.
+ */
 static int selection_matches_snapshot(const Document* document, const DocumentSnapshot* snapshot)
 {
     int i = 0;
@@ -112,7 +137,11 @@ static int selection_matches_snapshot(const Document* document, const DocumentSn
 }
 
 /**
- * @brief Push document edit to history and sync dirty flag.
+ * @brief Pushes document edit to history and syncs dirty flag.
+ * @param context [in,out] Tool context.
+ * @param before_snapshot [in,out] Before snapshot (consumed and reset by this function).
+ * @return None.
+ *
  * @remark Safely resets snapshot even when context/history is invalid.
  */
 static void tool_commit_document_change(ToolContext* context, DocumentSnapshot* before_snapshot)
@@ -132,14 +161,23 @@ static void tool_commit_document_change(ToolContext* context, DocumentSnapshot* 
     workspace_sync_document_dirty(context->workspace);
 }
 
-/** Select tool UI label. */
+/**
+ * @brief Gets the select tool label.
+ * @param tool Tool instance.
+ * @return Tool label string.
+ */
 static const char* select_tool_label(const Tool* tool)
 {
     (void)tool;
     return "Select";
 }
 
-/** Deactivate select tool and clear transient state. */
+/**
+ * @brief Deactivates the select tool.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @return None.
+ */
 static void select_tool_deactivate(Tool* tool, ToolContext* context)
 {
     SelectToolState* state = (SelectToolState*)tool->state;
@@ -152,7 +190,11 @@ static void select_tool_deactivate(Tool* tool, ToolContext* context)
 }
 
 /**
- * @brief Handle select tool pointer press.
+ * @brief Handles select tool pointer press.
+ * @param tool [in,out] Select tool instance.
+ * @param context [in,out] Tool context.
+ * @param event [in] Pointer event.
+ * @return None.
  *
  * Why snapshot first:
  * - Captures "before" state before selection/drag mutations so history entry
@@ -236,7 +278,13 @@ static void select_tool_pointer_down(Tool* tool, ToolContext* context, const Too
     state->drag_revision_before = context->document->revision;
 }
 
-/** Move all selected objects by world delta while dragging. */
+/**
+ * @brief Moves selected objects while dragging.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param event Pointer event.
+ * @return None.
+ */
 static void select_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     SelectToolState* state = (SelectToolState*)tool->state;
@@ -265,7 +313,13 @@ static void select_tool_pointer_move(Tool* tool, ToolContext* context, const Too
     document_touch(context->document);
 }
 
-/** Finalize select drag/selection change and commit history when needed. */
+/**
+ * @brief Finalizes select drag handling and commits history when needed.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param event Pointer event.
+ * @return None.
+ */
 static void select_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     SelectToolState* state = (SelectToolState*)tool->state;
@@ -294,7 +348,14 @@ static void select_tool_pointer_up(Tool* tool, ToolContext* context, const ToolE
     state->drag_revision_before = 0u;
 }
 
-/** Handle select tool keyboard input (Escape clears selection). */
+/**
+ * @brief Handles select tool keyboard input.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param key GLFW key code.
+ * @param mods Modifier flags.
+ * @return None.
+ */
 static void select_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)
 {
     (void)tool;
@@ -324,14 +385,23 @@ static const ToolVTable g_select_tool_vtable = {
     select_tool_key_down
 };
 
-/** Pan tool label. */
+/**
+ * @brief Gets the pan tool label.
+ * @param tool Tool instance.
+ * @return Tool label string.
+ */
 static const char* pan_tool_label(const Tool* tool)
 {
     (void)tool;
     return "Hand";
 }
 
-/** Stop panning when tool deactivates. */
+/**
+ * @brief Deactivates the pan tool.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @return None.
+ */
 static void pan_tool_deactivate(Tool* tool, ToolContext* context)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -339,7 +409,13 @@ static void pan_tool_deactivate(Tool* tool, ToolContext* context)
     state->panning = 0;
 }
 
-/** Start panning on left press. */
+/**
+ * @brief Handles pan tool pointer press.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param event Pointer event.
+ * @return None.
+ */
 static void pan_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -351,7 +427,13 @@ static void pan_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEv
     state->panning = 1;
 }
 
-/** Apply screen delta pan while active. */
+/**
+ * @brief Handles pan tool pointer movement.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param event Pointer event.
+ * @return None.
+ */
 static void pan_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -362,7 +444,13 @@ static void pan_tool_pointer_move(Tool* tool, ToolContext* context, const ToolEv
     canvas_view_pan_screen_delta(context->canvas, event->delta_screen);
 }
 
-/** End panning on release. */
+/**
+ * @brief Handles pan tool pointer release.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param event Pointer event.
+ * @return None.
+ */
 static void pan_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     PanToolState* state = (PanToolState*)tool->state;
@@ -373,7 +461,14 @@ static void pan_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEven
     }
 }
 
-/** Handle pan tool keyboard input (Escape cancels panning). */
+/**
+ * @brief Handles pan tool keyboard input.
+ * @param tool Tool instance.
+ * @param context Tool context.
+ * @param key GLFW key code.
+ * @param mods Modifier flags.
+ * @return None.
+ */
 static void pan_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)
 {
     PanToolState* state = (PanToolState*)tool->state;

--- a/src/ui/ui_menu_actions.c
+++ b/src/ui/ui_menu_actions.c
@@ -3,8 +3,12 @@
  * @brief Menu action dispatch implementation.
  *
  * Role in project:
- * - Bridges menu IDs into stable editor commands.
- * - Keeps menu handling thin by delegating business logic to the command registry.
+ * - Maps menu IDs to workspace/document/canvas operations.
+ * - Centralizes shortcut-equivalent command behavior.
+ *
+ * Module relationships:
+ * - Called by menu bar and application shortcut handling.
+ * - Uses command registry to dispatch workspace commands.
  */
 #include "ui_menu_actions.h"
 
@@ -12,6 +16,11 @@
 #include <app/workspace.h>
 #include <base/log.h>
 
+/**
+ * @brief Executes PNG export command (not yet implemented).
+ * @param workspace [in,out] Workspace instance (currently unused).
+ * @return Currently always returns 0.
+ */
 static int app_export_png(Workspace* workspace)
 {
     (void)workspace;
@@ -19,6 +28,11 @@ static int app_export_png(Workspace* workspace)
     return 0;
 }
 
+/**
+ * @brief Checks if menu action is currently available.
+ * @param id [in] Menu action ID.
+ * @return Non-zero if available, 0 if unavailable.
+ */
 int ui_menu_is_action_available(MenuId id)
 {
     switch (id) {
@@ -32,6 +46,12 @@ int ui_menu_is_action_available(MenuId id)
     }
 }
 
+/**
+ * @brief Executes menu action dispatch.
+ * @param workspace [in,out] Workspace instance.
+ * @param id [in] Menu action ID.
+ * @return None.
+ */
 void ui_menu_execute(Workspace* workspace, MenuId id)
 {
     const CommandDescriptor* descriptor = NULL;

--- a/src/ui/ui_menubar.c
+++ b/src/ui/ui_menubar.c
@@ -58,19 +58,28 @@ typedef struct UiQuickActionDef {
     const char* label;
     MenuId menu_id;
     float width;
+    const char* tooltip;
 } UiQuickActionDef;
 
 static const UiQuickActionDef g_quick_actions[] = {
-    { "New", MENU_ID_FILE_NEW, 48.0f },
-    { "Open", MENU_ID_FILE_OPEN, 52.0f },
-    { "Save", MENU_ID_FILE_SAVE, 52.0f },
-    { "Undo", MENU_ID_EDIT_UNDO, 52.0f },
-    { "Redo", MENU_ID_EDIT_REDO, 52.0f },
-    { "+", MENU_ID_VIEW_ZOOM_IN, 30.0f },
-    { "-", MENU_ID_VIEW_ZOOM_OUT, 30.0f },
-    { "Fit", MENU_ID_VIEW_ZOOM_FIT, 40.0f },
+    { "New", MENU_ID_FILE_NEW, 48.0f, "Create new document (Ctrl+N)" },
+    { "Open", MENU_ID_FILE_OPEN, 52.0f, "Open document (Ctrl+O)" },
+    { "Save", MENU_ID_FILE_SAVE, 52.0f, "Save document (Ctrl+S)" },
+    { "Undo", MENU_ID_EDIT_UNDO, 52.0f, "Undo (Ctrl+Z)" },
+    { "Redo", MENU_ID_EDIT_REDO, 52.0f, "Redo (Ctrl+Y)" },
+    { "+", MENU_ID_VIEW_ZOOM_IN, 30.0f, "Zoom in (Ctrl++)" },
+    { "-", MENU_ID_VIEW_ZOOM_OUT, 30.0f, "Zoom out (Ctrl+-)" },
+    { "Fit", MENU_ID_VIEW_ZOOM_FIT, 40.0f, "Zoom to fit (Ctrl+0)" },
 };
 
+/**
+ * @brief Builds menu item text with shortcut.
+ * @param workspace Workspace instance.
+ * @param out_text Output text buffer.
+ * @param out_size Buffer size.
+ * @param item Menu item definition.
+ * @return None.
+ */
 static void ui_build_menu_item_text(const Workspace* workspace,
                                     char* out_text,
                                     size_t out_size,
@@ -307,6 +316,11 @@ static int ui_render_dropdown(struct nk_context* ctx, Workspace* workspace, int 
     return clicked_id;
 }
 
+/**
+ * @brief Render the theme dropdown menu.
+ * @param menubar Menu bar instance.
+ * @return Selected theme index, or `-1` if unchanged.
+ */
 static int ui_render_theme_dropdown(UiMenuBar* menubar)
 {
     struct nk_context* ctx = NULL;
@@ -345,6 +359,13 @@ static int ui_render_theme_dropdown(UiMenuBar* menubar)
     return -1;
 }
 
+/**
+ * @brief Render one top-level menu and return any clicked action id.
+ * @param menubar Menu bar instance.
+ * @param workspace Workspace instance.
+ * @param menu Top-level menu definition.
+ * @return Clicked menu item id, or `-1` if no action was triggered.
+ */
 static int ui_render_top_menu(UiMenuBar* menubar, Workspace* workspace, const UiTopMenuDef* menu)
 {
     struct nk_context* ctx = NULL;
@@ -374,6 +395,13 @@ static int ui_render_top_menu(UiMenuBar* menubar, Workspace* workspace, const Ui
     return clicked_id;
 }
 
+/**
+ * @brief Dispatch the clicked menu action.
+ * @param menubar Menu bar instance.
+ * @param workspace Workspace instance.
+ * @param clicked_id Clicked menu action id.
+ * @return None.
+ */
 static void ui_dispatch_menu_action(UiMenuBar* menubar, Workspace* workspace, int clicked_id)
 {
     if (!menubar || !workspace || clicked_id == -1) {

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -10,9 +10,9 @@
  * - Uses workspace/document/tools for editable UI actions.
  * - Cooperates with application input loop and theme subsystem.
  */
+#include <ui/ui_system.h>
 #include <ui/ui_menubar.h>
 #include <ui/ui_dialog.h>
-#include <ui/ui_system.h>
 
 #include <app/workspace.h>
 #include <app/workspace_actions.h>
@@ -82,6 +82,13 @@ typedef enum UiThemeReloadReason {
   UI_THEME_RELOAD_REASON_MANUAL
 } UiThemeReloadReason;
 
+/**
+ * @brief Clamps a float value.
+ * @param value Value to clamp.
+ * @param min_value Minimum value.
+ * @param max_value Maximum value.
+ * @return Clamped value.
+ */
 static float ui_clampf(float value, float min_value, float max_value) {
   if (value < min_value) {
     return min_value;
@@ -92,6 +99,11 @@ static float ui_clampf(float value, float min_value, float max_value) {
   return value;
 }
 
+/**
+ * @brief Gets label for theme reload reason.
+ * @param reason Reload reason enum.
+ * @return Reason label string.
+ */
 static const char *ui_theme_reload_reason_label(UiThemeReloadReason reason) {
   switch (reason) {
   case UI_THEME_RELOAD_REASON_MANUAL:
@@ -104,6 +116,11 @@ static const char *ui_theme_reload_reason_label(UiThemeReloadReason reason) {
   }
 }
 
+/**
+ * @brief Syncs theme registry with menu bar.
+ * @param ui UI system instance.
+ * @return None.
+ */
 static void ui_system_sync_menubar_themes(UiSystem *ui) {
   int theme_count = 0;
   int active_theme_index = 0;
@@ -138,6 +155,13 @@ static void ui_system_sync_menubar_themes(UiSystem *ui) {
   ui_menubar_set_active_theme_index(ui->menu_bar, active_theme_index);
 }
 
+/**
+ * @brief Sets the active theme.
+ * @param ui UI system instance.
+ * @param theme_id Theme ID to activate.
+ * @param persist_selection Whether to persist selection.
+ * @return 1 on success, 0 on failure.
+ */
 static int ui_system_set_theme(UiSystem *ui, const char *theme_id,
                                int persist_selection) {
   int theme_index = -1;
@@ -174,6 +198,14 @@ static int ui_system_set_theme(UiSystem *ui, const char *theme_id,
   return 1;
 }
 
+/**
+ * @brief Reloads external themes.
+ * @param ui UI system instance.
+ * @param workspace Workspace instance.
+ * @param notify_status Whether to notify status bar.
+ * @param reason Reload reason.
+ * @return None.
+ */
 static void ui_system_reload_themes(UiSystem *ui, Workspace *workspace,
                                     int notify_status,
                                     UiThemeReloadReason reason) {
@@ -706,7 +738,14 @@ static void ui_status_bar(UiSystem *ui, Workspace *workspace, int window_width,
   nk_end(ctx);
 }
 
-/** Render active reusable workspace dialogs and route the result back into workspace state. */
+/**
+ * @brief Render active reusable workspace dialogs and route the result back into workspace state.
+ * @param ui UI system instance.
+ * @param workspace Workspace instance.
+ * @param window_width Window width in pixels.
+ * @param window_height Window height in pixels.
+ * @return None.
+ */
 static void ui_modal_dialogs(UiSystem *ui, Workspace *workspace,
                              int window_width, int window_height) {
   UiDialogResult result = UI_DIALOG_RESULT_NONE;


### PR DESCRIPTION
Follow-up to #47

## Summary
- align the conflict-affected files with the comment and Doxygen style established by the merged refactor work
- keep runtime behavior unchanged while normalizing the documentation wording that diverged during conflict resolution
- make the post-merge cleanup consistent with the intended comment policy from the earlier work

## Testing
- cmake --build build --parallel
