### PR TITLE
fix: restore post-merge build compatibility

### DIFF
--- a/src/app/workspace_dialogs.c
+++ b/src/app/workspace_dialogs.c
@@ -7,31 +7,13 @@
 #include <stdio.h>
 #include <string.h>
 
-static const UiDialogButtonDefinition UI_DIALOG_BUTTON_CONFIRM_UNSAVED_SAVE = {
-    "Save",
-    UI_DIALOG_RESULT_PRIMARY,
-    1
-};
-
-static const UiDialogButtonDefinition UI_DIALOG_BUTTON_CONFIRM_UNSAVED_DISCARD = {
-    "Don't Save",
-    UI_DIALOG_RESULT_SECONDARY,
-    0
-};
-
-static const UiDialogButtonDefinition UI_DIALOG_BUTTON_CONFIRM_UNSAVED_CANCEL = {
-    "Cancel",
-    UI_DIALOG_RESULT_CANCEL,
-    0
-};
-
 static int workspace_dialog_resolve_confirm_unsaved(Workspace* workspace,
                                                     UiDialogResult result);
 
 static const UiDialogButtonDefinition UI_DIALOG_BUTTONS_CONFIRM_UNSAVED[] = {
-    UI_DIALOG_BUTTON_CONFIRM_UNSAVED_SAVE,
-    UI_DIALOG_BUTTON_CONFIRM_UNSAVED_DISCARD,
-    UI_DIALOG_BUTTON_CONFIRM_UNSAVED_CANCEL
+    {"Save", UI_DIALOG_RESULT_PRIMARY, 1},
+    {"Don't Save", UI_DIALOG_RESULT_SECONDARY, 0},
+    {"Cancel", UI_DIALOG_RESULT_CANCEL, 0}
 };
 
 static const UiDialogDefinition UI_DIALOG_DEFINITION_CONFIRM_UNSAVED = {

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -193,7 +193,7 @@ static void render_prepare_pass_state(const RenderSystem* renderer)
         return;
     }
 
-    glViewport(0, 0, renderer->width, renderer->height);
+    glViewport(0, 0, renderer->framebuffer_width, renderer->framebuffer_height);
     glUseProgram(renderer->program);
     glBindVertexArray(renderer->vao);
     glBindBuffer(GL_ARRAY_BUFFER, renderer->vbo);


### PR DESCRIPTION
Closes #56

## Summary
- fix the renderer pass setup to use framebuffer dimensions after the HiDPI renderer changes from #63/#64/#65
- rewrite the unsaved-dialog button table as direct literals so MSVC accepts the static initialization
- restore successful local Windows Release builds after the post-merge breakage surfaced

## Context
PR #65 has already been merged. This follow-up PR carries the minimal build fixes needed after that merge, rather than reopening the merged PR.

## Testing
- cmake -S . -B build-post-merge-fixes -G "Visual Studio 17 2022" -A x64
- cmake --build build-post-merge-fixes --config Release
- ctest --test-dir build-post-merge-fixes -C Release --output-on-failure (no tests found)