### PR TITLE
feat: add keyboard shortcuts help dialog

### DIFF
--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -48,7 +48,8 @@ typedef enum UiRequestType {
  */
 typedef enum UiDialogKind {
     UI_DIALOG_NONE = 0,
-    UI_DIALOG_CONFIRM_UNSAVED
+    UI_DIALOG_CONFIRM_UNSAVED,
+    UI_DIALOG_SHORTCUTS
 } UiDialogKind;
 
 /**
@@ -71,7 +72,7 @@ typedef enum UiDialogResult {
  */
 typedef struct UiDialogPayload {
     int int_values[4];
-    char text[128];
+    char text[1024];
 } UiDialogPayload;
 
 /**
@@ -105,7 +106,7 @@ typedef struct UiDialogButtonSpec {
 typedef struct UiDialogState {
     UiDialogKind kind;
     char title[64];
-    char message[256];
+    char message[1024];
     UiDialogPayload payload;
     UiDialogButtonSpec buttons[3];
     int button_count;

--- a/include/app/workspace_dialogs.h
+++ b/include/app/workspace_dialogs.h
@@ -71,5 +71,7 @@ int workspace_dialog_resolve(Workspace* workspace, UiDialogResult result);
 
 /** Open the standard unsaved-changes confirmation dialog. */
 int workspace_dialog_open_confirm_unsaved(Workspace* workspace, WorkspaceActionType pending_action);
+/** Open the keyboard shortcuts help dialog using preformatted content text. */
+int workspace_dialog_open_shortcuts(Workspace* workspace, const char* content_text);
 
 #endif /* GLDRAW_APP_WORKSPACE_DIALOGS_H */

--- a/src/app/command_registry.c
+++ b/src/app/command_registry.c
@@ -6,6 +6,7 @@
 
 #include <app/workspace.h>
 #include <app/workspace_actions.h>
+#include <app/workspace_dialogs.h>
 #include <base/log.h>
 #include <base/math2d.h>
 #include <canvas/canvas_view.h>
@@ -14,6 +15,7 @@
 #include <tools/tool_controller.h>
 #include <ui/ui_menu_def.h>
 
+#include <stdio.h>
 #include <string.h>
 
 static const CommandDescriptor g_commands[] = {
@@ -41,6 +43,92 @@ static const CommandDescriptor g_commands[] = {
     {EDITOR_COMMAND_MODAL_CONFIRM, "modal.confirm", "Confirm", KEY_SCOPE_MODAL, MENU_ID_HELP},
     {EDITOR_COMMAND_MODAL_CANCEL, "modal.cancel", "Cancel", KEY_SCOPE_MODAL, MENU_ID_HELP}
 };
+
+static void command_registry_append_shortcut_line(char* buffer,
+                                                  size_t buffer_size,
+                                                  const Workspace* workspace,
+                                                  const char* command_id,
+                                                  KeyScope scope,
+                                                  const char* label)
+{
+    char shortcut[64];
+
+    if (!buffer || buffer_size == 0u || !workspace || !command_id || !label) {
+        return;
+    }
+
+    shortcut[0] = '\0';
+    keymap_format_command_shortcut(&workspace->keymap,
+                                   command_id,
+                                   scope,
+                                   shortcut,
+                                   sizeof(shortcut));
+    if (shortcut[0] == '\0') {
+        return;
+    }
+
+    snprintf(buffer + strlen(buffer),
+             buffer_size - strlen(buffer),
+             "  %-16s %s\n",
+             shortcut,
+             label);
+}
+
+static int command_registry_toggle_shortcuts_dialog(Workspace* workspace)
+{
+    char content[1024];
+
+    if (!workspace) {
+        return 0;
+    }
+
+    if (workspace_active_dialog_kind(workspace) == UI_DIALOG_SHORTCUTS) {
+        workspace_confirm_pending_action_cancel(workspace);
+        return 1;
+    }
+    if (workspace_modal_is_active(workspace)) {
+        return 0;
+    }
+
+    content[0] = '\0';
+    snprintf(content + strlen(content),
+             sizeof(content) - strlen(content),
+             "Tools\n");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "tool.select", KEY_SCOPE_GLOBAL, "Select Tool");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "tool.pan", KEY_SCOPE_GLOBAL, "Pan/Hand Tool");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "tool.line", KEY_SCOPE_GLOBAL, "Line Tool");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "tool.rect", KEY_SCOPE_GLOBAL, "Rectangle Tool");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "tool.ellipse", KEY_SCOPE_GLOBAL, "Ellipse Tool");
+
+    snprintf(content + strlen(content),
+             sizeof(content) - strlen(content),
+             "\nFile\n");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "file.new", KEY_SCOPE_GLOBAL, "New Document");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "file.open", KEY_SCOPE_GLOBAL, "Open Document");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "file.save", KEY_SCOPE_GLOBAL, "Save Document");
+
+    snprintf(content + strlen(content),
+             sizeof(content) - strlen(content),
+             "\nEdit\n");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "edit.undo", KEY_SCOPE_GLOBAL, "Undo");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "edit.redo", KEY_SCOPE_GLOBAL, "Redo");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "edit.delete", KEY_SCOPE_GLOBAL, "Delete Selection");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "edit.select_all", KEY_SCOPE_GLOBAL, "Select All");
+
+    snprintf(content + strlen(content),
+             sizeof(content) - strlen(content),
+             "\nView\n");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "view.zoom_fit", KEY_SCOPE_GLOBAL, "Zoom to Fit");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "view.zoom_in", KEY_SCOPE_GLOBAL, "Zoom In");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "view.zoom_out", KEY_SCOPE_GLOBAL, "Zoom Out");
+
+    snprintf(content + strlen(content),
+             sizeof(content) - strlen(content),
+             "\nHelp\n");
+    command_registry_append_shortcut_line(content, sizeof(content), workspace, "help.shortcuts", KEY_SCOPE_GLOBAL, "Toggle This Dialog");
+
+    return workspace_dialog_open_shortcuts(workspace, content);
+}
 
 static int command_registry_zoom_to_fit(Workspace* workspace)
 {
@@ -250,8 +338,7 @@ int command_registry_execute(Workspace* workspace,
         if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_ELLIPSE);
         return 1;
     case EDITOR_COMMAND_HELP_SHORTCUTS:
-        LOG_INFO("%s", "Keyboard shortcuts dialog requested");
-        return 1;
+        return command_registry_toggle_shortcuts_dialog(workspace);
     case EDITOR_COMMAND_HELP_ABOUT:
         LOG_INFO("%s", "About dialog requested");
         return 1;

--- a/src/app/workspace_dialogs.c
+++ b/src/app/workspace_dialogs.c
@@ -24,9 +24,16 @@ static const UiDialogButtonDefinition UI_DIALOG_BUTTON_CONFIRM_UNSAVED_CANCEL = 
     UI_DIALOG_RESULT_CANCEL,
     0
 };
