### PR TITLE
fix: use framebuffer coordinates for canvas rendering

### DIFF
--- a/include/platform/window.h
+++ b/include/platform/window.h
@@ -13,14 +13,18 @@
  * @brief Platform window state.
  *
  * @member handle GLFW native window handle.
- * @member width Desired window width.
- * @member height Desired window height.
+ * @member width Current logical window width.
+ * @member height Current logical window height.
+ * @member framebuffer_width Current framebuffer width.
+ * @member framebuffer_height Current framebuffer height.
  * @member title Window title string.
  */
 typedef struct {
     GLFWwindow* handle;
     int width;
     int height;
+    int framebuffer_width;
+    int framebuffer_height;
     const char* title;
 } PlatformWindow;
 

--- a/include/render/render_system.h
+++ b/include/render/render_system.h
@@ -28,11 +28,17 @@ void render_system_destroy(RenderSystem* renderer);
 /**
  * @brief Handle window resize events.
  * @param renderer Renderer instance.
- * @param width New width in pixels.
- * @param height New height in pixels.
+ * @param logical_width New logical window width in screen coordinates.
+ * @param logical_height New logical window height in screen coordinates.
+ * @param framebuffer_width New framebuffer width in pixels.
+ * @param framebuffer_height New framebuffer height in pixels.
  * @return No return value.
  */
-void render_system_resize(RenderSystem* renderer, int width, int height);
+void render_system_resize(RenderSystem* renderer,
+                          int logical_width,
+                          int logical_height,
+                          int framebuffer_width,
+                          int framebuffer_height);
 
 /**
  * @brief Draw one frame of canvas content.

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -458,13 +458,20 @@ static ToolEvent make_tool_event(Application *app, int button, int mods,
 static void framebuffer_size_callback(GLFWwindow *handle, int width,
                                       int height) {
   Application *app = (Application *)glfwGetWindowUserPointer(handle);
+  int window_width = 0;
+  int window_height = 0;
+
   if (!app) {
     return;
   }
-  app->window.width = width;
-  app->window.height = height;
+
+  glfwGetWindowSize(handle, &window_width, &window_height);
+  app->window.width = window_width;
+  app->window.height = window_height;
+  app->window.framebuffer_width = width;
+  app->window.framebuffer_height = height;
   update_canvas_viewport(app);
-  render_system_resize(app->renderer, width, height);
+  render_system_resize(app->renderer, window_width, window_height, width, height);
 }
 
 /**
@@ -668,7 +675,11 @@ static int app_init(Application *app) {
   glfwSetScrollCallback(app->window.handle, scroll_callback);
   glfwSetWindowCloseCallback(app->window.handle, window_close_callback);
 
-  render_system_resize(app->renderer, app->window.width, app->window.height);
+  render_system_resize(app->renderer,
+                       app->window.width,
+                       app->window.height,
+                       app->window.framebuffer_width,
+                       app->window.framebuffer_height);
   update_canvas_viewport(app);
   app->cursor_inside_canvas =
       app->ui ? ui_system_point_in_canvas(app->ui, app->cursor_screen) : 1;

--- a/src/platform/window.c
+++ b/src/platform/window.c
@@ -65,6 +65,9 @@ int platform_window_init(PlatformWindow* window, int width, int height, const ch
 
     window->width = width;
     window->height = height;
+    glfwGetFramebufferSize(window->handle,
+                           &window->framebuffer_width,
+                           &window->framebuffer_height);
     window->title = title;
 
     glfwMakeContextCurrent(window->handle);

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -49,8 +49,12 @@ struct RenderSystem {
     GLuint vao;
     GLuint vbo;
     GLint screen_size_loc;
-    int width;
-    int height;
+    int logical_width;
+    int logical_height;
+    int framebuffer_width;
+    int framebuffer_height;
+    float framebuffer_scale_x;
+    float framebuffer_scale_y;
     float* vertex_buffer;
     size_t vertex_buffer_capacity;
     size_t gpu_vertex_buffer_capacity;
@@ -369,6 +373,25 @@ static void write_screen_vertex(float** cursor, Vec2 screen, Color color)
 }
 
 /**
+ * @brief Convert logical screen coordinates to framebuffer coordinates.
+ * @param renderer Renderer instance.
+ * @param logical_screen Screen coordinate in logical window space.
+ * @return Screen coordinate in framebuffer space.
+ */
+static Vec2 render_framebuffer_point(const RenderSystem* renderer, Vec2 logical_screen)
+{
+    Vec2 framebuffer_screen = logical_screen;
+
+    if (!renderer) {
+        return framebuffer_screen;
+    }
+
+    framebuffer_screen.x *= renderer->framebuffer_scale_x;
+    framebuffer_screen.y *= renderer->framebuffer_scale_y;
+    return framebuffer_screen;
+}
+
+/**
  * @brief Normalize primitive type for batching.
  * @param primitive GL primitive type.
  * @return GL primitive type suitable for batching.
@@ -536,12 +559,21 @@ static int append_line_vertices(RenderSystem* renderer,
 
     if (primitive == GL_LINE_STRIP) {
         for (i = 0; i < count - 1; ++i) {
-            write_screen_vertex(&cursor, canvas_view_world_to_screen(canvas, points[i]), color);
-            write_screen_vertex(&cursor, canvas_view_world_to_screen(canvas, points[i + 1]), color);
+            write_screen_vertex(&cursor,
+                                render_framebuffer_point(renderer,
+                                                         canvas_view_world_to_screen(canvas, points[i])),
+                                color);
+            write_screen_vertex(&cursor,
+                                render_framebuffer_point(renderer,
+                                                         canvas_view_world_to_screen(canvas, points[i + 1])),
+                                color);
         }
     } else {
         for (i = 0; i < count; ++i) {
-            write_screen_vertex(&cursor, canvas_view_world_to_screen(canvas, points[i]), color);
+            write_screen_vertex(&cursor,
+                                render_framebuffer_point(renderer,
+                                                         canvas_view_world_to_screen(canvas, points[i])),
+                                color);
         }
     }
 
@@ -721,7 +753,12 @@ static void draw_object(RenderSystem* renderer,
  * @param out_scissor [out] Output scissor box (x, y, w, h).
  * @return `1` when resulting scissor area is valid and non-empty, else `0`.
  */
