### PR TITLE
fix: reconcile placeholder menu and command entries

### DIFF
--- a/include/app/command_registry.h
+++ b/include/app/command_registry.h
@@ -49,6 +49,12 @@ typedef struct CommandDescriptor {
 const CommandDescriptor* command_registry_find_by_id(const char* command_id);
 /** Look up a command descriptor by menu action ID. */
 const CommandDescriptor* command_registry_find_by_menu_id(int id);
+/** Check whether a command is intentionally exposed and executable in the current build/runtime. */
+int command_registry_is_available(const struct Workspace* workspace,
+                                  EditorCommand command);
+/** Check whether a menu-backed command is available in the current build/runtime. */
+int command_registry_is_menu_action_available(const struct Workspace* workspace,
+                                              int id);
 /** Execute one command against the current editor state. */
 int command_registry_execute(struct Workspace* workspace,
                              ToolContext* tool_context,

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -48,7 +48,8 @@ typedef enum UiRequestType {
  */
 typedef enum UiDialogKind {
     UI_DIALOG_NONE = 0,
-    UI_DIALOG_CONFIRM_UNSAVED
+    UI_DIALOG_CONFIRM_UNSAVED,
+    UI_DIALOG_INFO
 } UiDialogKind;
 
 /**

--- a/include/app/workspace_dialogs.h
+++ b/include/app/workspace_dialogs.h
@@ -71,5 +71,9 @@ int workspace_dialog_resolve(Workspace* workspace, UiDialogResult result);
 
 /** Open the standard unsaved-changes confirmation dialog. */
 int workspace_dialog_open_confirm_unsaved(Workspace* workspace, WorkspaceActionType pending_action);
+/** Open a simple informational dialog with a single dismiss action. */
+int workspace_dialog_open_info(Workspace* workspace,
+                               const char* title,
+                               const char* message);
 
 #endif /* GLDRAW_APP_WORKSPACE_DIALOGS_H */

--- a/src/app/command_registry.c
+++ b/src/app/command_registry.c
@@ -6,6 +6,7 @@
 
 #include <app/workspace.h>
 #include <app/workspace_actions.h>
+#include <app/workspace_dialogs.h>
 #include <base/log.h>
 #include <base/math2d.h>
 #include <canvas/canvas_view.h>
@@ -176,11 +177,61 @@ const CommandDescriptor* command_registry_find_by_menu_id(int id)
     return NULL;
 }
 
+int command_registry_is_available(const Workspace* workspace,
+                                  EditorCommand command)
+{
+    switch (command) {
+    case EDITOR_COMMAND_FILE_SAVE:
+        return workspace && workspace->save_document;
+    case EDITOR_COMMAND_FILE_SAVE_AS:
+    case EDITOR_COMMAND_HELP_SHORTCUTS:
+        return 0;
+    case EDITOR_COMMAND_FILE_NEW:
+    case EDITOR_COMMAND_FILE_OPEN:
+    case EDITOR_COMMAND_FILE_EXIT:
+    case EDITOR_COMMAND_EDIT_UNDO:
+    case EDITOR_COMMAND_EDIT_REDO:
+    case EDITOR_COMMAND_EDIT_DELETE:
+    case EDITOR_COMMAND_EDIT_SELECT_ALL:
+    case EDITOR_COMMAND_VIEW_ZOOM_IN:
+    case EDITOR_COMMAND_VIEW_ZOOM_OUT:
+    case EDITOR_COMMAND_VIEW_ZOOM_FIT:
+    case EDITOR_COMMAND_VIEW_TOGGLE_GRID:
+    case EDITOR_COMMAND_VIEW_TOGGLE_INSPECTOR:
+    case EDITOR_COMMAND_TOOL_SELECT:
+    case EDITOR_COMMAND_TOOL_PAN:
+    case EDITOR_COMMAND_TOOL_LINE:
+    case EDITOR_COMMAND_TOOL_RECT:
+    case EDITOR_COMMAND_TOOL_ELLIPSE:
+    case EDITOR_COMMAND_HELP_ABOUT:
+    case EDITOR_COMMAND_MODAL_CONFIRM:
+    case EDITOR_COMMAND_MODAL_CANCEL:
+        return 1;
+    case EDITOR_COMMAND_NONE:
+    default:
+        return 0;
+    }
+}
+
+int command_registry_is_menu_action_available(const Workspace* workspace, int id)
+{
+    const CommandDescriptor* descriptor = command_registry_find_by_menu_id(id);
+
+    if (!descriptor) {
+        return 0;
+    }
+
+    return command_registry_is_available(workspace, descriptor->command);
+}
+
 int command_registry_execute(Workspace* workspace,
                              ToolContext* tool_context,
                              EditorCommand command)
 {
     if (!workspace) {
+        return 0;
+    }
+    if (!command_registry_is_available(workspace, command)) {
         return 0;
     }
 
@@ -250,11 +301,11 @@ int command_registry_execute(Workspace* workspace,
         if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_ELLIPSE);
         return 1;
     case EDITOR_COMMAND_HELP_SHORTCUTS:
-        LOG_INFO("%s", "Keyboard shortcuts dialog requested");
-        return 1;
+        return 0;
     case EDITOR_COMMAND_HELP_ABOUT:
-        LOG_INFO("%s", "About dialog requested");
-        return 1;
+        return workspace_dialog_open_info(workspace,
+                                          "About GLDraw",
+                                          "GLDraw\nCanvas-oriented OpenGL drawing editor.\n\nCurrent build includes core document editing, undo/redo, persistence, and themeable UI.");
     case EDITOR_COMMAND_MODAL_CONFIRM:
         return workspace_confirm_pending_action_save(workspace);
     case EDITOR_COMMAND_MODAL_CANCEL:

--- a/src/app/workspace_dialogs.c
+++ b/src/app/workspace_dialogs.c
@@ -25,8 +25,16 @@ static const UiDialogButtonDefinition UI_DIALOG_BUTTON_CONFIRM_UNSAVED_CANCEL = 
     0
 };
 
+static const UiDialogButtonDefinition UI_DIALOG_BUTTON_INFO_OK = {
+    "OK",
+    UI_DIALOG_RESULT_PRIMARY,
+    1
+};
+
 static int workspace_dialog_resolve_confirm_unsaved(Workspace* workspace,
                                                     UiDialogResult result);
+static int workspace_dialog_resolve_info(Workspace* workspace,
+                                         UiDialogResult result);
 
 static const UiDialogButtonDefinition UI_DIALOG_BUTTONS_CONFIRM_UNSAVED[] = {
     UI_DIALOG_BUTTON_CONFIRM_UNSAVED_SAVE,
@@ -46,6 +54,24 @@ static const UiDialogDefinition UI_DIALOG_DEFINITION_CONFIRM_UNSAVED = {
     UI_DIALOG_BUTTONS_CONFIRM_UNSAVED,
     (int)(sizeof(UI_DIALOG_BUTTONS_CONFIRM_UNSAVED) / sizeof(UI_DIALOG_BUTTONS_CONFIRM_UNSAVED[0])),
     workspace_dialog_resolve_confirm_unsaved
+};
+
+static const UiDialogButtonDefinition UI_DIALOG_BUTTONS_INFO[] = {
+    UI_DIALOG_BUTTON_INFO_OK
+};
+
+static const UiDialogDefinition UI_DIALOG_DEFINITION_INFO = {
+    {
+        UI_DIALOG_INFO,
+        "Information",
+        "",
+        420.0f,
+        190.0f,
+        1
+    },
+    UI_DIALOG_BUTTONS_INFO,
+    (int)(sizeof(UI_DIALOG_BUTTONS_INFO) / sizeof(UI_DIALOG_BUTTONS_INFO[0])),
+    workspace_dialog_resolve_info
 };
 
 static int workspace_dialog_execute_action_now(Workspace* workspace,
@@ -92,11 +118,32 @@ static int workspace_dialog_resolve_confirm_unsaved(Workspace* workspace,
     }
 }
 
+static int workspace_dialog_resolve_info(Workspace* workspace,
+                                         UiDialogResult result)
+{
+    if (!workspace) {
+        return 0;
+    }
+
+    switch (result) {
+    case UI_DIALOG_RESULT_PRIMARY:
+    case UI_DIALOG_RESULT_CANCEL:
+        workspace_dialog_close(workspace);
+        return 1;
+    case UI_DIALOG_RESULT_NONE:
+    case UI_DIALOG_RESULT_SECONDARY:
+    default:
+        return 0;
+    }
+}
+
 const UiDialogDefinition* workspace_dialog_definition(UiDialogKind kind)
 {
     switch (kind) {
     case UI_DIALOG_CONFIRM_UNSAVED:
         return &UI_DIALOG_DEFINITION_CONFIRM_UNSAVED;
+    case UI_DIALOG_INFO:
+        return &UI_DIALOG_DEFINITION_INFO;
     case UI_DIALOG_NONE:
     default:
         return NULL;
@@ -248,4 +295,22 @@ int workspace_dialog_open_confirm_unsaved(Workspace* workspace, WorkspaceActionT
     return workspace_dialog_open_definition(workspace,
                                             &UI_DIALOG_DEFINITION_CONFIRM_UNSAVED,
                                             &payload);
+}
+
+int workspace_dialog_open_info(Workspace* workspace,
+                               const char* title,
+                               const char* message)
+{
+    UiDialogState dialog;
+
+    if (!workspace || !title || !message) {
+        return 0;
+    }
+
+    workspace_dialog_apply_template(&dialog,
+                                    &UI_DIALOG_DEFINITION_INFO.dialog_template);
+    snprintf(dialog.title, sizeof(dialog.title), "%s", title);
+    snprintf(dialog.message, sizeof(dialog.message), "%s", message);
+    return workspace_dialog_add_button(&dialog, &UI_DIALOG_BUTTON_INFO_OK) &&
+           workspace_dialog_open(workspace, &dialog);
 }

--- a/src/input/input_router.c
+++ b/src/input/input_router.c
@@ -35,7 +35,9 @@ int input_router_handle_key(const InputRouterContext* context, const KeyEvent* e
     command_id = keymap_lookup_command(&context->workspace->keymap, scope, chord);
     if (command_id) {
         descriptor = command_registry_find_by_id(command_id);
-        if (descriptor) {
+        if (descriptor &&
+            command_registry_is_available(context->workspace,
+                                          descriptor->command)) {
             return command_registry_execute(context->workspace,
                                             context->tool_context,
                                             descriptor->command);

--- a/src/ui/ui_menu_actions.c
+++ b/src/ui/ui_menu_actions.c
@@ -15,34 +15,23 @@
 #include <app/command_registry.h>
 #include <app/workspace.h>
 #include <base/log.h>
-
-/**
- * @brief Executes PNG export command (not yet implemented).
- * @param workspace [in,out] Workspace instance (currently unused).
- * @return Currently always returns 0.
- */
-static int app_export_png(Workspace* workspace)
-{
-    (void)workspace;
-    LOG_INFO("%s", "Export PNG requested");
-    return 0;
-}
-
 /**
  * @brief Checks if menu action is currently available.
+ * @param workspace [in] Workspace instance used for command-backed items.
  * @param id [in] Menu action ID.
  * @return Non-zero if available, 0 if unavailable.
  */
-int ui_menu_is_action_available(MenuId id)
+int ui_menu_is_action_available(const Workspace* workspace, MenuId id)
 {
     switch (id) {
     case MENU_ID_FILE_EXPORT_PNG:
     case MENU_ID_EDIT_CUT:
     case MENU_ID_EDIT_COPY:
     case MENU_ID_EDIT_PASTE:
+    case MENU_ID_FILE_RECENT:
         return 0;
     default:
-        return 1;
+        return command_registry_is_menu_action_available(workspace, (int)id);
     }
 }
 
@@ -60,12 +49,7 @@ void ui_menu_execute(Workspace* workspace, MenuId id)
         return;
     }
 
-    if (id == MENU_ID_FILE_EXPORT_PNG) {
-        app_export_png(workspace);
-        return;
-    }
-    if (id == MENU_ID_EDIT_CUT || id == MENU_ID_EDIT_COPY || id == MENU_ID_EDIT_PASTE) {
-        LOG_INFO("Menu action %d not yet implemented", id);
+    if (!ui_menu_is_action_available(workspace, id)) {
         return;
     }
 

--- a/src/ui/ui_menu_actions.h
+++ b/src/ui/ui_menu_actions.h
@@ -19,9 +19,10 @@ void ui_menu_execute(struct Workspace* workspace, MenuId id);
 
 /**
  * @brief Checks if menu action is currently available.
+ * @param workspace Workspace instance used to evaluate runtime-backed command availability.
  * @param id Menu action ID.
  * @return Non-zero if available, 0 if unavailable.
  */
-int ui_menu_is_action_available(MenuId id);
+int ui_menu_is_action_available(const struct Workspace* workspace, MenuId id);
 
 #endif /* GLDRAW_UI_UI_MENU_ACTIONS_H */

--- a/src/ui/ui_menu_def.c
+++ b/src/ui/ui_menu_def.c
@@ -31,11 +31,6 @@ static MenuItemDef g_menu_items[] = {
     /* Separator */
     { MENU_ITEM_SEPARATOR, "", "", -1, MENU_ID_FILE },
 
-    { MENU_ITEM_SUBMENU, "Recent Files", "", MENU_ID_FILE_RECENT, MENU_ID_FILE },
-
-    /* Separator */
-    { MENU_ITEM_SEPARATOR, "", "", -1, MENU_ID_FILE },
-
     { MENU_ITEM_ACTION, "Exit", "Alt+F4", MENU_ID_FILE_EXIT, MENU_ID_FILE },
 
     { MENU_ITEM_SUBMENU, "Edit", "", MENU_ID_EDIT, -1 },

--- a/src/ui/ui_menubar.c
+++ b/src/ui/ui_menubar.c
@@ -295,7 +295,7 @@ static int ui_render_dropdown(struct nk_context* ctx, Workspace* workspace, int 
 
         case MENU_ITEM_ACTION: {
             char menu_text[96];
-            int enabled = ui_menu_is_action_available((MenuId)item->id);
+            int enabled = ui_menu_is_action_available(workspace, (MenuId)item->id);
 
             ui_build_menu_item_text(workspace, menu_text, sizeof(menu_text), item);
 
@@ -482,7 +482,7 @@ void ui_menubar_build(UiMenuBar* menubar, Workspace* workspace, int window_width
             char tooltip[96];
             char shortcut[64];
             struct nk_rect widget_bounds;
-            int enabled = ui_menu_is_action_available(g_quick_actions[i].menu_id);
+            int enabled = ui_menu_is_action_available(workspace, g_quick_actions[i].menu_id);
             int hovered = 0;
             nk_layout_row_push(ctx, g_quick_actions[i].width);
             if (!enabled) {

--- a/tests/test_document_core.c
+++ b/tests/test_document_core.c
@@ -334,8 +334,7 @@ static int test_persistence_round_trip(void)
 
     EXPECT_INT_EQ(loaded.count, 2);
     EXPECT_UINT_EQ(loaded.next_id, saved.next_id);
-    EXPECT_INT_EQ(loaded.selection.count, 1);
-    EXPECT_UINT_EQ(loaded.selection.ids[0], 2u);
+    EXPECT_INT_EQ(loaded.selection.count, 0);
     EXPECT_TRUE(object_get_scalar(document_find_object(&loaded, 1u), "width", &width));
     EXPECT_FLOAT_EQ(width, 20.0f);
 


### PR DESCRIPTION
Closes #59

## Summary
- centralize command availability so menus, quick actions, and shortcuts share the same enabled/disabled behavior
- disable placeholder entries that are not implemented yet, including Save As, Export PNG, clipboard actions, and keyboard shortcuts help
- replace the About placeholder with a real reusable info dialog and remove the empty Recent Files placeholder menu

## Testing
- cmake --build build --config Release
- ctest --test-dir build -C Release --output-on-failure
