### PR TITLE
cleanup: consolidate shared file helper utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ find_package(OpenGL REQUIRED)
 
 set(GLDRAW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/base/file_utils.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/application.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/command_registry.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_actions.c

--- a/include/base/file_utils.h
+++ b/include/base/file_utils.h
@@ -1,0 +1,14 @@
+/**
+ * @file file_utils.h
+ * @brief Shared file/path helpers for small text and temp-file workflows.
+ */
+#ifndef GLDRAW_BASE_FILE_UTILS_H
+#define GLDRAW_BASE_FILE_UTILS_H
+
+char* file_utils_read_text_file(const char* path);
+char* file_utils_duplicate_path_with_suffix(const char* path, const char* suffix);
+int file_utils_path_exists(const char* path);
+int file_utils_replace_file_with_temp(const char* temp_path,
+                                      const char* target_path);
+
+#endif /* GLDRAW_BASE_FILE_UTILS_H */

--- a/src/base/file_utils.c
+++ b/src/base/file_utils.c
@@ -1,0 +1,120 @@
+/**
+ * @file file_utils.c
+ * @brief Shared file/path helpers for small text and temp-file workflows.
+ */
+#include <base/file_utils.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+char* file_utils_read_text_file(const char* path)
+{
+    FILE* file = NULL;
+    char* buffer = NULL;
+    long size = 0;
+    size_t read_size = 0u;
+
+    if (!path || path[0] == '\0') {
+        return NULL;
+    }
+
+    file = fopen(path, "rb");
+    if (!file) {
+        return NULL;
+    }
+
+    if (fseek(file, 0, SEEK_END) != 0) {
+        fclose(file);
+        return NULL;
+    }
+    size = ftell(file);
+    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        return NULL;
+    }
+
+    buffer = (char*)malloc((size_t)size + 1u);
+    if (!buffer) {
+        fclose(file);
+        return NULL;
+    }
+
+    read_size = fread(buffer, 1u, (size_t)size, file);
+    if (read_size != (size_t)size && ferror(file)) {
+        free(buffer);
+        fclose(file);
+        return NULL;
+    }
+
+    buffer[read_size] = '\0';
+    fclose(file);
+    return buffer;
+}
+
+char* file_utils_duplicate_path_with_suffix(const char* path, const char* suffix)
+{
+    size_t path_length = 0u;
+    size_t suffix_length = 0u;
+    char* result = NULL;
+
+    if (!path || !suffix) {
+        return NULL;
+    }
+
+    path_length = strlen(path);
+    suffix_length = strlen(suffix);
+    result = (char*)malloc(path_length + suffix_length + 1u);
+    if (!result) {
+        return NULL;
+    }
+
+    memcpy(result, path, path_length);
+    memcpy(result + path_length, suffix, suffix_length);
+    result[path_length + suffix_length] = '\0';
+    return result;
+}
+
+int file_utils_path_exists(const char* path)
+{
+    FILE* file = NULL;
+
+    if (!path || path[0] == '\0') {
+        return 0;
+    }
+
+    file = fopen(path, "rb");
+    if (!file) {
+        return 0;
+    }
+
+    fclose(file);
+    return 1;
+}
+
+int file_utils_replace_file_with_temp(const char* temp_path,
+                                      const char* target_path)
+{
+    if (!temp_path || !target_path) {
+        return 0;
+    }
+
+#ifdef _WIN32
+    if (MoveFileExA(temp_path,
+                    target_path,
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        return 1;
+    }
+#else
+    if (rename(temp_path, target_path) == 0) {
+        return 1;
+    }
+#endif
+
+    remove(temp_path);
+    return 0;
+}

--- a/src/document/persistence.c
+++ b/src/document/persistence.c
@@ -12,6 +12,7 @@
  */
 #include <document/persistence.h>
 
+#include <base/file_utils.h>
 #include <base/log.h>
 
 #include <ctype.h>
@@ -19,10 +20,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#ifdef _WIN32
-#include <windows.h>
-#endif
 
 typedef enum {
     JSON_TOKEN_EOF = 0,
@@ -86,101 +83,6 @@ typedef struct {
 } LoadedObjectData;
 
 /**
- * @brief Reads a text file.
- * @param path File path.
- * @return File contents or NULL.
- */
-static char* read_text_file(const char* path)
-{
-    FILE* file = NULL;
-    char* buffer = NULL;
-    long size = 0;
-    size_t read_size = 0;
-
-    file = fopen(path, "rb");
-    if (!file) {
-        return NULL;
-    }
-
-    if (fseek(file, 0, SEEK_END) != 0) {
-        fclose(file);
-        return NULL;
-    }
-    size = ftell(file);
-    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) {
-        fclose(file);
-        return NULL;
-    }
-
-    buffer = (char*)malloc((size_t)size + 1u);
-    if (!buffer) {
-        fclose(file);
-        return NULL;
-    }
-
-    read_size = fread(buffer, 1u, (size_t)size, file);
-    if (read_size != (size_t)size && ferror(file)) {
-        free(buffer);
-        fclose(file);
-        return NULL;
-    }
-    buffer[read_size] = '\0';
-    fclose(file);
-    return buffer;
-}
-
-/**
- * @brief Duplicates a path with a suffix appended.
- * @param path Original path.
- * @param suffix Suffix to append.
- * @return Duplicated path or NULL.
- */
-static char* duplicate_path_with_suffix(const char* path, const char* suffix)
-{
-    size_t path_length = 0;
-    size_t suffix_length = 0;
-    char* result = NULL;
-
-    if (!path || !suffix) {
-        return NULL;
-    }
-
-    path_length = strlen(path);
-    suffix_length = strlen(suffix);
-    result = (char*)malloc(path_length + suffix_length + 1u);
-    if (!result) {
-        return NULL;
-    }
-
-    memcpy(result, path, path_length);
-    memcpy(result + path_length, suffix, suffix_length);
-    result[path_length + suffix_length] = '\0';
-    return result;
-}
-
-/**
- * @brief Checks if a file exists at path.
- * @param path File path.
- * @return 1 if exists, 0 otherwise.
- */
-static int file_exists_at_path(const char* path)
-{
-    FILE* file = NULL;
-
-    if (!path) {
-        return 0;
-    }
-
-    file = fopen(path, "rb");
-    if (!file) {
-        return 0;
-    }
-
-    fclose(file);
-    return 1;
-}
-
-/**
  * @brief Gets the type tag string for an object.
  * @param type Object type.
  * @return Type tag string.
@@ -197,39 +99,6 @@ static const char* object_type_tag(GraphicObjectType type)
     default:
         return "unknown";
     }
-}
-
-/**
- * @brief Replaces target file with temp file atomically.
- * @param temp_path Temp file path.
- * @param target_path Target file path.
- * @return 1 on success, 0 on failure.
- */
-static int replace_file_with_temp(const char* temp_path, const char* target_path)
-{
-    if (!temp_path || !target_path) {
-        return 0;
-    }
-
-#ifdef _WIN32
-    if (MoveFileExA(temp_path,
-                    target_path,
-                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
-        return 1;
-    }
-
-    LOG_ERROR("Failed to replace document file: %s", target_path);
-    remove(temp_path);
-    return 0;
-#else
-    if (rename(temp_path, target_path) == 0) {
-        return 1;
-    }
-
-    LOG_ERROR("Failed to replace document file: %s", target_path);
-    remove(temp_path);
-    return 0;
-#endif
 }
 
 /**
@@ -1233,13 +1102,13 @@ int document_save_json(const Document* document, const char* path)
         return 0;
     }
 
-    temp_path = duplicate_path_with_suffix(path, ".tmp");
+    temp_path = file_utils_duplicate_path_with_suffix(path, ".tmp");
     if (!temp_path) {
         LOG_ERROR("Failed to allocate temp path for document: %s", path);
         return 0;
     }
 
-    target_exists = file_exists_at_path(path);
+    target_exists = file_utils_path_exists(path);
     file = fopen(temp_path, "wb");
     if (!file) {
         LOG_ERROR("Failed to open temp document for writing: %s", temp_path);
@@ -1263,7 +1132,8 @@ int document_save_json(const Document* document, const char* path)
         return 0;
     }
 
-    if (!replace_file_with_temp(temp_path, path)) {
+    if (!file_utils_replace_file_with_temp(temp_path, path)) {
+        LOG_ERROR("Failed to replace document file: %s", path);
         if (target_exists) {
             LOG_ERROR("Preserved existing document after failed replace: %s", path);
         }
@@ -1295,7 +1165,7 @@ int document_load_json(Document* document, const char* path)
         return 0;
     }
 
-    text = read_text_file(path);
+    text = file_utils_read_text_file(path);
     if (!text) {
         LOG_ERROR("Failed to open document for reading: %s", path);
         return 0;

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -12,6 +12,7 @@
  */
 #include <render/render_system.h>
 
+#include <base/file_utils.h>
 #include <base/log.h>
 #include <base/math2d.h>
 
@@ -155,38 +156,6 @@ static void render_log_frame_stats(const RenderSystem* renderer)
 }
 
 /**
- * @brief Read a text file into a heap-allocated buffer.
- * @param path File path.
- * @return Newly allocated buffer on success, `NULL` on failure.
- */
-static char* read_text_file(const char* path)
-{
-    FILE* file = fopen(path, "rb");
-    char* buffer = NULL;
-    long length = 0;
-    size_t read_count = 0;
-
-    if (!file) {
-        return NULL;
-    }
-
-    fseek(file, 0, SEEK_END);
-    length = ftell(file);
-    fseek(file, 0, SEEK_SET);
-
-    buffer = (char*)malloc((size_t)length + 1u);
-    if (!buffer) {
-        fclose(file);
-        return NULL;
-    }
-
-    read_count = fread(buffer, 1u, (size_t)length, file);
-    buffer[read_count] = '\0';
-    fclose(file);
-    return buffer;
-}
-
-/**
  * @brief Compile a shader from source string.
  * @param type Shader type (GL_VERTEX_SHADER or GL_FRAGMENT_SHADER).
  * @param source Shader source code.
@@ -222,8 +191,8 @@ static GLuint compile_shader(GLenum type, const char* source, const char* label)
  */
 static GLuint load_program(const char* vertex_path, const char* fragment_path)
 {
-    char* vertex_source = read_text_file(vertex_path);
-    char* fragment_source = read_text_file(fragment_path);
+    char* vertex_source = file_utils_read_text_file(vertex_path);
+    char* fragment_source = file_utils_read_text_file(fragment_path);
     GLuint vertex_shader = 0;
     GLuint fragment_shader = 0;
     GLuint program = 0;

--- a/src/ui/ui_theme.c
+++ b/src/ui/ui_theme.c
@@ -11,8 +11,9 @@
  * - Uses file-system helpers and lightweight parsing utilities.
  */
 #include <nuklear/nuklear.h>
-#include <ui/ui_theme.h>
+#include <base/file_utils.h>
 #include <base/log.h>
+#include <ui/ui_theme.h>
 
 #include <ctype.h>
 #include <stddef.h>
@@ -381,54 +382,6 @@ UiThemeTokens ui_theme_tokens_for_id(const char* theme_id)
         return ui_theme_builtin_tokens_at(theme_index);
     }
     return g_custom_theme_entries[theme_index - builtin_count].tokens;
-}
-
-/**
- * @brief Reads a text file.
- * @param path File path.
- * @return File contents or NULL.
- */
-static char* ui_read_text_file(const char* path)
-{
-    FILE* file = NULL;
-    char* buffer = NULL;
-    long size = 0;
-    size_t read_size = 0;
-
-    if (!path || path[0] == '\0') {
-        return NULL;
-    }
-
-    file = fopen(path, "rb");
-    if (!file) {
-        return NULL;
-    }
-
-    if (fseek(file, 0, SEEK_END) != 0) {
-        fclose(file);
-        return NULL;
-    }
-    size = ftell(file);
-    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) {
-        fclose(file);
-        return NULL;
-    }
-
-    buffer = (char*)malloc((size_t)size + 1u);
-    if (!buffer) {
-        fclose(file);
-        return NULL;
-    }
-
-    read_size = fread(buffer, 1u, (size_t)size, file);
-    if (read_size != (size_t)size && ferror(file)) {
-        free(buffer);
-        fclose(file);
-        return NULL;
-    }
-    buffer[read_size] = '\0';
-    fclose(file);
-    return buffer;
 }
 
 /**
@@ -1102,7 +1055,7 @@ static int ui_theme_load_external_file(const char* path)
         return 0;
     }
 
-    text = ui_read_text_file(path);
+    text = file_utils_read_text_file(path);
     if (!text) {
         return 0;
     }
@@ -1207,7 +1160,7 @@ int ui_theme_reload_external(const char* directory_path)
                 if (g_last_reload_error[0] == '\0') {
                     snprintf(g_last_reload_error,
                              sizeof(g_last_reload_error),
-                             "Failed parsing theme file: %s",
+                             "Failed parsing theme file: %.200s",
                              file_path);
                 }
             }
@@ -1244,7 +1197,7 @@ int ui_theme_reload_external(const char* directory_path)
                 if (g_last_reload_error[0] == '\0') {
                     snprintf(g_last_reload_error,
                              sizeof(g_last_reload_error),
-                             "Failed parsing theme file: %s",
+                             "Failed parsing theme file: %.200s",
                              file_path);
                 }
             }
@@ -1395,7 +1348,7 @@ int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_t
     }
 
     out_theme_id[0] = '\0';
-    text = ui_read_text_file(path);
+    text = file_utils_read_text_file(path);
     if (!text) {
         return 0;
     }
@@ -1413,64 +1366,6 @@ int ui_theme_load_selected_id(const char* path, char* out_theme_id, size_t out_t
 
     free(text);
     return loaded && out_theme_id[0] != '\0';
-}
-
-/**
- * @brief Duplicates path with suffix appended.
- * @param path Original path.
- * @param suffix Suffix to append.
- * @return Duplicated path or NULL.
- */
-static char* ui_duplicate_path_with_suffix(const char* path, const char* suffix)
-{
-    size_t path_length = 0u;
-    size_t suffix_length = 0u;
-    char* result = NULL;
-
-    if (!path || !suffix) {
-        return NULL;
-    }
-
-    path_length = strlen(path);
-    suffix_length = strlen(suffix);
-    result = (char*)malloc(path_length + suffix_length + 1u);
-    if (!result) {
-        return NULL;
-    }
-
-    memcpy(result, path, path_length);
-    memcpy(result + path_length, suffix, suffix_length);
-    result[path_length + suffix_length] = '\0';
-    return result;
-}
-
-/**
- * @brief Replaces target file with temp file atomically.
- * @param temp_path Temp file path.
- * @param target_path Target file path.
- * @return 1 on success, 0 on failure.
- */
-static int ui_replace_file_with_temp(const char* temp_path, const char* target_path)
-{
-    if (!temp_path || !target_path) {
-        return 0;
-    }
-
-#ifdef _WIN32
-    if (MoveFileExA(temp_path,
-                    target_path,
-                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
-        return 1;
-    }
-    remove(temp_path);
-    return 0;
-#else
-    if (rename(temp_path, target_path) == 0) {
-        return 1;
-    }
-    remove(temp_path);
-    return 0;
-#endif
 }
 
 /**
@@ -1495,7 +1390,7 @@ int ui_theme_save_selected_id(const char* path, const char* theme_id)
         return 0;
     }
 
-    temp_path = ui_duplicate_path_with_suffix(path, ".tmp");
+    temp_path = file_utils_duplicate_path_with_suffix(path, ".tmp");
     if (!temp_path) {
         return 0;
     }
@@ -1523,7 +1418,7 @@ int ui_theme_save_selected_id(const char* path, const char* theme_id)
         return 0;
     }
 
-    if (!ui_replace_file_with_temp(temp_path, path)) {
+    if (!file_utils_replace_file_with_temp(temp_path, path)) {
         free(temp_path);
         return 0;
     }


### PR DESCRIPTION
Closes #57

## Summary
- add a small shared base file utility module for reading text files, appending temp suffixes, checking path existence, and replacing temp files atomically
- switch render shader loading, document persistence, and theme settings/theme file loading to the shared helpers
- keep module-level logging and error-policy decisions in the calling modules while removing duplicated helper implementations

## Testing
- cmake --build build --config Release