+static const UiDialogButtonDefinition UI_DIALOG_BUTTON_SHORTCUTS_CLOSE = {
+    "Close",
+    UI_DIALOG_RESULT_CANCEL,
+    1
+};
 
 static int workspace_dialog_resolve_confirm_unsaved(Workspace* workspace,
                                                     UiDialogResult result);
+static int workspace_dialog_resolve_shortcuts(Workspace* workspace,
+                                              UiDialogResult result);
 
 static const UiDialogButtonDefinition UI_DIALOG_BUTTONS_CONFIRM_UNSAVED[] = {
     UI_DIALOG_BUTTON_CONFIRM_UNSAVED_SAVE,
@@ -46,6 +53,22 @@ static const UiDialogDefinition UI_DIALOG_DEFINITION_CONFIRM_UNSAVED = {
     UI_DIALOG_BUTTONS_CONFIRM_UNSAVED,
     (int)(sizeof(UI_DIALOG_BUTTONS_CONFIRM_UNSAVED) / sizeof(UI_DIALOG_BUTTONS_CONFIRM_UNSAVED[0])),
     workspace_dialog_resolve_confirm_unsaved
+};
+static const UiDialogButtonDefinition UI_DIALOG_BUTTONS_SHORTCUTS[] = {
+    UI_DIALOG_BUTTON_SHORTCUTS_CLOSE
+};
+static const UiDialogDefinition UI_DIALOG_DEFINITION_SHORTCUTS = {
+    {
+        UI_DIALOG_SHORTCUTS,
+        "Keyboard Shortcuts",
+        "",
+        520.0f,
+        420.0f,
+        1
+    },
+    UI_DIALOG_BUTTONS_SHORTCUTS,
+    (int)(sizeof(UI_DIALOG_BUTTONS_SHORTCUTS) / sizeof(UI_DIALOG_BUTTONS_SHORTCUTS[0])),
+    workspace_dialog_resolve_shortcuts
 };
 
 static int workspace_dialog_execute_action_now(Workspace* workspace,
@@ -92,11 +115,32 @@ static int workspace_dialog_resolve_confirm_unsaved(Workspace* workspace,
     }
 }
 
+static int workspace_dialog_resolve_shortcuts(Workspace* workspace,
+                                              UiDialogResult result)
+{
+    if (!workspace) {
+        return 0;
+    }
+
+    switch (result) {
+    case UI_DIALOG_RESULT_PRIMARY:
+    case UI_DIALOG_RESULT_CANCEL:
+        workspace_dialog_close(workspace);
+        return 1;
+    case UI_DIALOG_RESULT_NONE:
+    case UI_DIALOG_RESULT_SECONDARY:
+    default:
+        return 0;
+    }
+}
+
 const UiDialogDefinition* workspace_dialog_definition(UiDialogKind kind)
 {
     switch (kind) {
     case UI_DIALOG_CONFIRM_UNSAVED:
         return &UI_DIALOG_DEFINITION_CONFIRM_UNSAVED;
+    case UI_DIALOG_SHORTCUTS:
+        return &UI_DIALOG_DEFINITION_SHORTCUTS;
     case UI_DIALOG_NONE:
     default:
         return NULL;
@@ -248,4 +292,19 @@ int workspace_dialog_open_confirm_unsaved(Workspace* workspace, WorkspaceActionT
     return workspace_dialog_open_definition(workspace,
                                             &UI_DIALOG_DEFINITION_CONFIRM_UNSAVED,
                                             &payload);
+}
+
+int workspace_dialog_open_shortcuts(Workspace* workspace, const char* content_text)
+{
+    UiDialogState dialog;
+
+    if (!workspace || !content_text) {
+        return 0;
+    }
+
+    workspace_dialog_apply_template(&dialog,
+                                    &UI_DIALOG_DEFINITION_SHORTCUTS.dialog_template);
+    snprintf(dialog.message, sizeof(dialog.message), "%s", content_text);
+    return workspace_dialog_add_button(&dialog, &UI_DIALOG_BUTTON_SHORTCUTS_CLOSE) &&
+           workspace_dialog_open(workspace, &dialog);
 }

--- a/src/input/keymap.c
+++ b/src/input/keymap.c
@@ -31,6 +31,7 @@ static const struct {
     {"tool.rect", KEY_SCOPE_GLOBAL, "R", ""},
     {"tool.ellipse", KEY_SCOPE_GLOBAL, "E", ""},
     {"help.shortcuts", KEY_SCOPE_GLOBAL, "Shift+Slash", ""},
+    {"help.shortcuts", KEY_SCOPE_MODAL, "Shift+Slash", ""},
     {"modal.confirm", KEY_SCOPE_MODAL, "Enter", ""},
     {"modal.cancel", KEY_SCOPE_MODAL, "Esc", ""}
 };

--- a/src/ui/ui_dialog.c
+++ b/src/ui/ui_dialog.c
@@ -11,17 +11,52 @@
 
 #include "nuklear/nuklear.h"
 
+#include <stdio.h>
+#include <string.h>
+
+static int ui_dialog_supports_backdrop_close(const UiDialogState* dialog)
+{
+    return dialog && dialog->kind == UI_DIALOG_SHORTCUTS;
+}
+
+static int ui_dialog_supports_header_close(const UiDialogState* dialog)
+{
+    return dialog && dialog->kind == UI_DIALOG_SHORTCUTS;
+}
+
+static void ui_dialog_render_message_lines(struct nk_context* ctx,
+                                           const UiDialogState* dialog)
+{
+    char local[sizeof(dialog->message)];
+    char* line = NULL;
+
+    if (!ctx || !dialog || dialog->message[0] == '\0') {
+        return;
+    }
+
+    snprintf(local, sizeof(local), "%s", dialog->message);
+    line = strtok(local, "\n");
+    while (line) {
+        nk_layout_row_dynamic(ctx, 18.0f, 1);
+        nk_label(ctx, line, NK_TEXT_LEFT);
+        line = strtok(NULL, "\n");
+    }
+}
+
 UiDialogResult ui_dialog_show(struct nk_context* ctx,
                               const UiDialogState* dialog,
                               int window_width,
                               int window_height)
 {
     struct nk_style_item blocker_background;
+    struct nk_rect full_bounds;
     struct nk_rect bounds;
     float dialog_width = 0.0f;
     float dialog_height = 0.0f;
     UiDialogResult result = UI_DIALOG_RESULT_NONE;
     int i = 0;
+    nk_flags window_flags = 0;
+    const char* window_title = NULL;
 
     if (!ctx || !dialog || dialog->kind == UI_DIALOG_NONE) {
         return UI_DIALOG_RESULT_NONE;
@@ -46,29 +81,36 @@ UiDialogResult ui_dialog_show(struct nk_context* ctx,
                      ((float)window_height - dialog_height) * 0.5f,
                      dialog_width,
                      dialog_height);
+    full_bounds = nk_rect(0.0f, 0.0f, (float)window_width, (float)window_height);
+    window_title = dialog->title[0] != '\0' ? dialog->title : "Dialog";
 
     if (dialog->modal) {
         blocker_background = nk_style_item_color(nk_rgba(0, 0, 0, 96));
         nk_style_push_style_item(ctx, &ctx->style.window.fixed_background, blocker_background);
         if (nk_begin(ctx,
                      "##modal_blocker##",
-                     nk_rect(0.0f, 0.0f, (float)window_width, (float)window_height),
+                     full_bounds,
                      NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND)) {
             nk_layout_row_dynamic(ctx, 1.0f, 1);
             nk_label(ctx, "", NK_TEXT_LEFT);
         }
         nk_end(ctx);
         nk_style_pop_style_item(ctx);
+
+        if (ui_dialog_supports_backdrop_close(dialog) &&
+            nk_input_is_mouse_click_in_rect(&ctx->input, NK_BUTTON_LEFT, full_bounds) &&
+            !nk_input_is_mouse_hovering_rect(&ctx->input, bounds)) {
+            result = UI_DIALOG_RESULT_CANCEL;
+        }
     }
 
-    if (nk_begin(ctx,
-                 dialog->title[0] != '\0' ? dialog->title : "Dialog",
-                 bounds,
-                 NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_TITLE)) {
-        if (dialog->message[0] != '\0') {
-            nk_layout_row_dynamic(ctx, 48.0f, 1);
-            nk_label_wrap(ctx, dialog->message);
-        }
+    window_flags = NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_TITLE;
+    if (ui_dialog_supports_header_close(dialog)) {
+        window_flags |= NK_WINDOW_CLOSABLE;
+    }
+
+    if (nk_begin(ctx, window_title, bounds, window_flags)) {
+        ui_dialog_render_message_lines(ctx, dialog);
         nk_layout_row_dynamic(ctx, 12.0f, 1);
         nk_label(ctx, "", NK_TEXT_LEFT);
         if (dialog->button_count > 0) {
@@ -81,6 +123,11 @@ UiDialogResult ui_dialog_show(struct nk_context* ctx,
         }
     }
     nk_end(ctx);
+
+    if (ui_dialog_supports_header_close(dialog) &&
+        nk_window_is_closed(ctx, window_title)) {
+        result = UI_DIALOG_RESULT_CANCEL;
+    }
 
     return result;
 }


### PR DESCRIPTION
Closes #29

## Summary
- add a reusable keyboard shortcuts modal dialog to the existing workspace-owned dialog system
- wire ? to toggle the dialog in both global and modal key scopes so pressing ? again closes it
- support closing the shortcuts dialog via Escape, the header close button, and clicking outside the dialog

## Testing
- cmake --build build --config Release
