### PR TITLE
fix: capture pointer only after tool acceptance

### DIFF
--- a/include/tools/tool.h
+++ b/include/tools/tool.h
@@ -74,7 +74,8 @@ typedef struct ToolVTable ToolVTable;
  * @member label Returns the tool display name.
  * @member activate Tool activate callback.
  * @member deactivate Tool deactivate callback.
- * @member pointer_down Mouse pointer down callback.
+ * @member pointer_down Mouse pointer down callback. Returns non-zero only when
+ * the tool accepts the interaction and expects captured follow-up events.
  * @member pointer_move Mouse pointer move callback.
  * @member pointer_up Mouse pointer up callback.
  * @member key_down Key down callback.
@@ -83,7 +84,7 @@ struct ToolVTable {
     const char* (*label)(const Tool* tool);
     void (*activate)(Tool* tool, ToolContext* context);
     void (*deactivate)(Tool* tool, ToolContext* context);
-    void (*pointer_down)(Tool* tool, ToolContext* context, const ToolEvent* event);
+    int (*pointer_down)(Tool* tool, ToolContext* context, const ToolEvent* event);
     void (*pointer_move)(Tool* tool, ToolContext* context, const ToolEvent* event);
     void (*pointer_up)(Tool* tool, ToolContext* context, const ToolEvent* event);
     void (*key_down)(Tool* tool, ToolContext* context, int key, int mods);

--- a/src/tools/tool_controller.c
+++ b/src/tools/tool_controller.c
@@ -200,14 +200,14 @@ static void select_tool_deactivate(Tool* tool, ToolContext* context)
  * - Captures "before" state before selection/drag mutations so history entry
  *   can represent either move edits or selection-only edits consistently.
  */
-static void select_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
+static int select_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     SelectToolState* state = (SelectToolState*)tool->state;
     GraphicObject* hit = NULL;
     int i = 0;
 
     if (event->button != GLFW_MOUSE_BUTTON_LEFT) {
-        return;
+        return 0;
     }
 
     state->dragging = 0;
@@ -228,7 +228,7 @@ static void select_tool_pointer_down(Tool* tool, ToolContext* context, const Too
                 }
             }
         }
-        return;
+        return 0;
     }
 
     if ((event->mods & GLFW_MOD_SHIFT) != 0) {
@@ -264,7 +264,7 @@ static void select_tool_pointer_down(Tool* tool, ToolContext* context, const Too
     }
 
     if (!state->dragging || context->document->selection.count <= 0) {
-        return;
+        return 0;
     }
 
     state->drag_object_count = context->document->selection.count;
@@ -276,6 +276,7 @@ static void select_tool_pointer_down(Tool* tool, ToolContext* context, const Too
     }
     state->last_world = event->world_pos;
     state->drag_revision_before = context->document->revision;
+    return 1;
 }
 
 /**
@@ -414,17 +415,18 @@ static void pan_tool_deactivate(Tool* tool, ToolContext* context)
  * @param tool Tool instance.
  * @param context Tool context.
  * @param event Pointer event.
- * @return None.
+ * @return Non-zero when the pan tool accepted the interaction.
  */
-static void pan_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
+static int pan_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     PanToolState* state = (PanToolState*)tool->state;
     (void)tool;
     (void)context;
     if (event->button != GLFW_MOUSE_BUTTON_LEFT) {
-        return;
+        return 0;
     }
     state->panning = 1;
+    return 1;
 }
 
 /**
@@ -514,14 +516,14 @@ static void shape_tool_deactivate(Tool* tool, ToolContext* context)
 }
 
 /** Start shape draw interaction and create translucent overlay preview. */
-static void shape_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
+static int shape_tool_pointer_down(Tool* tool, ToolContext* context, const ToolEvent* event)
 {
     ShapeToolState* state = (ShapeToolState*)tool->state;
     GraphicStyle style = object_default_style();
 
     (void)context;
     if (event->button != GLFW_MOUSE_BUTTON_LEFT) {
-        return;
+        return 0;
     }
 
     state->drawing = 1;
@@ -531,6 +533,7 @@ static void shape_tool_pointer_down(Tool* tool, ToolContext* context, const Tool
     style.stroke_color.a = 0.75f;
     destroy_overlay(tool);
     tool->overlay_object = build_shape_object(tool->kind, state->anchor, state->current, style);
+    return (tool->overlay_object != NULL);
 }
 
 /** Update shape overlay as pointer moves. */
@@ -707,13 +710,16 @@ void tool_controller_set_active(ToolController* controller, ToolContext* context
 void tool_controller_pointer_down(ToolController* controller, ToolContext* context, const ToolEvent* event)
 {
     Tool* tool = tool_controller_get_active(controller);
+    int accepted = 0;
+
     if (!controller || !tool || !tool->vtable || !tool->vtable->pointer_down) {
         return;
     }
-    controller->pointer_captured = 1;
+
     controller->last_screen = event->screen_pos;
     controller->last_world = event->world_pos;
-    tool->vtable->pointer_down(tool, context, event);
+    accepted = tool->vtable->pointer_down(tool, context, event);
+    controller->pointer_captured = accepted ? 1 : 0;
 }
 
 /** Dispatch pointer-move to active tool. */


### PR DESCRIPTION
Closes #51

## Summary
- make tool pointer-down handlers report whether they accepted the interaction
- move pointer capture ownership into the tool controller
- only enter captured mode when the active tool actually starts a drag, pan, or draw interaction

## Testing
- cmake --build build --config Release