### PR TITLE
docs: improve bilingual README and getting started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # GLDraw
 
-A canvas-oriented OpenGL drawing editor written in C11.
+A canvas-centered OpenGL drawing editor built in C11.
 
 ## Quick Start
 
-Choose your platform:
+Use the repository build scripts when possible:
 
-| Platform | Script | Modes |
+| Platform | Recommended command | Modes |
 |---|---|---|
 | Linux / macOS | `./build.sh` | `release` (default), `debug`, `clean` |
 | Windows (MinGW/MSYS2) | `./build.bat` | `release` (default), `debug`, `clean` |
 
 <details>
-<summary>Linux / macOS</summary>
+<summary>Linux / macOS via build script</summary>
 
 ```sh
 ./build.sh           # release
@@ -28,7 +28,7 @@ Run:
 </details>
 
 <details>
-<summary>Windows (MinGW/MSYS2, CMD)</summary>
+<summary>Windows (MinGW/MSYS2, CMD) via build script</summary>
 
 ```bat
 build.bat            rem release
@@ -44,7 +44,22 @@ build\Release\bin\GLDraw.exe
 </details>
 
 <details>
-<summary>Windows (Visual Studio 2022 x64, manual CMake)</summary>
+<summary>Linux / macOS via manual CMake</summary>
+
+```sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+```
+
+Run:
+
+```sh
+./build/bin/GLDraw
+```
+</details>
+
+<details>
+<summary>Windows (Visual Studio 2022 x64) via manual CMake</summary>
 
 ```bat
 cmake -S . -B build -G "Visual Studio 17 2022" -A x64
@@ -58,9 +73,9 @@ build\bin\Release\GLDraw.exe
 ```
 </details>
 
-## Build Environment
+## Build Requirements
 
-Choose your platform:
+GLDraw is built with CMake and C11, and uses GLFW, GLAD, Nuklear, and an OpenGL 3.3 Core Profile context.
 
 | Platform | Environment |
 |---|---|
@@ -88,6 +103,13 @@ Choose your platform:
 - Git + network access on first configure (to fetch GLFW 3.3.9)
 </details>
 
+## Project Overview
+
+- Canvas-centered 2D drawing workflow with line, rectangle, and ellipse tools
+- OpenGL rendering pipeline with GLFW windowing, GLAD loading, and Nuklear UI
+- Snapshot-based undo/redo plus JSON document save/load
+- Tool-driven architecture organized around `Workspace`, `Document`, and `CanvasView`
+
 ## Core Controls
 
 `V` Select, `H` Pan, `L` Line, `R` Rectangle, `E` Ellipse  
@@ -96,6 +118,7 @@ Choose your platform:
 
 ## Documentation
 
+- Getting started: [doc/wiki/getting-started.md](doc/wiki/getting-started.md)
 - Wiki index: [doc/wiki](doc/wiki/)
 - Architecture: [doc/wiki/architecture.md](doc/wiki/architecture.md)
 - Extending guide: [doc/wiki/extending.md](doc/wiki/extending.md)

--- a/README.md
+++ b/README.md
@@ -1,65 +1,105 @@
-GLDraw
-======================================
+# GLDraw
 
-A canvas-oriented OpenGL drawing editor in C11.
+A canvas-oriented OpenGL drawing editor written in C11.
 
-Build & Run
------------
+## Quick Start
 
-Linux / macOS:
+Choose your platform:
+
+| Platform | Script | Modes |
+|---|---|---|
+| Linux / macOS | `./build.sh` | `release` (default), `debug`, `clean` |
+| Windows (MinGW/MSYS2) | `./build.bat` | `release` (default), `debug`, `clean` |
+
+<details>
+<summary>Linux / macOS</summary>
 
 ```sh
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build --parallel
-./build/bin/GLDraw
+./build.sh           # release
+./build.sh debug     # debug
+./build.sh clean     # clean
 ```
 
-Windows (MinGW / MSYS2):
+Run:
 
 ```sh
-cmake -S . -B build-mingw -G "MinGW Makefiles"
-cmake --build build-mingw --parallel
-./build-mingw/bin/GLDraw.exe
+./build/Release/bin/GLDraw
+```
+</details>
+
+<details>
+<summary>Windows (MinGW/MSYS2, CMD)</summary>
+
+```bat
+build.bat            rem release
+build.bat debug      rem debug
+build.bat clean      rem clean
 ```
 
