### PR TITLE
fix: treat selection as editor session state

### DIFF
--- a/include/document/document.h
+++ b/include/document/document.h
@@ -30,7 +30,7 @@ typedef struct {
  * @member count Current object count.
  * @member revision Document revision number (incremented after edits).
  * @member next_id Auto-assigned ID for new objects.
- * @member selection Current selection set.
+ * @member selection Current editor-session selection set (not serialized).
  */
 typedef struct Document {
   GraphicObject *objects[DOCUMENT_MAX_OBJECTS];

--- a/src/document/persistence.c
+++ b/src/document/persistence.c
@@ -252,11 +252,6 @@ static int write_document_json(FILE* file, const Document* document)
     fprintf(file, "  \"format\": \"gldraw-document\",\n");
     fprintf(file, "  \"version\": 1,\n");
     fprintf(file, "  \"next_id\": %u,\n", document->next_id);
-    fprintf(file, "  \"selection\": [");
-    for (i = 0; i < document->selection.count; ++i) {
-        fprintf(file, "%s%u", (i == 0) ? "" : ", ", document->selection.ids[i]);
-    }
-    fprintf(file, "],\n");
     fprintf(file, "  \"objects\": [\n");
 
     for (i = 0; i < document->count; ++i) {
@@ -1022,50 +1017,6 @@ static int parse_object_entry(JsonParser* parser, Document* document)
 }
 
 /**
- * @brief Parses a selection array.
- * @param parser JSON parser.
- * @param selection_ids Output array for selection IDs.
- * @param selection_count Output count pointer.
- * @return 1 on success, 0 on failure.
- */
-static int parse_selection_array(JsonParser* parser, ObjectId* selection_ids, int* selection_count)
-{
-    if (!json_expect(parser, JSON_TOKEN_LBRACKET)) {
-        return 0;
-    }
-
-    json_parser_next(parser);
-    *selection_count = 0;
-
-    if (parser->type == JSON_TOKEN_RBRACKET) {
-        json_parser_next(parser);
-        return 1;
-    }
-
-    while (1) {
-        unsigned int value = 0;
-
-        if (!json_parse_u32(parser, &value)) {
-            return 0;
-        }
-
-        if (*selection_count < DOCUMENT_MAX_SELECTION) {
-            selection_ids[(*selection_count)++] = value;
-        }
-
-        if (parser->type == JSON_TOKEN_COMMA) {
-            json_parser_next(parser);
-            continue;
-        }
-        if (parser->type == JSON_TOKEN_RBRACKET) {
-            json_parser_next(parser);
-            return 1;
-        }
-        return 0;
-    }
-}
-
-/**
  * @brief Parses an objects array.
  * @param parser JSON parser.
  * @param document Target document.
@@ -1116,11 +1067,6 @@ static int parse_document_root(JsonParser* parser, Document* document)
     int got_next_id = 0;
     unsigned int version = 0;
     unsigned int next_id = 0;
-    ObjectId selection_ids[DOCUMENT_MAX_SELECTION];
-    int selection_count = 0;
-    int i = 0;
-
-    memset(selection_ids, 0, sizeof(selection_ids));
 
     if (!json_expect(parser, JSON_TOKEN_LBRACE)) {
         LOG_ERROR("%s", "[persistence][parse][top-level] expected root object");
@@ -1161,11 +1107,6 @@ static int parse_document_root(JsonParser* parser, Document* document)
             json_parser_next(parser);
             if (!json_parse_u32(parser, &next_id)) return 0;
             got_next_id = 1;
-        } else if (json_token_is_string(parser, "selection")) {
-            json_parser_next(parser);
-            if (!json_expect(parser, JSON_TOKEN_COLON)) return 0;
-            json_parser_next(parser);
-            if (!parse_selection_array(parser, selection_ids, &selection_count)) return 0;
         } else if (json_token_is_string(parser, "objects")) {
             json_parser_next(parser);
             if (!json_expect(parser, JSON_TOKEN_COLON)) return 0;
@@ -1195,13 +1136,8 @@ static int parse_document_root(JsonParser* parser, Document* document)
         return 0;
     }
 
+    /* Selection is editor-session state and intentionally not serialized. */
     document_clear_selection(document);
-    for (i = 0; i < selection_count; ++i) {
-        if (document_find_object(document, selection_ids[i])) {
-            document_selection_add(document, selection_ids[i]);
-        }
-    }
-
     if (got_next_id && next_id > document_max_id(document)) {
         document->next_id = next_id;
     } else {

--- a/src/tools/tool_controller.c
+++ b/src/tools/tool_controller.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/** Runtime state for select tool drag/selection/history behavior. */
+/** Runtime state for select tool drag/document-edit history behavior. */
 typedef struct {
     int dragging;
     int moved;
@@ -110,33 +110,6 @@ static GraphicObject* build_shape_object(ToolKind kind, Vec2 anchor, Vec2 curren
 }
 
 /**
- * @brief Checks if selection matches a snapshot.
- * @param document Document instance.
- * @param snapshot Snapshot to compare.
- * @return 1 if matches, 0 otherwise.
- */
-static int selection_matches_snapshot(const Document* document, const DocumentSnapshot* snapshot)
-{
-    int i = 0;
-
-    if (!document || !snapshot) {
-        return 0;
-    }
-
-    if (document->selection.count != snapshot->selection.count) {
-        return 0;
-    }
-
-    for (i = 0; i < document->selection.count; ++i) {
-        if (document->selection.ids[i] != snapshot->selection.ids[i]) {
-            return 0;
-        }
-    }
-
-    return 1;
-}
-
-/**
  * @brief Pushes document edit to history and syncs dirty flag.
  * @param context [in,out] Tool context.
  * @param before_snapshot [in,out] Before snapshot (consumed and reset by this function).
@@ -195,10 +168,6 @@ static void select_tool_deactivate(Tool* tool, ToolContext* context)
  * @param context [in,out] Tool context.
  * @param event [in] Pointer event.
  * @return None.
- *
- * Why snapshot first:
- * - Captures "before" state before selection/drag mutations so history entry
- *   can represent either move edits or selection-only edits consistently.
  */
 static void select_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
@@ -218,47 +187,18 @@ static void select_tool_pointer_down(Tool* tool, ToolContext* context, const Too
     hit = canvas_view_pick_object(context->canvas, event->screen_pos, 8.0f);
     if (!hit) {
         if ((event->mods & GLFW_MOD_SHIFT) == 0) {
-            if (context->document->selection.count > 0) {
-                DocumentSnapshot before_snapshot;
-                document_snapshot_init(&before_snapshot);
-                if (document_snapshot_capture(&before_snapshot, context->document)) {
-                    document_clear_selection(context->document);
-                    document_touch(context->document);
-                    tool_commit_document_change(context, &before_snapshot);
-                }
-            }
+            document_clear_selection(context->document);
         }
         return;
     }
 
     if ((event->mods & GLFW_MOD_SHIFT) != 0) {
-        DocumentSnapshot before_snapshot;
-        document_snapshot_init(&before_snapshot);
-        if (document_snapshot_capture(&before_snapshot, context->document)) {
-            document_selection_toggle(context->document, hit->id);
-            if (!selection_matches_snapshot(context->document, &before_snapshot)) {
-                document_touch(context->document);
-                tool_commit_document_change(context, &before_snapshot);
-            } else {
-                document_snapshot_free(&before_snapshot);
-            }
-        } else {
-            document_selection_toggle(context->document, hit->id);
-        }
+        document_selection_toggle(context->document, hit->id);
         state->dragging = document_selection_contains(context->document, hit->id);
     } else {
         if (!document_selection_contains(context->document, hit->id) || context->document->selection.count != 1) {
-            DocumentSnapshot before_snapshot;
-            document_snapshot_init(&before_snapshot);
-            if (document_snapshot_capture(&before_snapshot, context->document)) {
-                document_clear_selection(context->document);
-                document_selection_add(context->document, hit->id);
-                document_touch(context->document);
-                tool_commit_document_change(context, &before_snapshot);
-            } else {
-                document_clear_selection(context->document);
-                document_selection_add(context->document, hit->id);
-            }
+            document_clear_selection(context->document);
+            document_selection_add(context->document, hit->id);
         }
         state->dragging = document_selection_contains(context->document, hit->id);
     }
@@ -361,16 +301,6 @@ static void select_tool_key_down(Tool* tool, ToolContext* context, int key, int 
     (void)tool;
     (void)mods;
     if (key == GLFW_KEY_ESCAPE) {
-        if (context->document->selection.count > 0) {
-            DocumentSnapshot before_snapshot;
-            document_snapshot_init(&before_snapshot);
-            if (document_snapshot_capture(&before_snapshot, context->document)) {
-                document_clear_selection(context->document);
-                document_touch(context->document);
-                tool_commit_document_change(context, &before_snapshot);
-                return;
-            }
-        }
         document_clear_selection(context->document);
     }
 }


### PR DESCRIPTION
Closes #53

## Summary
- stop serializing selection into document files
- clear selection on load because selection is session-only state
- remove selection-only dirty and undo entries from select-tool interactions

## Testing
- cmake --build build --config Release