-static int render_canvas_scissor_box(const RectF* viewport, int framebuffer_width, int framebuffer_height, GLint out_scissor[4])
+static int render_canvas_scissor_box(const RectF* viewport,
+                                     float framebuffer_scale_x,
+                                     float framebuffer_scale_y,
+                                     int framebuffer_width,
+                                     int framebuffer_height,
+                                     GLint out_scissor[4])
 {
     int x = 0;
     int y_top = 0;
@@ -737,10 +774,14 @@ static int render_canvas_scissor_box(const RectF* viewport, int framebuffer_widt
         return 0;
     }
 
-    x = (int)floorf(viewport->x);
-    y_top = (int)floorf(viewport->y);
-    w = (int)ceilf(viewport->w);
-    h = (int)ceilf(viewport->h);
+    if (framebuffer_scale_x <= 0.0f || framebuffer_scale_y <= 0.0f) {
+        return 0;
+    }
+
+    x = (int)floorf(viewport->x * framebuffer_scale_x);
+    y_top = (int)floorf(viewport->y * framebuffer_scale_y);
+    w = (int)ceilf(viewport->w * framebuffer_scale_x);
+    h = (int)ceilf(viewport->h * framebuffer_scale_y);
     y = framebuffer_height - y_top - h;
 
     if (x < 0) {
@@ -817,8 +858,14 @@ RenderSystem* render_system_create(PlatformWindow* window)
     }
 #endif
 
-    renderer->width = window->width;
-    renderer->height = window->height;
+    renderer->logical_width = window->width;
+    renderer->logical_height = window->height;
+    renderer->framebuffer_width = window->framebuffer_width;
+    renderer->framebuffer_height = window->framebuffer_height;
+    renderer->framebuffer_scale_x =
+        (window->width > 0) ? ((float)window->framebuffer_width / (float)window->width) : 1.0f;
+    renderer->framebuffer_scale_y =
+        (window->height > 0) ? ((float)window->framebuffer_height / (float)window->height) : 1.0f;
     renderer->program = load_program("shaders/basic.vert", "shaders/basic.frag");
     if (!renderer->program) {
         free(renderer);
@@ -838,7 +885,9 @@ RenderSystem* render_system_create(PlatformWindow* window)
     glUseProgram(renderer->program);
     renderer->screen_size_loc = glGetUniformLocation(renderer->program, "uScreenSize");
     if (renderer->screen_size_loc >= 0) {
-        glUniform2f(renderer->screen_size_loc, (float)renderer->width, (float)renderer->height);
+        glUniform2f(renderer->screen_size_loc,
+                    (float)renderer->framebuffer_width,
+                    (float)renderer->framebuffer_height);
     }
     glUseProgram(0);
     glEnable(GL_BLEND);
@@ -872,18 +921,30 @@ void render_system_destroy(RenderSystem* renderer)
  * @param height New height in pixels.
  * @return No return value.
  */
-void render_system_resize(RenderSystem* renderer, int width, int height)
+void render_system_resize(RenderSystem* renderer,
+                          int logical_width,
+                          int logical_height,
+                          int framebuffer_width,
+                          int framebuffer_height)
 {
     if (!renderer) {
         return;
     }
 
-    renderer->width = width;
-    renderer->height = height;
-    glViewport(0, 0, width, height);
+    renderer->logical_width = logical_width;
+    renderer->logical_height = logical_height;
+    renderer->framebuffer_width = framebuffer_width;
+    renderer->framebuffer_height = framebuffer_height;
+    renderer->framebuffer_scale_x =
+        (logical_width > 0) ? ((float)framebuffer_width / (float)logical_width) : 1.0f;
+    renderer->framebuffer_scale_y =
+        (logical_height > 0) ? ((float)framebuffer_height / (float)logical_height) : 1.0f;
+    glViewport(0, 0, framebuffer_width, framebuffer_height);
     glUseProgram(renderer->program);
     if (renderer->screen_size_loc >= 0) {
-        glUniform2f(renderer->screen_size_loc, (float)width, (float)height);
+        glUniform2f(renderer->screen_size_loc,
+                    (float)framebuffer_width,
+                    (float)framebuffer_height);
     }
     glUseProgram(0);
 }
@@ -918,11 +979,13 @@ void render_system_draw(RenderSystem* renderer,
 
     viewport = canvas_view_viewport(canvas);
     has_canvas_area = render_canvas_scissor_box(&viewport,
-                                                renderer->width,
-                                                renderer->height,
+                                                renderer->framebuffer_scale_x,
+                                                renderer->framebuffer_scale_y,
+                                                renderer->framebuffer_width,
+                                                renderer->framebuffer_height,
                                                 canvas_scissor_box);
 
-    glViewport(0, 0, renderer->width, renderer->height);
+    glViewport(0, 0, renderer->framebuffer_width, renderer->framebuffer_height);
     scissor_was_enabled = glIsEnabled(GL_SCISSOR_TEST);
     glGetIntegerv(GL_SCISSOR_BOX, previous_scissor_box);
 


### PR DESCRIPTION
Closes #49

## Summary
- track logical window size and framebuffer size separately
- feed the renderer with framebuffer dimensions for viewport, scissor, and shader screen size
- scale canvas screen-space vertices into framebuffer space before submission

## Testing
- cmake --build build --config Release