-Windows (Visual Studio 2022):
+Run:
 
-```sh
+```bat
+build\Release\bin\GLDraw.exe
+```
+</details>
+
+<details>
+<summary>Windows (Visual Studio 2022 x64, manual CMake)</summary>
+
+```bat
 cmake -S . -B build -G "Visual Studio 17 2022" -A x64
 cmake --build build --config Release
-./build/bin/Release/GLDraw.exe
 ```
 
-Or use the convenience script:
+Run:
 
-```sh
-./build.sh          # Release build
-./build.sh debug    # Debug build
-./build.sh clean    # Clean artifacts
+```bat
+build\bin\Release\GLDraw.exe
 ```
+</details>
 
-Controls
---------
+## Build Environment
 
-| Key | Action |
-|-----|--------|
-| V | Select tool |
-| H | Hand / pan tool |
-| L | Line tool |
-| R | Rectangle tool |
-| E | Ellipse tool |
-| Shift+Click | Toggle selection |
-| Ctrl+Z | Undo |
-| Ctrl+Y / Ctrl+Shift+Z | Redo |
-| Ctrl+S | Save document |
-| Ctrl+O | Load document |
-| Delete / Backspace | Delete selection |
-| Mouse Wheel | Zoom at cursor |
-| Esc | Clear tool state |
+Choose your platform:
 
-Documentation
--------------
+| Platform | Environment |
+|---|---|
+| Linux / macOS | CMake + C11 compiler + OpenGL dev environment |
+| Windows (MinGW/MSYS2) | CMake + MinGW-w64 + OpenGL dev environment |
 
-Full documentation: [doc/wiki/](doc/wiki/)
+<details>
+<summary>Linux / macOS</summary>
 
-License: MIT
+- CMake 3.15+
+- C11 compiler (`gcc` or `clang`)
+- OpenGL development environment (headers + runtime)
+- Build tools for Makefiles (`make`)
+- Git + network access on first configure (to fetch GLFW 3.3.9)
+- macOS: Xcode Command Line Tools
+</details>
+
+<details>
+<summary>Windows (MinGW/MSYS2)</summary>
+
+- CMake 3.15+
+- MinGW-w64 C11 toolchain (`gcc`)
+- `mingw32-make` in `PATH`
+- OpenGL development environment (headers + runtime)
+- Git + network access on first configure (to fetch GLFW 3.3.9)
+</details>
+
+## Core Controls
+
+`V` Select, `H` Pan, `L` Line, `R` Rectangle, `E` Ellipse  
+`Ctrl+Z` Undo, `Ctrl+Y`/`Ctrl+Shift+Z` Redo  
+`Ctrl+S` Save, `Ctrl+O` Open
+
+## Documentation
+
+- Wiki index: [doc/wiki](doc/wiki/)
+- Architecture: [doc/wiki/architecture.md](doc/wiki/architecture.md)
+- Extending guide: [doc/wiki/extending.md](doc/wiki/extending.md)
+
+## License
+
+MIT

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -4,15 +4,15 @@
 
 ## 快速开始
 
-请选择平台：
+推荐优先使用项目自带构建脚本：
 
-| 平台 | 脚本 | 模式 |
+| 平台 | 推荐命令 | 模式 |
 |---|---|---|
 | Linux / macOS | `./build.sh` | `release`（默认）、`debug`、`clean` |
 | Windows（MinGW/MSYS2） | `./build.bat` | `release`（默认）、`debug`、`clean` |
 
 <details>
-<summary>Linux / macOS</summary>
+<summary>通过构建脚本在 Linux / macOS 上编译</summary>
 
 ```sh
 ./build.sh           # release
@@ -28,7 +28,7 @@
 </details>
 
 <details>
-<summary>Windows（MinGW/MSYS2，CMD）</summary>
+<summary>通过构建脚本在 Windows（MinGW/MSYS2，CMD）上编译</summary>
 
 ```bat
 build.bat            rem release
@@ -44,7 +44,22 @@ build\Release\bin\GLDraw.exe
 </details>
 
 <details>
-<summary>Windows（Visual Studio 2022 x64，手动 CMake）</summary>
+<summary>通过手动 CMake 在 Linux / macOS 上编译</summary>
+
+```sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+```
+
+运行：
+
+```sh
+./build/bin/GLDraw
+```
+</details>
+
+<details>
+<summary>通过手动 CMake 在 Windows（Visual Studio 2022 x64）上编译</summary>
 
 ```bat
 cmake -S . -B build -G "Visual Studio 17 2022" -A x64
@@ -58,9 +73,9 @@ build\bin\Release\GLDraw.exe
 ```
 </details>
 
-## 编译环境
+## 构建要求
 
-请选择平台：
+GLDraw 基于 CMake、C11、OpenGL、GLFW、GLAD 和 Nuklear。
 
 | 平台 | 环境 |
 |---|---|
@@ -88,6 +103,13 @@ build\bin\Release\GLDraw.exe
 - 首次配置需要 Git 与网络（用于拉取 GLFW 3.3.9）
 </details>
 
+## 项目概览
+
+- 以画布为核心的二维绘图流程，内置线段、矩形、椭圆工具
+- 基于 GLFW、GLAD 与 Nuklear 的 OpenGL 渲染和界面栈
+- 提供基于快照的撤销/重做，以及 JSON 文档读写
+- 以 `Workspace`、`Document`、`CanvasView` 为核心组织交互与状态
+
 ## 核心快捷键
 
 `V` 选择，`H` 平移，`L` 线段，`R` 矩形，`E` 椭圆  
@@ -96,6 +118,7 @@ build\bin\Release\GLDraw.exe
 
 ## 文档
 
+- 入门说明：[wiki/getting-started.md](wiki/getting-started.md)
 - Wiki 首页：[wiki](wiki/)
 - 架构说明：[wiki/architecture.md](wiki/architecture.md)
 - 扩展指南：[wiki/extending.md](wiki/extending.md)

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -1,65 +1,105 @@
-GLDraw
-======================================
+# GLDraw
 
 一个以画布为中心的 OpenGL 绘图编辑器，使用 C11 编写。
 
-构建与运行
------------
+## 快速开始
 
-Linux / macOS：
+请选择平台：
+
+| 平台 | 脚本 | 模式 |
+|---|---|---|
+| Linux / macOS | `./build.sh` | `release`（默认）、`debug`、`clean` |
+| Windows（MinGW/MSYS2） | `./build.bat` | `release`（默认）、`debug`、`clean` |
+
+<details>
+<summary>Linux / macOS</summary>
 
 ```sh
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build --parallel
-./build/bin/GLDraw
+./build.sh           # release
+./build.sh debug     # debug
+./build.sh clean     # clean
 ```
 
-Windows（MinGW / MSYS2）：
+运行：
 
 ```sh
-cmake -S . -B build-mingw -G "MinGW Makefiles"
-cmake --build build-mingw --parallel
-./build-mingw/bin/GLDraw.exe
+./build/Release/bin/GLDraw
+```
+</details>
+
+<details>
+<summary>Windows（MinGW/MSYS2，CMD）</summary>
+
+```bat
+build.bat            rem release
+build.bat debug      rem debug
+build.bat clean      rem clean
 ```
 
-Windows（Visual Studio 2022）：
+运行：
 
-```sh
+```bat
+build\Release\bin\GLDraw.exe
+```
+</details>
+
+<details>
+<summary>Windows（Visual Studio 2022 x64，手动 CMake）</summary>
+
+```bat
 cmake -S . -B build -G "Visual Studio 17 2022" -A x64
 cmake --build build --config Release
-./build/bin/Release/GLDraw.exe
 ```
 
-或使用通用构建脚本：
+运行：
 
-```sh
-./build.sh          # Release 构建
-./build.sh debug    # Debug 构建
-./build.sh clean    # 清理构建产物
+```bat
+build\bin\Release\GLDraw.exe
 ```
+</details>
 
-快捷键
---------
+## 编译环境
 
-| 快捷键 | 功能 |
-|--------|------|
-| V | 选择工具 |
-| H | 手型平移工具 |
-| L | 线段工具 |
-| R | 矩形工具 |
-| E | 椭圆工具 |
-| Shift+点击 | 切换多选 |
-| Ctrl+Z | 撤销 |
-| Ctrl+Y / Ctrl+Shift+Z | 重做 |
-| Ctrl+S | 保存文档 |
-| Ctrl+O | 加载文档 |
-| Delete / Backspace | 删除选择 |
-| 鼠标滚轮 | 以光标为中心缩放 |
-| Esc | 清除工具状态 |
+请选择平台：
 
-文档
--------------
+| 平台 | 环境 |
+|---|---|
+| Linux / macOS | CMake + C11 编译器 + OpenGL 开发环境 |
+| Windows（MinGW/MSYS2） | CMake + MinGW-w64 + OpenGL 开发环境 |
 
-详细文档：[../doc/wiki/](../doc/wiki/)
+<details>
+<summary>Linux / macOS</summary>
 
-许可证：MIT
+- CMake 3.15+
+- C11 编译器（`gcc` 或 `clang`）
+- OpenGL 开发环境（头文件与运行库）
+- Makefiles 构建工具（`make`）
+- 首次配置需要 Git 与网络（用于拉取 GLFW 3.3.9）
+- macOS：Xcode Command Line Tools
+</details>
+
+<details>
+<summary>Windows（MinGW/MSYS2）</summary>
+
+- CMake 3.15+
+- MinGW-w64 C11 工具链（`gcc`）
+- `mingw32-make` 在 `PATH` 中
+- OpenGL 开发环境（头文件与运行库）
+- 首次配置需要 Git 与网络（用于拉取 GLFW 3.3.9）
+</details>
+
+## 核心快捷键
+
+`V` 选择，`H` 平移，`L` 线段，`R` 矩形，`E` 椭圆  
+`Ctrl+Z` 撤销，`Ctrl+Y`/`Ctrl+Shift+Z` 重做  
+`Ctrl+S` 保存，`Ctrl+O` 打开
+
+## 文档
+
+- Wiki 首页：[wiki](wiki/)
+- 架构说明：[wiki/architecture.md](wiki/architecture.md)
+- 扩展指南：[wiki/extending.md](wiki/extending.md)
+
+## 许可证
+
+MIT

--- a/doc/wiki/getting-started.md
+++ b/doc/wiki/getting-started.md
@@ -2,15 +2,12 @@
 
 ## Build
 
-### Linux / macOS
+Recommended path:
 
-```sh
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build --parallel
-./build/bin/GLDraw
-```
+- Linux / macOS: `./build.sh`
+- Windows (MinGW/MSYS2): `./build.bat`
 
-Or use the convenience script:
+### Linux / macOS via build script
 
 ```sh
 ./build.sh          # Release build
@@ -18,7 +15,53 @@ Or use the convenience script:
 ./build.sh clean    # Clean artifacts
 ```
 
-For other platforms, see the main [README.md](../../README.md).
+Run:
+
+```sh
+./build/Release/bin/GLDraw
+```
+
+### Linux / macOS via manual CMake
+
+```sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+```
+
+Run:
+
+```sh
+./build/bin/GLDraw
+```
+
+### Windows (MinGW/MSYS2, CMD) via build script
+
+```bat
+build.bat           rem Release build
+build.bat debug     rem Debug build
+build.bat clean     rem Clean artifacts
+```
+
+Run:
+
+```bat
+build\Release\bin\GLDraw.exe
+```
+
+### Windows (Visual Studio 2022 x64) via manual CMake
+
+```bat
+cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+cmake --build build --config Release
+```
+
+Run:
+
+```bat
+build\bin\Release\GLDraw.exe
+```
+
+For platform requirements and related links, see the main [README.md](../../README.md).
 
 ## First Session
 


### PR DESCRIPTION
Closes #61

## Summary
- improve the bilingual README with clearer platform-specific build and run instructions
- document the expected generator and executable paths for Windows, Linux, and macOS
- tighten the getting-started flow so setup and first build are easier to follow

## Testing
- GitHub Actions build checks passed at merge