### PR TITLE
refactor: separate editor core session services

### DIFF
--- a/doc/wiki/architecture-layering-plan.md
+++ b/doc/wiki/architecture-layering-plan.md
@@ -1,0 +1,59 @@
+# Architecture Layering Plan
+
+This note captures the incremental architecture direction implemented as part of issue #55.
+
+## Current layering
+
+The editor runtime is now split into three explicit layers in `Workspace`:
+
+- `EditorCore`
+  - `Document`
+  - `DocumentHistory`
+  - `CanvasView`
+  - `ToolController`
+- `EditorSession`
+  - selection state
+  - clipboard state
+  - current file path
+  - dirty/save tracking
+  - keymap
+  - layout and dialog state
+  - status text
+- `EditorServices`
+  - save/load callbacks
+  - deferred action executor
+  - application-owned callback context
+
+This keeps persisted drawing data separate from runtime/editor-only state and makes backend integration points explicit.
+
+## Boundaries clarified in this refactor
+
+### Persisted document vs session-only state
+
+- `Document` now owns only persisted drawing data and revision bookkeeping.
+- Selection is no longer stored on `Document`.
+- Selection now lives in `EditorSession`, which matches actual runtime behavior and avoids re-entangling persistence, rendering, and UI state.
+
+### Self-contained history
+
+- `DocumentHistory` now owns all of its auxiliary entry-kind and lightweight edit buffers directly.
+- The previous global internal registry was removed.
+- Undo/redo now restores both document snapshots and session selection state through explicit parameters.
+
+### Command path consistency
+
+- Menu and shortcut actions continue to route through `command_registry_execute()`.
+- Session-sensitive edit commands now operate on `EditorSession.selection` rather than hidden document state.
+
+### Backend boundaries
+
+- Application/UI code now reaches editing state through `workspace.core`, `workspace.session`, and `workspace.services`.
+- This reduces the amount of backend-specific code that needs knowledge of mixed editor state.
+
+## Incremental follow-up slices
+
+1. Extract `EditorCore` lifecycle helpers from `application.c`.
+2. Move clipboard and file/session actions behind a dedicated session/service module instead of `command_registry.c`.
+3. Introduce a renderer-facing scene struct so `render_system_draw()` does not depend directly on raw document storage.
+4. Isolate Nuklear-specific UI implementation details behind a narrower presenter/model boundary.
+5. Convert remaining tool and inspector edit flows to use explicit command objects for all user-visible edits.

--- a/include/app/editor_session.h
+++ b/include/app/editor_session.h
@@ -1,0 +1,131 @@
+/**
+ * @file editor_session.h
+ * @brief Editor-session-only state helpers.
+ */
+#ifndef GLDRAW_APP_EDITOR_SESSION_H
+#define GLDRAW_APP_EDITOR_SESSION_H
+
+#include <document/document.h>
+
+#include <string.h>
+
+/**
+ * @brief Clear a selection set.
+ * @param selection Selection set to clear.
+ * @return No return value.
+ */
+static inline void selection_set_clear(SelectionSet* selection)
+{
+    if (selection) {
+        selection->count = 0;
+    }
+}
+
+/**
+ * @brief Check whether an object ID is selected.
+ * @param selection Selection set.
+ * @param id Object ID.
+ * @return Non-zero if selected, zero otherwise.
+ */
+static inline int selection_set_contains(const SelectionSet* selection, ObjectId id)
+{
+    int i = 0;
+
+    if (!selection || id == 0) {
+        return 0;
+    }
+
+    for (i = 0; i < selection->count; ++i) {
+        if (selection->ids[i] == id) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Add an object ID to a selection set.
+ * @param selection Selection set.
+ * @param id Object ID.
+ * @return Non-zero on success, zero on invalid parameters or capacity overflow.
+ */
+static inline int selection_set_add(SelectionSet* selection, ObjectId id)
+{
+    if (!selection || id == 0) {
+        return 0;
+    }
+
+    if (selection_set_contains(selection, id)) {
+        return 1;
+    }
+
+    if (selection->count >= DOCUMENT_MAX_SELECTION) {
+        return 0;
+    }
+
+    selection->ids[selection->count++] = id;
+    return 1;
+}
+
+/**
+ * @brief Remove an object ID from a selection set.
+ * @param selection Selection set.
+ * @param id Object ID.
+ * @return No return value.
+ */
+static inline void selection_set_remove(SelectionSet* selection, ObjectId id)
+{
+    int i = 0;
+
+    if (!selection || id == 0) {
+        return;
+    }
+
+    for (i = 0; i < selection->count; ++i) {
+        if (selection->ids[i] == id) {
+            memmove(&selection->ids[i],
+                    &selection->ids[i + 1],
+                    (size_t)(selection->count - i - 1) * sizeof(selection->ids[0]));
+            selection->count--;
+            return;
+        }
+    }
+}
+
+/**
+ * @brief Toggle an object ID in a selection set.
+ * @param selection Selection set.
+ * @param id Object ID.
+ * @return No return value.
+ */
+static inline void selection_set_toggle(SelectionSet* selection, ObjectId id)
+{
+    if (!selection) {
+        return;
+    }
+
+    if (selection_set_contains(selection, id)) {
+        selection_set_remove(selection, id);
+    } else {
+        selection_set_add(selection, id);
+    }
+}
+
+/**
+ * @brief Resolve the primary selected object from a document.
+ * @param selection Selection set.
+ * @param document Document to search.
+ * @return Selected object or `NULL`.
+ */
+static inline GraphicObject* selection_set_primary_object(const SelectionSet* selection,
+                                                          const Document* document)
+{
+    if (!selection || !document || selection->count <= 0) {
+        return NULL;
+    }
+
+    return document_find_object(document, selection->ids[0]);
+}
+
+#endif /* GLDRAW_APP_EDITOR_SESSION_H */

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -5,8 +5,8 @@
 #ifndef GLDRAW_APP_WORKSPACE_H
 #define GLDRAW_APP_WORKSPACE_H
 
+#include <app/editor_session.h>
 #include <canvas/canvas_view.h>
-#include <document/document.h>
 #include <document/history.h>
 #include <input/keymap.h>
 #include <tools/tool_controller.h>
@@ -151,15 +151,28 @@ typedef struct WorkspaceLayout {
 } WorkspaceLayout;
 
 /**
- * @struct Workspace
- * @brief Runtime core state container.
+ * @struct EditorCore
+ * @brief Backend-agnostic editing state.
  *
- * @member document Current document object and selection state.
+ * @member document Persisted document model.
  * @member history Undo/redo history.
  * @member canvas Canvas view state.
  * @member tools Tool controller.
+ */
+typedef struct EditorCore {
+    Document document;
+    DocumentHistory history;
+    CanvasView canvas;
+    ToolController tools;
+} EditorCore;
+
+/**
+ * @struct EditorSession
+ * @brief Session-only editor state.
+ *
  * @member keymap Effective keyboard mapping state.
  * @member layout UI layout information.
+ * @member selection Active object selection.
  * @member clipboard_objects Internal clipboard object clones.
  * @member clipboard_count Number of objects currently stored in the internal clipboard.
  * @member clipboard_paste_serial Repeated paste counter used to offset pasted content.
@@ -169,18 +182,11 @@ typedef struct WorkspaceLayout {
  * @member document_dirty Whether the document is dirty (non-zero means unsaved changes).
  * @member active_request_type Active top-level UI request type.
  * @member active_dialog Active reusable dialog state.
- * @member save_document Save callback.
- * @member load_document Load callback.
- * @member execute_action Deferred workspace action executor.
- * @member command_user_data Callback context.
  */
-typedef struct Workspace {
-    Document document;
-    DocumentHistory history;
-    CanvasView canvas;
-    ToolController tools;
+typedef struct EditorSession {
     EditorKeymap keymap;
     WorkspaceLayout layout;
+    SelectionSet selection;
     GraphicObject* clipboard_objects[DOCUMENT_MAX_SELECTION];
     int clipboard_count;
     unsigned int clipboard_paste_serial;
@@ -190,10 +196,27 @@ typedef struct Workspace {
     int document_dirty;
     UiRequestType active_request_type;
     UiDialogState active_dialog;
+} EditorSession;
+
+/**
+ * @struct EditorServices
+ * @brief Integration callbacks supplied by the application shell.
+ */
+typedef struct EditorServices {
     WorkspaceCommandFn save_document;
     WorkspaceCommandFn load_document;
     WorkspaceActionExecutorFn execute_action;
     void* command_user_data;
+} EditorServices;
+
+/**
+ * @struct Workspace
+ * @brief Runtime editor container split into core/session/services layers.
+ */
+typedef struct Workspace {
+    EditorCore core;
+    EditorSession session;
+    EditorServices services;
 } Workspace;
 
 /**
@@ -207,8 +230,8 @@ static inline void workspace_mark_saved(Workspace* workspace)
         return;
     }
 
-    workspace->saved_revision = workspace->document.revision;
-    workspace->document_dirty = 0;
+    workspace->session.saved_revision = workspace->core.document.revision;
+    workspace->session.document_dirty = 0;
 }
 
 /**
@@ -222,7 +245,8 @@ static inline void workspace_sync_document_dirty(Workspace* workspace)
         return;
     }
 
-    workspace->document_dirty = (workspace->saved_revision != workspace->document.revision);
+    workspace->session.document_dirty =
+        (workspace->session.saved_revision != workspace->core.document.revision);
 }
 
 /**
@@ -238,13 +262,13 @@ static inline void workspace_clear_clipboard(Workspace* workspace)
         return;
     }
 
-    for (i = 0; i < workspace->clipboard_count; ++i) {
-        object_destroy(workspace->clipboard_objects[i]);
-        workspace->clipboard_objects[i] = NULL;
+    for (i = 0; i < workspace->session.clipboard_count; ++i) {
+        object_destroy(workspace->session.clipboard_objects[i]);
+        workspace->session.clipboard_objects[i] = NULL;
     }
 
-    workspace->clipboard_count = 0;
-    workspace->clipboard_paste_serial = 0;
+    workspace->session.clipboard_count = 0;
+    workspace->session.clipboard_paste_serial = 0;
 }
 
 #endif /* GLDRAW_APP_WORKSPACE_H */

--- a/include/document/document.h
+++ b/include/document/document.h
@@ -1,6 +1,6 @@
 /**
  * @file document.h
- * @brief Document object container and selection set operation interface.
+ * @brief Document object container interface.
  */
 #ifndef GLDRAW_DOCUMENT_DOCUMENT_H
 #define GLDRAW_DOCUMENT_DOCUMENT_H
@@ -30,14 +30,12 @@ typedef struct {
  * @member count Current object count.
  * @member revision Document revision number (incremented after edits).
  * @member next_id Auto-assigned ID for new objects.
- * @member selection Current editor-session selection set (not serialized).
  */
 typedef struct Document {
   GraphicObject *objects[DOCUMENT_MAX_OBJECTS];
   int count;
   unsigned int revision;
   ObjectId next_id;
-  SelectionSet selection;
 } Document;
 
 /**
@@ -105,13 +103,6 @@ GraphicObject *document_get_object_at(const Document *document, int index);
 int document_remove_object(Document *document, ObjectId id);
 
 /**
- * @brief Delete all objects in the current selection set.
- * @param document Target document.
- * @return No return value.
- */
-void document_delete_selection(Document *document);
-
-/**
  * @brief Mark a non-structural modification (increments revision).
  * @param document Target document.
  * @return No return value.
@@ -124,51 +115,5 @@ void document_touch(Document *document);
  * @return Maximum ID; returns `0` if the document is empty or parameters are invalid.
  */
 ObjectId document_max_id(const Document *document);
-
-/**
- * @brief Clear the selection set.
- * @param document Target document.
- * @return No return value.
- */
-void document_clear_selection(Document *document);
-
-/**
- * @brief Check whether an object ID is in the selection set.
- * @param document Document.
- * @param id Object ID.
- * @return Non-zero if in the selection set, zero otherwise.
- */
-int document_selection_contains(const Document *document, ObjectId id);
-
-/**
- * @brief Add an object ID to the selection set.
- * @param document Target document.
- * @param id Object ID.
- * @return Non-zero on success or if already present; zero on invalid parameters or capacity error.
- */
-int document_selection_add(Document *document, ObjectId id);
-
-/**
- * @brief Remove an object ID from the selection set.
- * @param document Target document.
- * @param id Object ID.
- * @return No return value.
- */
-void document_selection_remove(Document *document, ObjectId id);
-
-/**
- * @brief Toggle the selection state of an object ID.
- * @param document Target document.
- * @param id Object ID.
- * @return No return value.
- */
-void document_selection_toggle(Document *document, ObjectId id);
-
-/**
- * @brief Get the "primary selected object" (object corresponding to the first element of the selection set).
- * @param document Document.
- * @return Primary selected object; returns `NULL` if no selection.
- */
-GraphicObject *document_primary_selection(const Document *document);
 
 #endif /* GLDRAW_DOCUMENT_DOCUMENT_H */

--- a/include/document/history.h
+++ b/include/document/history.h
@@ -5,6 +5,7 @@
 #ifndef GLDRAW_DOCUMENT_HISTORY_H
 #define GLDRAW_DOCUMENT_HISTORY_H
 
+#include <app/editor_session.h>
 #include <document/document.h>
 
 #define DOCUMENT_HISTORY_MAX_ENTRIES 128
@@ -39,7 +40,34 @@ typedef struct {
 typedef struct {
     DocumentSnapshot before;
     DocumentSnapshot after;
+    SelectionSet before_selection;
+    SelectionSet after_selection;
 } DocumentHistoryEntry;
+
+typedef enum {
+    DOCUMENT_HISTORY_ENTRY_SNAPSHOT = 0,
+    DOCUMENT_HISTORY_ENTRY_SCALAR_EDIT,
+    DOCUMENT_HISTORY_ENTRY_TRANSFORM_EDIT
+} DocumentHistoryEntryKind;
+
+typedef struct {
+    ObjectId object_id;
+    char key[32];
+    float before_value;
+    float after_value;
+    unsigned int revision_before;
+    unsigned int revision_after;
+    SelectionSet selection;
+} DocumentHistoryScalarEdit;
+
+typedef struct {
+    ObjectId object_ids[DOCUMENT_MAX_SELECTION];
+    int object_count;
+    Vec2 delta;
+    unsigned int revision_before;
+    unsigned int revision_after;
+    SelectionSet selection;
+} DocumentHistoryTransformEdit;
 
 /**
  * @struct DocumentHistory
@@ -57,6 +85,12 @@ typedef struct DocumentHistory {
     int capacity;
     int undo_count;
     int redo_count;
+    DocumentHistoryEntryKind* undo_kinds;
+    DocumentHistoryEntryKind* redo_kinds;
+    DocumentHistoryScalarEdit* undo_scalar_edits;
+    DocumentHistoryScalarEdit* redo_scalar_edits;
+    DocumentHistoryTransformEdit* undo_transform_edits;
+    DocumentHistoryTransformEdit* redo_transform_edits;
 } DocumentHistory;
 
 /**
@@ -109,7 +143,11 @@ void document_history_shutdown(DocumentHistory* history);
  * @param after_document Document after the edit.
  * @return Non-zero on success, zero on failure.
  */
-int document_history_push(DocumentHistory* history, DocumentSnapshot* before, const Document* after_document);
+int document_history_push(DocumentHistory* history,
+                          DocumentSnapshot* before,
+                          const SelectionSet* before_selection,
+                          const Document* after_document,
+                          const SelectionSet* after_selection);
 
 /**
  * @brief Push a scalar property edit history record.
@@ -126,7 +164,15 @@ int document_history_push(DocumentHistory* history, DocumentSnapshot* before, co
  * @param revision_after Document revision after modification.
  * @return Non-zero on success, zero on failure.
  */
-int document_history_push_scalar_edit(DocumentHistory* history, const Document* document, ObjectId object_id, const char* key, float before_value, float after_value, unsigned int revision_before, unsigned int revision_after);
+int document_history_push_scalar_edit(DocumentHistory* history,
+                                      const Document* document,
+                                      const SelectionSet* selection,
+                                      ObjectId object_id,
+                                      const char* key,
+                                      float before_value,
+                                      float after_value,
+                                      unsigned int revision_before,
+                                      unsigned int revision_after);
 
 /**
  * @brief Push a batch translate edit history record.
@@ -143,7 +189,14 @@ int document_history_push_scalar_edit(DocumentHistory* history, const Document* 
  * @param revision_after Revision after modification.
  * @return Non-zero on success, zero on failure.
  */
-int document_history_push_translate_edit(DocumentHistory* history, const Document* document, const ObjectId* object_ids, int object_count, Vec2 delta, unsigned int revision_before, unsigned int revision_after);
+int document_history_push_translate_edit(DocumentHistory* history,
+                                         const Document* document,
+                                         const SelectionSet* selection,
+                                         const ObjectId* object_ids,
+                                         int object_count,
+                                         Vec2 delta,
+                                         unsigned int revision_before,
+                                         unsigned int revision_after);
 
 /**
  * @brief Perform an undo.
@@ -158,7 +211,9 @@ int document_history_push_translate_edit(DocumentHistory* history, const Documen
  * @param document Target document.
  * @return Non-zero if there is something to undo and the application succeeded, zero otherwise.
  */
-int document_history_undo(DocumentHistory* history, Document* document);
+int document_history_undo(DocumentHistory* history,
+                          Document* document,
+                          SelectionSet* selection);
 
 /**
  * @brief Perform a redo.
@@ -169,7 +224,9 @@ int document_history_undo(DocumentHistory* history, Document* document);
  * @param document Target document.
  * @return Non-zero if there is something to redo and the application succeeded, zero otherwise.
  */
-int document_history_redo(DocumentHistory* history, Document* document);
+int document_history_redo(DocumentHistory* history,
+                          Document* document,
+                          SelectionSet* selection);
 
 /**
  * @brief Check whether undo is available.

--- a/include/render/render_system.h
+++ b/include/render/render_system.h
@@ -6,6 +6,7 @@
 #define GLDRAW_RENDER_RENDER_SYSTEM_H
 
 #include <canvas/canvas_view.h>
+#include <app/editor_session.h>
 #include <document/document.h>
 #include <platform/window.h>
 
@@ -47,12 +48,14 @@ void render_system_resize(RenderSystem* renderer,
  *
  * @param renderer Renderer instance.
  * @param document Current document.
+ * @param selection Current editor selection state.
  * @param canvas Current canvas view.
  * @param overlay_object Tool overlay preview object (may be `NULL`).
  * @return No return value.
  */
 void render_system_draw(RenderSystem* renderer,
                         const Document* document,
+                        const SelectionSet* selection,
                         const CanvasView* canvas,
                         const GraphicObject* overlay_object);
 

--- a/include/tools/tool.h
+++ b/include/tools/tool.h
@@ -6,6 +6,7 @@
 #define GLDRAW_TOOLS_TOOL_H
 
 #include <base/types.h>
+#include <document/document.h>
 #include <document/object.h>
 
 struct Workspace;
@@ -56,12 +57,14 @@ typedef struct {
  * @member document Current document.
  * @member history History stack.
  * @member canvas Canvas view.
+ * @member selection Active editor selection state.
  */
 typedef struct {
     struct Workspace* workspace;
     struct Document* document;
     struct DocumentHistory* history;
     struct CanvasView* canvas;
+    SelectionSet* selection;
 } ToolContext;
 
 typedef struct Tool Tool;

--- a/include/ui/ui_system.h
+++ b/include/ui/ui_system.h
@@ -51,6 +51,21 @@ void ui_system_build(UiSystem* ui, struct Workspace* workspace);
 int ui_system_handle_key(UiSystem* ui, int key, int action);
 
 /**
+ * @brief Offer one mouse button event to the UI before routing it elsewhere.
+ * @param ui UI system instance.
+ * @param workspace Workspace instance used to derive menu state.
+ * @param screen_pos Pointer position in screen coordinates.
+ * @param button GLFW mouse button code.
+ * @param action GLFW action code.
+ * @return Non-zero if the UI consumed the event, zero otherwise.
+ */
+int ui_system_handle_mouse_button(UiSystem* ui,
+                                  struct Workspace* workspace,
+                                  Vec2 screen_pos,
+                                  int button,
+                                  int action);
+
+/**
  * @brief Commit UI draw commands.
  * @param ui UI system instance.
  * @return No return value.

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -533,6 +533,11 @@ static void mouse_button_callback(GLFWwindow *handle, int button, int action,
   }
 
   if (action == GLFW_PRESS) {
+    if (app->ui &&
+        ui_system_handle_mouse_button(app->ui, &app->workspace,
+                                      app->cursor_screen, button, action)) {
+      return;
+    }
     if (!app->workspace.tools.pointer_captured &&
         app_pointer_blocks_canvas(app, app->cursor_screen)) {
       return;

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -79,8 +79,8 @@ static void app_set_status(Application *app, const char *fmt, ...) {
   }
 
   va_start(args, fmt);
-  vsnprintf(app->workspace.status_message,
-            sizeof(app->workspace.status_message), fmt, args);
+  vsnprintf(app->workspace.session.status_message,
+            sizeof(app->workspace.session.status_message), fmt, args);
   va_end(args);
 }
 
@@ -117,8 +117,8 @@ static const char *app_default_document_path(void) { return "document.json"; }
  * @return Current document path string.
  */
 static const char *app_current_document_path(const Application *app) {
-  if (app->workspace.current_document_path[0] != '\0') {
-    return app->workspace.current_document_path;
+  if (app->workspace.session.current_document_path[0] != '\0') {
+    return app->workspace.session.current_document_path;
   }
   return app_default_document_path();
 }
@@ -138,10 +138,10 @@ static void app_set_document_path(Application *app, const char *path) {
     return;
   }
 
-  strncpy(app->workspace.current_document_path, path,
-          sizeof(app->workspace.current_document_path) - 1u);
-  app->workspace
-      .current_document_path[sizeof(app->workspace.current_document_path) -
+  strncpy(app->workspace.session.current_document_path, path,
+          sizeof(app->workspace.session.current_document_path) - 1u);
+  app->workspace.session
+      .current_document_path[sizeof(app->workspace.session.current_document_path) -
                              1u] = '\0';
 }
 
@@ -155,8 +155,8 @@ static void app_reset_tool_state(Application *app) {
     return;
   }
 
-  tool_controller_shutdown(&app->workspace.tools);
-  tool_controller_init(&app->workspace.tools);
+  tool_controller_shutdown(&app->workspace.core.tools);
+  tool_controller_init(&app->workspace.core.tools);
 }
 
 static int app_new_document(Application *app) {
@@ -164,19 +164,20 @@ static int app_new_document(Application *app) {
     return 0;
   }
 
-  document_reset(&app->workspace.document);
+  document_reset(&app->workspace.core.document);
+  selection_set_clear(&app->workspace.session.selection);
   app_clear_clipboard(app);
-  document_history_shutdown(&app->workspace.history);
-  if (!document_history_init(&app->workspace.history)) {
+  document_history_shutdown(&app->workspace.core.history);
+  if (!document_history_init(&app->workspace.core.history)) {
     LOG_ERROR("%s", "Failed to reinitialize history");
     app_set_status(app, "History reset failed");
     return 0;
   }
 
   app_reset_tool_state(app);
-  canvas_view_set_center_zoom(&app->workspace.canvas, vec2_make(0.0f, 0.0f),
+  canvas_view_set_center_zoom(&app->workspace.core.canvas, vec2_make(0.0f, 0.0f),
                               1.0f);
-  app->workspace.current_document_path[0] = '\0';
+  app->workspace.session.current_document_path[0] = '\0';
   workspace_mark_saved(&app->workspace);
   app_set_status(app, "New empty document");
   return 1;
@@ -195,7 +196,7 @@ static int app_new_document(Application *app) {
 static int app_save_document(Application *app) {
   const char *path = app_current_document_path(app);
 
-  if (!document_save_json(&app->workspace.document, path)) {
+  if (!document_save_json(&app->workspace.core.document, path)) {
     LOG_ERROR("%s", "Save document failed");
     app_set_status(app, "Save failed: %s", path);
     return 0;
@@ -229,17 +230,18 @@ static int app_load_document(Application *app) {
     return 0;
   }
 
-  if (!document_load_json(&app->workspace.document, path)) {
+  if (!document_load_json(&app->workspace.core.document, path)) {
     LOG_ERROR("%s", "Load document failed");
     app_set_status(app, "Load failed: %s", path);
     return 0;
   }
 
+  selection_set_clear(&app->workspace.session.selection);
   /* Rebuild history against the newly loaded object graph.
      Reusing old snapshots would leave dangling object pointers. */
   app_clear_clipboard(app);
-  document_history_shutdown(&app->workspace.history);
-  if (!document_history_init(&app->workspace.history)) {
+  document_history_shutdown(&app->workspace.core.history);
+  if (!document_history_init(&app->workspace.core.history)) {
     LOG_ERROR("%s", "Failed to reinitialize history after document load");
     app_set_status(app, "History reset failed after load");
     return 0;
@@ -333,9 +335,10 @@ static void app_open_startup_document(Application *app) {
 static ToolContext app_tool_context(Application *app) {
   ToolContext context;
   context.workspace = &app->workspace;
-  context.document = &app->workspace.document;
-  context.history = &app->workspace.history;
-  context.canvas = &app->workspace.canvas;
+  context.document = &app->workspace.core.document;
+  context.history = &app->workspace.core.history;
+  context.canvas = &app->workspace.core.canvas;
+  context.selection = &app->workspace.session.selection;
   return context;
 }
 
@@ -369,9 +372,9 @@ static void app_sync_tool_pointer_anchor(Application *app) {
     return;
   }
 
-  app->workspace.tools.last_screen = app->cursor_screen;
-  app->workspace.tools.last_world =
-      canvas_view_screen_to_world(&app->workspace.canvas, app->cursor_screen);
+  app->workspace.core.tools.last_screen = app->cursor_screen;
+  app->workspace.core.tools.last_world =
+      canvas_view_screen_to_world(&app->workspace.core.canvas, app->cursor_screen);
 }
 
 /**
@@ -382,7 +385,7 @@ static void app_sync_tool_pointer_anchor(Application *app) {
 static void app_sync_canvas_boundary(Application *app) {
   int inside_canvas = 0;
 
-  if (!app || app->workspace.tools.pointer_captured) {
+  if (!app || app->workspace.core.tools.pointer_captured) {
     return;
   }
 
@@ -411,7 +414,7 @@ static void update_canvas_viewport(Application *app) {
     viewport = ui_system_content_bounds(app->ui);
     fallback_window = ui_system_window_bounds(app->ui);
   } else {
-    viewport = app->workspace.layout.canvas_content_bounds;
+    viewport = app->workspace.session.layout.canvas_content_bounds;
     fallback_window.w = (float)app->window.width;
     fallback_window.h = (float)app->window.height;
     if (fallback_window.w < 1.0f) {
@@ -427,10 +430,10 @@ static void update_canvas_viewport(Application *app) {
   }
 
   if (app->ui) {
-    app->workspace.canvas.background = ui_system_canvas_background(app->ui);
+    app->workspace.core.canvas.background = ui_system_canvas_background(app->ui);
   }
 
-  canvas_view_set_viewport(&app->workspace.canvas, viewport);
+  canvas_view_set_viewport(&app->workspace.core.canvas, viewport);
   app_sync_canvas_boundary(app);
 }
 
@@ -447,11 +450,11 @@ static ToolEvent make_tool_event(Application *app, int button, int mods,
   ToolEvent event;
   event.screen_pos = app->cursor_screen;
   event.world_pos =
-      canvas_view_screen_to_world(&app->workspace.canvas, app->cursor_screen);
+      canvas_view_screen_to_world(&app->workspace.core.canvas, app->cursor_screen);
   event.delta_screen =
-      vec2_sub(event.screen_pos, app->workspace.tools.last_screen);
+      vec2_sub(event.screen_pos, app->workspace.core.tools.last_screen);
   event.delta_world =
-      vec2_sub(event.world_pos, app->workspace.tools.last_world);
+      vec2_sub(event.world_pos, app->workspace.core.tools.last_world);
   event.button = button;
   event.mods = mods;
   event.wheel_y = wheel_y;
@@ -503,7 +506,7 @@ static void cursor_pos_callback(GLFWwindow *handle, double xpos, double ypos) {
   app->cursor_screen = vec2_make((float)xpos, (float)ypos);
   app_sync_canvas_boundary(app);
 
-  if (!app->workspace.tools.pointer_captured &&
+  if (!app->workspace.core.tools.pointer_captured &&
       app_pointer_blocks_canvas(app, app->cursor_screen)) {
     return;
   }
@@ -511,7 +514,7 @@ static void cursor_pos_callback(GLFWwindow *handle, double xpos, double ypos) {
   context = app_tool_context(app);
   event = make_tool_event(app, -1, 0, 0.0f);
 
-  tool_controller_pointer_move(&app->workspace.tools, &context, &event);
+  tool_controller_pointer_move(&app->workspace.core.tools, &context, &event);
 }
 
 /**
@@ -538,18 +541,18 @@ static void mouse_button_callback(GLFWwindow *handle, int button, int action,
                                       app->cursor_screen, button, action)) {
       return;
     }
-    if (!app->workspace.tools.pointer_captured &&
+    if (!app->workspace.core.tools.pointer_captured &&
         app_pointer_blocks_canvas(app, app->cursor_screen)) {
       return;
     }
     context = app_tool_context(app);
     event = make_tool_event(app, button, mods, 0.0f);
-    tool_controller_pointer_down(&app->workspace.tools, &context, &event);
+    tool_controller_pointer_down(&app->workspace.core.tools, &context, &event);
   } else if (action == GLFW_RELEASE) {
     /* Ignore release outside canvas unless we previously captured the pointer.
        This keeps drag/end-state transitions consistent across window regions.
      */
-    if (!app->workspace.tools.pointer_captured) {
+    if (!app->workspace.core.tools.pointer_captured) {
       if (app_pointer_blocks_canvas(app, app->cursor_screen)) {
         return;
       }
@@ -557,7 +560,7 @@ static void mouse_button_callback(GLFWwindow *handle, int button, int action,
     }
     context = app_tool_context(app);
     event = make_tool_event(app, button, mods, 0.0f);
-    tool_controller_pointer_up(&app->workspace.tools, &context, &event);
+    tool_controller_pointer_up(&app->workspace.core.tools, &context, &event);
   }
 }
 
@@ -618,13 +621,13 @@ static void scroll_callback(GLFWwindow *handle, double xoffset,
     return;
   }
 
-  if (!app->workspace.tools.pointer_captured &&
+  if (!app->workspace.core.tools.pointer_captured &&
       app_pointer_blocks_canvas(app, app->cursor_screen)) {
     return;
   }
 
   context = app_tool_context(app);
-  tool_controller_scroll(&app->workspace.tools, &context, app->cursor_screen,
+  tool_controller_scroll(&app->workspace.core.tools, &context, app->cursor_screen,
                          (float)yoffset);
 }
 
@@ -655,19 +658,19 @@ static int app_init(Application *app) {
     return -1;
   }
 
-  document_init(&app->workspace.document);
-  if (!document_history_init(&app->workspace.history)) {
+  document_init(&app->workspace.core.document);
+  if (!document_history_init(&app->workspace.core.history)) {
     LOG_ERROR("%s", "Failed to initialize document history");
     return -1;
   }
-  canvas_view_init(&app->workspace.canvas, &app->workspace.document, viewport);
-  tool_controller_init(&app->workspace.tools);
-  keymap_init(&app->workspace.keymap, APP_KEYMAP_SETTINGS_PATH);
+  canvas_view_init(&app->workspace.core.canvas, &app->workspace.core.document, viewport);
+  tool_controller_init(&app->workspace.core.tools);
+  keymap_init(&app->workspace.session.keymap, APP_KEYMAP_SETTINGS_PATH);
   app_set_document_path(app, app_default_document_path());
-  app->workspace.save_document = app_workspace_save;
-  app->workspace.load_document = app_workspace_load;
-  app->workspace.execute_action = app_workspace_execute_action;
-  app->workspace.command_user_data = app;
+  app->workspace.services.save_document = app_workspace_save;
+  app->workspace.services.load_document = app_workspace_load;
+  app->workspace.services.execute_action = app_workspace_execute_action;
+  app->workspace.services.command_user_data = app;
   workspace_mark_saved(&app->workspace);
   app_set_status(app, "Initializing editor");
   app->cursor_screen =
@@ -723,11 +726,11 @@ static void app_shutdown(Application *app) {
 
   ui_system_destroy(app->ui);
   render_system_destroy(app->renderer);
-  tool_controller_shutdown(&app->workspace.tools);
-  keymap_shutdown(&app->workspace.keymap);
+  tool_controller_shutdown(&app->workspace.core.tools);
+  keymap_shutdown(&app->workspace.session.keymap);
   app_clear_clipboard(app);
-  document_history_shutdown(&app->workspace.history);
-  document_shutdown(&app->workspace.document);
+  document_history_shutdown(&app->workspace.core.history);
+  document_shutdown(&app->workspace.core.document);
   platform_window_shutdown(&app->window);
 }
 
@@ -767,9 +770,11 @@ int app_run(void) {
     ui_system_begin_frame(app->ui);
     ui_system_build(app->ui, &app->workspace);
     update_canvas_viewport(app);
-    render_system_draw(app->renderer, &app->workspace.document,
-                       &app->workspace.canvas,
-                       tool_controller_overlay_object(&app->workspace.tools));
+    render_system_draw(app->renderer,
+                       &app->workspace.core.document,
+                       &app->workspace.session.selection,
+                       &app->workspace.core.canvas,
+                       tool_controller_overlay_object(&app->workspace.core.tools));
     ui_system_render(app->ui);
     platform_window_swap_buffers(&app->window);
   }

--- a/src/app/command_registry.c
+++ b/src/app/command_registry.c
@@ -58,15 +58,15 @@ static int command_registry_copy_selection(Workspace* workspace)
         return 0;
     }
 
-    selection_count = workspace->document.selection.count;
+    selection_count = workspace->session.selection.count;
     if (selection_count <= 0) {
         return 0;
     }
 
     memset(clipboard_objects, 0, sizeof(clipboard_objects));
     for (i = 0; i < selection_count; ++i) {
-        GraphicObject* source = document_find_object(&workspace->document,
-                                                     workspace->document.selection.ids[i]);
+        GraphicObject* source = document_find_object(&workspace->core.document,
+                                                     workspace->session.selection.ids[i]);
 
         if (!source) {
             break;
@@ -88,16 +88,17 @@ static int command_registry_copy_selection(Workspace* workspace)
 
     workspace_clear_clipboard(workspace);
     for (i = 0; i < selection_count; ++i) {
-        workspace->clipboard_objects[i] = clipboard_objects[i];
+        workspace->session.clipboard_objects[i] = clipboard_objects[i];
     }
-    workspace->clipboard_count = selection_count;
-    workspace->clipboard_paste_serial = 0;
+    workspace->session.clipboard_count = selection_count;
+    workspace->session.clipboard_paste_serial = 0;
     return 1;
 }
 
 static int command_registry_paste_clipboard(Workspace* workspace)
 {
     DocumentSnapshot before_snapshot;
+    SelectionSet before_selection;
     GraphicObject* pasted_objects[DOCUMENT_MAX_SELECTION];
     Vec2 paste_delta = vec2_make(0.0f, 0.0f);
     float world_offset = 0.0f;
@@ -108,22 +109,22 @@ static int command_registry_paste_clipboard(Workspace* workspace)
         return 0;
     }
 
-    paste_count = workspace->clipboard_count;
+    paste_count = workspace->session.clipboard_count;
     if (paste_count <= 0) {
         return 0;
     }
-    if (workspace->document.count + paste_count > DOCUMENT_MAX_OBJECTS) {
+    if (workspace->core.document.count + paste_count > DOCUMENT_MAX_OBJECTS) {
         return 0;
     }
 
     memset(pasted_objects, 0, sizeof(pasted_objects));
-    world_offset = canvas_view_world_tolerance_for_pixels(&workspace->canvas,
+    world_offset = canvas_view_world_tolerance_for_pixels(&workspace->core.canvas,
                                                           CLIPBOARD_PASTE_OFFSET_PIXELS);
-    paste_delta = vec2_make(world_offset * (float)(workspace->clipboard_paste_serial + 1u),
-                            -world_offset * (float)(workspace->clipboard_paste_serial + 1u));
+    paste_delta = vec2_make(world_offset * (float)(workspace->session.clipboard_paste_serial + 1u),
+                            -world_offset * (float)(workspace->session.clipboard_paste_serial + 1u));
 
     for (i = 0; i < paste_count; ++i) {
-        pasted_objects[i] = object_clone(workspace->clipboard_objects[i]);
+        pasted_objects[i] = object_clone(workspace->session.clipboard_objects[i]);
         if (!pasted_objects[i]) {
             break;
         }
@@ -140,20 +141,21 @@ static int command_registry_paste_clipboard(Workspace* workspace)
     }
 
     document_snapshot_init(&before_snapshot);
-    if (!document_snapshot_capture(&before_snapshot, &workspace->document)) {
+    before_selection = workspace->session.selection;
+    if (!document_snapshot_capture(&before_snapshot, &workspace->core.document)) {
         for (i = 0; i < paste_count; ++i) {
             object_destroy(pasted_objects[i]);
         }
         return 0;
     }
 
-    document_clear_selection(&workspace->document);
+    selection_set_clear(&workspace->session.selection);
     for (i = 0; i < paste_count; ++i) {
-        if (!document_add_object(&workspace->document, pasted_objects[i])) {
+        if (!document_add_object(&workspace->core.document, pasted_objects[i])) {
             break;
         }
 
-        document_selection_add(&workspace->document, pasted_objects[i]->id);
+        selection_set_add(&workspace->session.selection, pasted_objects[i]->id);
     }
 
     if (i != paste_count) {
@@ -161,11 +163,15 @@ static int command_registry_paste_clipboard(Workspace* workspace)
         return 0;
     }
 
-    if (!document_history_push(&workspace->history, &before_snapshot, &workspace->document)) {
+    if (!document_history_push(&workspace->core.history,
+                               &before_snapshot,
+                               &before_selection,
+                               &workspace->core.document,
+                               &workspace->session.selection)) {
         document_snapshot_free(&before_snapshot);
     }
 
-    workspace->clipboard_paste_serial++;
+    workspace->session.clipboard_paste_serial++;
     workspace_sync_document_dirty(workspace);
     return 1;
 }
@@ -184,7 +190,7 @@ static void command_registry_append_shortcut_line(char* buffer,
     }
 
     shortcut[0] = '\0';
-    keymap_format_command_shortcut(&workspace->keymap,
+    keymap_format_command_shortcut(&workspace->session.keymap,
                                    command_id,
                                    scope,
                                    shortcut,
@@ -279,12 +285,12 @@ static int command_registry_zoom_to_fit(Workspace* workspace)
     int first = 1;
     int i = 0;
 
-    if (!workspace || !workspace->canvas.document) {
+    if (!workspace || !workspace->core.canvas.document) {
         return 0;
     }
 
-    doc = &workspace->document;
-    canvas = &workspace->canvas;
+    doc = &workspace->core.document;
+    canvas = &workspace->core.canvas;
     canvas_viewport = canvas_view_viewport(canvas);
     if (canvas_viewport.w <= 1.0f || canvas_viewport.h <= 1.0f) {
         canvas_view_set_center_zoom(canvas, vec2_make(0.0f, 0.0f), 1.0f);
@@ -362,15 +368,31 @@ static int command_registry_zoom_to_fit(Workspace* workspace)
 static void command_registry_delete_selection(Workspace* workspace)
 {
     DocumentSnapshot before_snapshot;
+    SelectionSet before_selection;
+    ObjectId ids[DOCUMENT_MAX_SELECTION];
+    int selection_count = 0;
+    int i = 0;
 
-    if (!workspace || workspace->document.selection.count <= 0) {
+    if (!workspace || workspace->session.selection.count <= 0) {
         return;
     }
 
     document_snapshot_init(&before_snapshot);
-    document_snapshot_capture(&before_snapshot, &workspace->document);
-    document_delete_selection(&workspace->document);
-    if (!document_history_push(&workspace->history, &before_snapshot, &workspace->document)) {
+    before_selection = workspace->session.selection;
+    document_snapshot_capture(&before_snapshot, &workspace->core.document);
+    selection_count = workspace->session.selection.count;
+    for (i = 0; i < selection_count; ++i) {
+        ids[i] = workspace->session.selection.ids[i];
+    }
+    for (i = 0; i < selection_count; ++i) {
+        document_remove_object(&workspace->core.document, ids[i]);
+    }
+    selection_set_clear(&workspace->session.selection);
+    if (!document_history_push(&workspace->core.history,
+                               &before_snapshot,
+                               &before_selection,
+                               &workspace->core.document,
+                               &workspace->session.selection)) {
         document_snapshot_free(&before_snapshot);
     }
     workspace_sync_document_dirty(workspace);
@@ -378,7 +400,7 @@ static void command_registry_delete_selection(Workspace* workspace)
 
 static int command_registry_cut_selection(Workspace* workspace)
 {
-    if (!workspace || workspace->document.selection.count <= 0) {
+    if (!workspace || workspace->session.selection.count <= 0) {
         return 0;
     }
 
@@ -398,10 +420,10 @@ static void command_registry_select_all(Workspace* workspace)
         return;
     }
 
-    document_clear_selection(&workspace->document);
-    for (i = 0; i < workspace->document.count; ++i) {
-        document_selection_add(&workspace->document,
-                               workspace->document.objects[i]->id);
+    selection_set_clear(&workspace->session.selection);
+    for (i = 0; i < workspace->core.document.count; ++i) {
+        selection_set_add(&workspace->session.selection,
+                          workspace->core.document.objects[i]->id);
     }
 }
 
@@ -440,7 +462,7 @@ int command_registry_is_available(const Workspace* workspace,
 {
     switch (command) {
     case EDITOR_COMMAND_FILE_SAVE:
-        return workspace && workspace->save_document;
+        return workspace && workspace->services.save_document;
     case EDITOR_COMMAND_FILE_SAVE_AS:
         return 0;
     case EDITOR_COMMAND_HELP_SHORTCUTS:
@@ -448,9 +470,9 @@ int command_registry_is_available(const Workspace* workspace,
     case EDITOR_COMMAND_EDIT_CUT:
     case EDITOR_COMMAND_EDIT_COPY:
     case EDITOR_COMMAND_EDIT_DELETE:
-        return workspace && workspace->document.selection.count > 0;
+        return workspace && workspace->session.selection.count > 0;
     case EDITOR_COMMAND_EDIT_PASTE:
-        return workspace && workspace->clipboard_count > 0;
+        return workspace && workspace->session.clipboard_count > 0;
     case EDITOR_COMMAND_FILE_NEW:
     case EDITOR_COMMAND_FILE_OPEN:
     case EDITOR_COMMAND_FILE_EXIT:
@@ -505,19 +527,25 @@ int command_registry_execute(Workspace* workspace,
     case EDITOR_COMMAND_FILE_OPEN:
         return workspace_request_action(workspace, WORKSPACE_ACTION_OPEN_DOCUMENT);
     case EDITOR_COMMAND_FILE_SAVE:
-        return workspace->save_document ? workspace->save_document(workspace, workspace->command_user_data) : 0;
+        return workspace->services.save_document ?
+               workspace->services.save_document(workspace, workspace->services.command_user_data) : 0;
     case EDITOR_COMMAND_FILE_SAVE_AS:
-        return workspace->save_document ? workspace->save_document(workspace, workspace->command_user_data) : 0;
+        return workspace->services.save_document ?
+               workspace->services.save_document(workspace, workspace->services.command_user_data) : 0;
     case EDITOR_COMMAND_FILE_EXIT:
         return workspace_request_action(workspace, WORKSPACE_ACTION_EXIT_APPLICATION);
     case EDITOR_COMMAND_EDIT_UNDO:
-        if (document_history_undo(&workspace->history, &workspace->document)) {
+        if (document_history_undo(&workspace->core.history,
+                                  &workspace->core.document,
+                                  &workspace->session.selection)) {
             workspace_sync_document_dirty(workspace);
             return 1;
         }
         return 0;
     case EDITOR_COMMAND_EDIT_REDO:
-        if (document_history_redo(&workspace->history, &workspace->document)) {
+        if (document_history_redo(&workspace->core.history,
+                                  &workspace->core.document,
+                                  &workspace->session.selection)) {
             workspace_sync_document_dirty(workspace);
             return 1;
         }
@@ -536,39 +564,39 @@ int command_registry_execute(Workspace* workspace,
         return 1;
     case EDITOR_COMMAND_VIEW_ZOOM_IN:
     {
-        Vec2 center = canvas_view_center(&workspace->canvas);
-        canvas_view_zoom_at_screen_point(&workspace->canvas, 1.25f,
-                                         canvas_view_world_to_screen(&workspace->canvas, center));
+        Vec2 center = canvas_view_center(&workspace->core.canvas);
+        canvas_view_zoom_at_screen_point(&workspace->core.canvas, 1.25f,
+                                         canvas_view_world_to_screen(&workspace->core.canvas, center));
         return 1;
     }
     case EDITOR_COMMAND_VIEW_ZOOM_OUT:
     {
-        Vec2 center = canvas_view_center(&workspace->canvas);
-        canvas_view_zoom_at_screen_point(&workspace->canvas, 0.8f,
-                                         canvas_view_world_to_screen(&workspace->canvas, center));
+        Vec2 center = canvas_view_center(&workspace->core.canvas);
+        canvas_view_zoom_at_screen_point(&workspace->core.canvas, 0.8f,
+                                         canvas_view_world_to_screen(&workspace->core.canvas, center));
         return 1;
     }
     case EDITOR_COMMAND_VIEW_ZOOM_FIT:
         return command_registry_zoom_to_fit(workspace);
     case EDITOR_COMMAND_VIEW_TOGGLE_GRID:
-        workspace->canvas.show_grid = !workspace->canvas.show_grid;
+        workspace->core.canvas.show_grid = !workspace->core.canvas.show_grid;
         return 1;
     case EDITOR_COMMAND_VIEW_TOGGLE_INSPECTOR:
         return 1;
     case EDITOR_COMMAND_TOOL_SELECT:
-        if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_SELECT);
+        if (tool_context) tool_controller_set_active(&workspace->core.tools, tool_context, TOOL_KIND_SELECT);
         return 1;
     case EDITOR_COMMAND_TOOL_PAN:
-        if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_PAN);
+        if (tool_context) tool_controller_set_active(&workspace->core.tools, tool_context, TOOL_KIND_PAN);
         return 1;
     case EDITOR_COMMAND_TOOL_LINE:
-        if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_LINE);
+        if (tool_context) tool_controller_set_active(&workspace->core.tools, tool_context, TOOL_KIND_LINE);
         return 1;
     case EDITOR_COMMAND_TOOL_RECT:
-        if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_RECT);
+        if (tool_context) tool_controller_set_active(&workspace->core.tools, tool_context, TOOL_KIND_RECT);
         return 1;
     case EDITOR_COMMAND_TOOL_ELLIPSE:
-        if (tool_context) tool_controller_set_active(&workspace->tools, tool_context, TOOL_KIND_ELLIPSE);
+        if (tool_context) tool_controller_set_active(&workspace->core.tools, tool_context, TOOL_KIND_ELLIPSE);
         return 1;
     case EDITOR_COMMAND_HELP_SHORTCUTS:
         return command_registry_toggle_shortcuts_dialog(workspace);
@@ -608,7 +636,7 @@ void command_registry_format_menu_shortcut(const Workspace* workspace,
         return;
     }
 
-    keymap_format_command_shortcut(&workspace->keymap,
+    keymap_format_command_shortcut(&workspace->session.keymap,
                                    descriptor->id,
                                    descriptor->scope,
                                    buffer,

--- a/src/app/workspace_actions.c
+++ b/src/app/workspace_actions.c
@@ -29,17 +29,17 @@ static int workspace_action_requires_unsaved_confirmation(WorkspaceActionType ac
 int workspace_modal_is_active(const Workspace* workspace)
 {
     return workspace &&
-           workspace->active_request_type == UI_REQUEST_DIALOG &&
-           workspace->active_dialog.modal &&
-           workspace->active_dialog.kind != UI_DIALOG_NONE;
+           workspace->session.active_request_type == UI_REQUEST_DIALOG &&
+           workspace->session.active_dialog.modal &&
+           workspace->session.active_dialog.kind != UI_DIALOG_NONE;
 }
 
 UiDialogKind workspace_active_dialog_kind(const Workspace* workspace)
 {
-    if (!workspace || workspace->active_request_type != UI_REQUEST_DIALOG) {
+    if (!workspace || workspace->session.active_request_type != UI_REQUEST_DIALOG) {
         return UI_DIALOG_NONE;
     }
-    return workspace->active_dialog.kind;
+    return workspace->session.active_dialog.kind;
 }
 
 int workspace_request_action(Workspace* workspace, WorkspaceActionType action)
@@ -53,15 +53,17 @@ int workspace_request_action(Workspace* workspace, WorkspaceActionType action)
     }
 
     if (workspace_action_requires_unsaved_confirmation(action) &&
-        workspace->document_dirty) {
+        workspace->session.document_dirty) {
         return workspace_dialog_open_confirm_unsaved(workspace, action);
     }
 
-    if (!workspace->execute_action) {
+    if (!workspace->services.execute_action) {
         return 0;
     }
 
-    return workspace->execute_action(workspace, action, workspace->command_user_data);
+    return workspace->services.execute_action(workspace,
+                                              action,
+                                              workspace->services.command_user_data);
 }
 
 int workspace_confirm_pending_action_save(Workspace* workspace)

--- a/src/app/workspace_dialogs.c
+++ b/src/app/workspace_dialogs.c
@@ -73,11 +73,13 @@ static const UiDialogDefinition UI_DIALOG_DEFINITION_INFO = {
 static int workspace_dialog_execute_action_now(Workspace* workspace,
                                                WorkspaceActionType action)
 {
-    if (!workspace || action == WORKSPACE_ACTION_NONE || !workspace->execute_action) {
+    if (!workspace || action == WORKSPACE_ACTION_NONE || !workspace->services.execute_action) {
         return 0;
     }
 
-    return workspace->execute_action(workspace, action, workspace->command_user_data);
+    return workspace->services.execute_action(workspace,
+                                              action,
+                                              workspace->services.command_user_data);
 }
 
 static int workspace_dialog_resolve_confirm_unsaved(Workspace* workspace,
@@ -89,12 +91,12 @@ static int workspace_dialog_resolve_confirm_unsaved(Workspace* workspace,
         return 0;
     }
 
-    action = (WorkspaceActionType)workspace->active_dialog.payload.int_values[0];
+    action = (WorkspaceActionType)workspace->session.active_dialog.payload.int_values[0];
 
     switch (result) {
     case UI_DIALOG_RESULT_PRIMARY:
-        if (!workspace->save_document ||
-            !workspace->save_document(workspace, workspace->command_user_data)) {
+        if (!workspace->services.save_document ||
+            !workspace->services.save_document(workspace, workspace->services.command_user_data)) {
             return 0;
         }
         workspace_dialog_close(workspace);
@@ -104,8 +106,8 @@ static int workspace_dialog_resolve_confirm_unsaved(Workspace* workspace,
         return workspace_dialog_execute_action_now(workspace, action);
     case UI_DIALOG_RESULT_CANCEL:
         workspace_dialog_close(workspace);
-        snprintf(workspace->status_message,
-                 sizeof(workspace->status_message),
+        snprintf(workspace->session.status_message,
+                 sizeof(workspace->session.status_message),
                  "Action cancelled.");
         return 1;
     case UI_DIALOG_RESULT_NONE:
@@ -268,8 +270,8 @@ int workspace_dialog_open(Workspace* workspace, const UiDialogState* dialog)
         return 0;
     }
 
-    workspace->active_request_type = UI_REQUEST_DIALOG;
-    workspace->active_dialog = *dialog;
+    workspace->session.active_request_type = UI_REQUEST_DIALOG;
+    workspace->session.active_dialog = *dialog;
     return 1;
 }
 
@@ -279,19 +281,19 @@ void workspace_dialog_close(Workspace* workspace)
         return;
     }
 
-    workspace->active_request_type = UI_REQUEST_NONE;
-    workspace_dialog_reset(&workspace->active_dialog);
+    workspace->session.active_request_type = UI_REQUEST_NONE;
+    workspace_dialog_reset(&workspace->session.active_dialog);
 }
 
 int workspace_dialog_resolve(Workspace* workspace, UiDialogResult result)
 {
     const UiDialogDefinition* definition = NULL;
 
-    if (!workspace || workspace->active_request_type != UI_REQUEST_DIALOG) {
+    if (!workspace || workspace->session.active_request_type != UI_REQUEST_DIALOG) {
         return 0;
     }
 
-    definition = workspace_dialog_definition(workspace->active_dialog.kind);
+    definition = workspace_dialog_definition(workspace->session.active_dialog.kind);
     if (!definition || !definition->resolve) {
         return 0;
     }

--- a/src/document/document.c
+++ b/src/document/document.c
@@ -1,9 +1,9 @@
 /**
  * @file document.c
- * @brief In-memory document storage and selection operations.
+ * @brief In-memory document storage.
  *
  * Role in project:
- * - Owns bounded object array and selection list mutation logic.
+ * - Owns bounded object array mutation logic.
  * - Maintains revision counters used for dirty tracking and history commits.
  *
  * Module relationships:
@@ -49,7 +49,6 @@ void document_shutdown(Document* document)
     }
 
     document->count = 0;
-    document->selection.count = 0;
     document->revision++;
 }
 
@@ -72,7 +71,6 @@ void document_reset(Document* document)
     }
 
     document->count = 0;
-    document->selection.count = 0;
     document->next_id = 1;
     document->revision = 1;
 }
@@ -159,123 +157,6 @@ GraphicObject* document_get_object_at(const Document* document, int index)
 }
 
 /**
- * @brief Checks if an object is in the selection.
- * @param document Document instance.
- * @param id Object ID to check.
- * @return 1 if selected, 0 otherwise.
- */
-int document_selection_contains(const Document* document, ObjectId id)
-{
-    int i = 0;
-
-    if (!document) {
-        return 0;
-    }
-
-    for (i = 0; i < document->selection.count; ++i) {
-        if (document->selection.ids[i] == id) {
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-/**
- * @brief Clears the selection.
- * @param document Document instance.
- * @return None.
- */
-void document_clear_selection(Document* document)
-{
-    if (document) {
-        document->selection.count = 0;
-    }
-}
-
-/**
- * @brief Adds an object to the selection.
- * @param document Document instance.
- * @param id Object ID to add.
- * @return 1 on success, 0 on failure.
- */
-int document_selection_add(Document* document, ObjectId id)
-{
-    if (!document || id == 0) {
-        return 0;
-    }
-
-    if (document_selection_contains(document, id)) {
-        return 1;
-    }
-
-    if (document->selection.count >= DOCUMENT_MAX_SELECTION) {
-        return 0;
-    }
-
-    document->selection.ids[document->selection.count++] = id;
-    return 1;
-}
-
-/**
- * @brief Removes an object from the selection.
- * @param document Document instance.
- * @param id Object ID to remove.
- * @return None.
- */
-void document_selection_remove(Document* document, ObjectId id)
-{
-    int i = 0;
-
-    if (!document) {
-        return;
-    }
-
-    for (i = 0; i < document->selection.count; ++i) {
-        if (document->selection.ids[i] == id) {
-            int j = 0;
-            for (j = i; j < document->selection.count - 1; ++j) {
-                document->selection.ids[j] = document->selection.ids[j + 1];
-            }
-            document->selection.count--;
-            return;
-        }
-    }
-}
-
-/**
- * @brief Toggles an object in the selection.
- * @param document Document instance.
- * @param id Object ID to toggle.
- * @return None.
- */
-void document_selection_toggle(Document* document, ObjectId id)
-{
-    if (!document) {
-        return;
-    }
-
-    if (document_selection_contains(document, id)) {
-        document_selection_remove(document, id);
-    } else {
-        document_selection_add(document, id);
-    }
-}
-
-/**
- * @brief Gets the primary (first) selected object.
- * @param document Document instance.
- * @return Pointer to primary selected object or NULL.
- */
-GraphicObject* document_primary_selection(const Document* document)
-{
-    if (!document || document->selection.count <= 0) {
-        return NULL;
-    }
-    return document_find_object(document, document->selection.ids[0]);
-}
-
-/**
  * @brief Removes an object from the document.
  * @param document Document instance.
  * @param id Object ID to remove.
@@ -298,40 +179,12 @@ int document_remove_object(Document* document, ObjectId id)
             }
             document->objects[document->count - 1] = NULL;
             document->count--;
-            document_selection_remove(document, id);
             document->revision++;
             return 1;
         }
     }
 
     return 0;
-}
-
-/**
- * @brief Deletes all selected objects.
- * @param document Document instance.
- * @return None.
- */
-void document_delete_selection(Document* document)
-{
-    ObjectId ids[DOCUMENT_MAX_SELECTION];
-    int count = 0;
-    int i = 0;
-
-    if (!document) {
-        return;
-    }
-
-    count = document->selection.count;
-    for (i = 0; i < count; ++i) {
-        ids[i] = document->selection.ids[i];
-    }
-
-    for (i = 0; i < count; ++i) {
-        document_remove_object(document, ids[i]);
-    }
-
-    document_clear_selection(document);
 }
 
 /**

--- a/src/document/history.c
+++ b/src/document/history.c
@@ -1,14 +1,6 @@
 /**
  * @file history.c
  * @brief Snapshot-based undo/redo implementation.
- *
- * Role in project:
- * - Captures deep document snapshots before/after edits.
- * - Applies snapshots for undo and redo with bounded stack capacity.
- *
- * Module relationships:
- * - Depends on document/object cloning and destruction.
- * - Called by tools/UI commit paths for user-visible edits.
  */
 #include <document/history.h>
 
@@ -16,175 +8,48 @@
 #include <base/math2d.h>
 
 #include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-typedef enum {
-    HISTORY_ENTRY_SNAPSHOT = 0,
-    HISTORY_ENTRY_SCALAR_EDIT,
-    HISTORY_ENTRY_TRANSFORM_EDIT
-} HistoryEntryKind;
-
-typedef struct {
-    ObjectId object_id;
-    char key[32];
-    float before_value;
-    float after_value;
-    unsigned int revision_before;
-    unsigned int revision_after;
-} HistoryScalarEdit;
-
-typedef struct {
-    ObjectId object_ids[DOCUMENT_MAX_SELECTION];
-    int object_count;
-    Vec2 delta;
-    unsigned int revision_before;
-    unsigned int revision_after;
-} HistoryTransformEdit;
-
-typedef struct HistoryInternals {
-    DocumentHistory* owner;
-    HistoryEntryKind* undo_kinds;
-    HistoryEntryKind* redo_kinds;
-    HistoryScalarEdit* undo_scalar_edits;
-    HistoryScalarEdit* redo_scalar_edits;
-    HistoryTransformEdit* undo_transform_edits;
-    HistoryTransformEdit* redo_transform_edits;
-    struct HistoryInternals* next;
-} HistoryInternals;
-
-static HistoryInternals* g_history_internals_head = NULL;
 
 static void history_entry_free(DocumentHistoryEntry* entry);
 static void history_entry_reset(DocumentHistoryEntry* entry);
 
-/**
- * @brief Finds internal history state.
- * @param history Document history instance.
- * @return Internal state or NULL.
- */
-static HistoryInternals* history_find_internals(const DocumentHistory* history)
+static void history_reset_scalar_edit(DocumentHistoryScalarEdit* edit)
 {
-    HistoryInternals* cursor = g_history_internals_head;
-    while (cursor) {
-        if (cursor->owner == history) {
-            return cursor;
-        }
-        cursor = cursor->next;
-    }
-    return NULL;
-}
-
-/**
- * @brief Frees internal history state.
- * @param internals Internal state to free.
- * @return None.
- */
-static void history_free_internals(HistoryInternals* internals)
-{
-    if (!internals) {
+    if (!edit) {
         return;
     }
 
-    free(internals->undo_kinds);
-    free(internals->redo_kinds);
-    free(internals->undo_scalar_edits);
-    free(internals->redo_scalar_edits);
-    free(internals->undo_transform_edits);
-    free(internals->redo_transform_edits);
-    internals->undo_kinds = NULL;
-    internals->redo_kinds = NULL;
-    internals->undo_scalar_edits = NULL;
-    internals->redo_scalar_edits = NULL;
-    internals->undo_transform_edits = NULL;
-    internals->redo_transform_edits = NULL;
+    memset(edit, 0, sizeof(*edit));
 }
 
-/**
- * @brief Unregisters internal history state.
- * @param history Document history instance.
- * @return None.
- */
-static void history_unregister_internals(DocumentHistory* history)
+static void history_reset_transform_edit(DocumentHistoryTransformEdit* edit)
 {
-    HistoryInternals* prev = NULL;
-    HistoryInternals* cursor = g_history_internals_head;
-
-    while (cursor) {
-        if (cursor->owner == history) {
-            if (prev) {
-                prev->next = cursor->next;
-            } else {
-                g_history_internals_head = cursor->next;
-            }
-            history_free_internals(cursor);
-            free(cursor);
-            return;
-        }
-        prev = cursor;
-        cursor = cursor->next;
+    if (!edit) {
+        return;
     }
+
+    memset(edit, 0, sizeof(*edit));
 }
 
-/**
- * @brief Registers internal history state.
- * @param history Document history instance.
- * @return 1 on success, 0 on failure.
- */
-static int history_register_internals(DocumentHistory* history)
+static void history_reset_slot(DocumentHistory* history, int index, int undo_stack)
 {
-    HistoryInternals* internals = NULL;
-    size_t cap = 0u;
-
-    if (!history || history->capacity <= 0) {
-        return 0;
-    }
-    if (history_find_internals(history)) {
-        return 1;
+    if (!history || index < 0 || index >= history->capacity) {
+        return;
     }
 
-    internals = (HistoryInternals*)calloc(1u, sizeof(*internals));
-    if (!internals) {
-        return 0;
+    if (undo_stack) {
+        history->undo_kinds[index] = DOCUMENT_HISTORY_ENTRY_SNAPSHOT;
+        history_reset_scalar_edit(&history->undo_scalar_edits[index]);
+        history_reset_transform_edit(&history->undo_transform_edits[index]);
+    } else {
+        history->redo_kinds[index] = DOCUMENT_HISTORY_ENTRY_SNAPSHOT;
+        history_reset_scalar_edit(&history->redo_scalar_edits[index]);
+        history_reset_transform_edit(&history->redo_transform_edits[index]);
     }
-
-    cap = (size_t)history->capacity;
-    internals->undo_kinds = (HistoryEntryKind*)calloc(cap, sizeof(*internals->undo_kinds));
-    internals->redo_kinds = (HistoryEntryKind*)calloc(cap, sizeof(*internals->redo_kinds));
-    internals->undo_scalar_edits = (HistoryScalarEdit*)calloc(cap, sizeof(*internals->undo_scalar_edits));
-    internals->redo_scalar_edits = (HistoryScalarEdit*)calloc(cap, sizeof(*internals->redo_scalar_edits));
-    internals->undo_transform_edits = (HistoryTransformEdit*)calloc(cap, sizeof(*internals->undo_transform_edits));
-    internals->redo_transform_edits = (HistoryTransformEdit*)calloc(cap, sizeof(*internals->redo_transform_edits));
-    if (!internals->undo_kinds || !internals->redo_kinds ||
-        !internals->undo_scalar_edits || !internals->redo_scalar_edits ||
-        !internals->undo_transform_edits || !internals->redo_transform_edits) {
-        history_free_internals(internals);
-        free(internals);
-        return 0;
-    }
-
-    internals->owner = history;
-    internals->next = g_history_internals_head;
-    g_history_internals_head = internals;
-    return 1;
 }
 
-/**
- * @brief Gets internal history state.
- * @param history Document history instance.
- * @return Internal state or NULL.
- */
-static HistoryInternals* history_get_internals(const DocumentHistory* history)
-{
-    return history_find_internals(history);
-}
-
-/**
- * @brief Moves a snapshot (transferring ownership).
- * @param dst Destination snapshot.
- * @param src Source snapshot.
- * @return None.
- */
 static void snapshot_move(DocumentSnapshot* dst, DocumentSnapshot* src)
 {
     document_snapshot_free(dst);
@@ -194,79 +59,60 @@ static void snapshot_move(DocumentSnapshot* dst, DocumentSnapshot* src)
     src->count = 0;
     src->revision = 0;
     src->next_id = 0;
-    src->selection.count = 0;
 }
 
-/**
- * @brief Finds an object by ID for scalar edit operations.
- * @param document Document instance.
- * @param id Object ID.
- * @return Object pointer or NULL.
- */
 static GraphicObject* history_find_scalar_object(Document* document, ObjectId id)
 {
     if (!document || id == 0) {
         return NULL;
     }
+
     return document_find_object(document, id);
 }
 
-/**
- * @brief Applies scalar edit undo.
- * @param document Document instance.
- * @param edit Scalar edit to undo.
- * @return 1 on success, 0 on failure.
- */
-static int history_apply_scalar_edit_undo(Document* document, const HistoryScalarEdit* edit)
+static int history_apply_scalar_edit_undo(Document* document,
+                                          SelectionSet* selection,
+                                          const DocumentHistoryScalarEdit* edit)
 {
     GraphicObject* object = history_find_scalar_object(document, edit ? edit->object_id : 0);
 
-    if (!document || !edit || !object) {
+    if (!document || !selection || !edit || !object) {
         return 0;
     }
     if (!object_set_scalar(object, edit->key, edit->before_value)) {
         return 0;
     }
     document->revision = edit->revision_before;
+    *selection = edit->selection;
     return 1;
 }
 
-/**
- * @brief Applies scalar edit redo.
- * @param document Document instance.
- * @param edit Scalar edit to redo.
- * @return 1 on success, 0 on failure.
- */
-static int history_apply_scalar_edit_redo(Document* document, const HistoryScalarEdit* edit)
+static int history_apply_scalar_edit_redo(Document* document,
+                                          SelectionSet* selection,
+                                          const DocumentHistoryScalarEdit* edit)
 {
     GraphicObject* object = history_find_scalar_object(document, edit ? edit->object_id : 0);
 
-    if (!document || !edit || !object) {
+    if (!document || !selection || !edit || !object) {
         return 0;
     }
     if (!object_set_scalar(object, edit->key, edit->after_value)) {
         return 0;
     }
     document->revision = edit->revision_after;
+    *selection = edit->selection;
     return 1;
 }
 
-/**
- * @brief Applies a transform edit.
- * @param document Document instance.
- * @param edit Transform edit data.
- * @param delta Translation delta.
- * @param target_revision Target revision number.
- * @return 1 on success, 0 on failure.
- */
 static int history_apply_transform(Document* document,
-                                   const HistoryTransformEdit* edit,
+                                   SelectionSet* selection,
+                                   const DocumentHistoryTransformEdit* edit,
                                    Vec2 delta,
                                    unsigned int target_revision)
 {
     int i = 0;
 
-    if (!document || !edit) {
+    if (!document || !selection || !edit) {
         return 0;
     }
 
@@ -279,16 +125,13 @@ static int history_apply_transform(Document* document,
     }
 
     document->revision = target_revision;
+    *selection = edit->selection;
     return 1;
 }
 
-/**
- * @brief Applies transform edit undo.
- * @param document Document instance.
- * @param edit Transform edit to undo.
- * @return 1 on success, 0 on failure.
- */
-static int history_apply_transform_edit_undo(Document* document, const HistoryTransformEdit* edit)
+static int history_apply_transform_edit_undo(Document* document,
+                                             SelectionSet* selection,
+                                             const DocumentHistoryTransformEdit* edit)
 {
     Vec2 undo_delta = {0.0f, 0.0f};
 
@@ -298,185 +141,151 @@ static int history_apply_transform_edit_undo(Document* document, const HistoryTr
 
     undo_delta.x = -edit->delta.x;
     undo_delta.y = -edit->delta.y;
-    return history_apply_transform(document, edit, undo_delta, edit->revision_before);
+    return history_apply_transform(document, selection, edit, undo_delta, edit->revision_before);
 }
 
-/**
- * @brief Applies transform edit redo.
- * @param document Document instance.
- * @param edit Transform edit to redo.
- * @return 1 on success, 0 on failure.
- */
-static int history_apply_transform_edit_redo(Document* document, const HistoryTransformEdit* edit)
+static int history_apply_transform_edit_redo(Document* document,
+                                             SelectionSet* selection,
+                                             const DocumentHistoryTransformEdit* edit)
 {
     if (!edit) {
         return 0;
     }
-    return history_apply_transform(document, edit, edit->delta, edit->revision_after);
+
+    return history_apply_transform(document, selection, edit, edit->delta, edit->revision_after);
 }
 
-/**
- * @brief Records a scalar property edit and pushes to undo stack.
- *
- * Algorithm steps:
- * 1. Constructs HistoryScalarEdit payload.
- * 2. Clears redo stack (new branch).
- * 3. Evicts oldest undo entry if needed.
- * 4. Writes new entry to end of undo stack.
- *
- * @param history [in,out] History instance.
- * @param document [in] Current document for validation.
- * @param object_id [in] Object ID.
- * @param key [in] Property key.
- * @param before_value [in] Value before change.
- * @param after_value [in] Value after change.
- * @param revision_before [in] Revision before change.
- * @param revision_after [in] Revision after change.
- * @return 1 on success, 0 on failure.
- */
-static int history_push_scalar_edit(DocumentHistory* history,
-                                    const Document* document,
-                                    ObjectId object_id,
-                                    const char* key,
-                                    float before_value,
-                                    float after_value,
-                                    unsigned int revision_before,
-                                    unsigned int revision_after)
+static void history_clear_redo(DocumentHistory* history)
+{
+    while (history->redo_count > 0) {
+        history_entry_free(&history->redo_stack[history->redo_count - 1]);
+        history_entry_reset(&history->redo_stack[history->redo_count - 1]);
+        history->redo_count--;
+        history_reset_slot(history, history->redo_count, 0);
+    }
+}
+
+static void history_evict_oldest(DocumentHistory* history, int undo_stack)
+{
+    int i = 0;
+    DocumentHistoryEntry* entries = undo_stack ? history->undo_stack : history->redo_stack;
+    DocumentHistoryEntryKind* kinds = undo_stack ? history->undo_kinds : history->redo_kinds;
+    DocumentHistoryScalarEdit* scalar_edits =
+        undo_stack ? history->undo_scalar_edits : history->redo_scalar_edits;
+    DocumentHistoryTransformEdit* transform_edits =
+        undo_stack ? history->undo_transform_edits : history->redo_transform_edits;
+    int* count = undo_stack ? &history->undo_count : &history->redo_count;
+
+    if (!history || !entries || !kinds || !scalar_edits || !transform_edits || *count <= 0) {
+        return;
+    }
+
+    history_entry_free(&entries[0]);
+    for (i = 1; i < *count; ++i) {
+        entries[i - 1] = entries[i];
+        history_entry_reset(&entries[i]);
+        kinds[i - 1] = kinds[i];
+        scalar_edits[i - 1] = scalar_edits[i];
+        transform_edits[i - 1] = transform_edits[i];
+    }
+    (*count)--;
+    history_reset_slot(history, *count, undo_stack);
+}
+
+static int history_push_scalar_edit_impl(DocumentHistory* history,
+                                         const Document* document,
+                                         const SelectionSet* selection,
+                                         ObjectId object_id,
+                                         const char* key,
+                                         float before_value,
+                                         float after_value,
+                                         unsigned int revision_before,
+                                         unsigned int revision_after)
 {
     DocumentHistoryEntry entry;
-    HistoryInternals* internals = history_get_internals(history);
-    HistoryScalarEdit scalar = {0};
+    DocumentHistoryScalarEdit scalar = {0};
 
-    if (!history || !document || !internals || !key || key[0] == '\0' || object_id == 0) {
+    if (!history || !document || !selection || !key || key[0] == '\0' || object_id == 0) {
         return 0;
     }
 
     document_snapshot_init(&entry.before);
     document_snapshot_init(&entry.after);
+    entry.before_selection = *selection;
+    entry.after_selection = *selection;
 
     scalar.object_id = object_id;
     scalar.before_value = before_value;
     scalar.after_value = after_value;
     scalar.revision_before = revision_before;
     scalar.revision_after = revision_after;
+    scalar.selection = *selection;
     snprintf(scalar.key, sizeof(scalar.key), "%s", key);
 
-    while (history->redo_count > 0) {
-        history_entry_free(&history->redo_stack[history->redo_count - 1]);
-        history_entry_reset(&history->redo_stack[history->redo_count - 1]);
-        internals->redo_kinds[history->redo_count - 1] = HISTORY_ENTRY_SNAPSHOT;
-        memset(&internals->redo_scalar_edits[history->redo_count - 1], 0, sizeof(HistoryScalarEdit));
-        memset(&internals->redo_transform_edits[history->redo_count - 1], 0, sizeof(HistoryTransformEdit));
-        history->redo_count--;
-    }
-
+    history_clear_redo(history);
     if (history->undo_count >= history->capacity) {
-        int i = 0;
-        history_entry_free(&history->undo_stack[0]);
-        for (i = 1; i < history->undo_count; ++i) {
-            history->undo_stack[i - 1] = history->undo_stack[i];
-            history_entry_reset(&history->undo_stack[i]);
-            internals->undo_kinds[i - 1] = internals->undo_kinds[i];
-            internals->undo_scalar_edits[i - 1] = internals->undo_scalar_edits[i];
-            internals->undo_transform_edits[i - 1] = internals->undo_transform_edits[i];
-        }
-        history->undo_count--;
+        history_evict_oldest(history, 1);
     }
 
     history->undo_stack[history->undo_count] = entry;
-    internals->undo_kinds[history->undo_count] = HISTORY_ENTRY_SCALAR_EDIT;
-    internals->undo_scalar_edits[history->undo_count] = scalar;
-    memset(&internals->undo_transform_edits[history->undo_count], 0, sizeof(HistoryTransformEdit));
+    history->undo_kinds[history->undo_count] = DOCUMENT_HISTORY_ENTRY_SCALAR_EDIT;
+    history->undo_scalar_edits[history->undo_count] = scalar;
+    history_reset_transform_edit(&history->undo_transform_edits[history->undo_count]);
     history->undo_count++;
     return 1;
 }
 
-/**
- * @brief Records a translate edit and pushes to undo stack.
- *
- * @param history [in,out] History instance.
- * @param document [in] Current document.
- * @param object_ids [in] Array of object IDs to translate.
- * @param object_count [in] Number of objects.
- * @param delta [in] Translation vector.
- * @param revision_before [in] Revision before change.
- * @param revision_after [in] Revision after change.
- * @return 1 on success, 0 on failure.
- */
-static int history_push_transform_edit(DocumentHistory* history,
-                                       const Document* document,
-                                       const ObjectId* object_ids,
-                                       int object_count,
-                                       Vec2 delta,
-                                       unsigned int revision_before,
-                                       unsigned int revision_after)
+static int history_push_transform_edit_impl(DocumentHistory* history,
+                                            const Document* document,
+                                            const SelectionSet* selection,
+                                            const ObjectId* object_ids,
+                                            int object_count,
+                                            Vec2 delta,
+                                            unsigned int revision_before,
+                                            unsigned int revision_after)
 {
     DocumentHistoryEntry entry;
-    HistoryInternals* internals = history_get_internals(history);
-    HistoryTransformEdit transform = {0};
+    DocumentHistoryTransformEdit transform = {0};
     int i = 0;
 
-    if (!history || !document || !internals || !object_ids ||
+    if (!history || !document || !selection || !object_ids ||
         object_count <= 0 || object_count > DOCUMENT_MAX_SELECTION) {
         return 0;
     }
 
     document_snapshot_init(&entry.before);
     document_snapshot_init(&entry.after);
+    entry.before_selection = *selection;
+    entry.after_selection = *selection;
 
     transform.object_count = object_count;
     transform.delta = delta;
     transform.revision_before = revision_before;
     transform.revision_after = revision_after;
+    transform.selection = *selection;
     for (i = 0; i < object_count; ++i) {
         transform.object_ids[i] = object_ids[i];
     }
 
-    while (history->redo_count > 0) {
-        history_entry_free(&history->redo_stack[history->redo_count - 1]);
-        history_entry_reset(&history->redo_stack[history->redo_count - 1]);
-        internals->redo_kinds[history->redo_count - 1] = HISTORY_ENTRY_SNAPSHOT;
-        memset(&internals->redo_scalar_edits[history->redo_count - 1], 0, sizeof(HistoryScalarEdit));
-        memset(&internals->redo_transform_edits[history->redo_count - 1], 0, sizeof(HistoryTransformEdit));
-        history->redo_count--;
-    }
-
+    history_clear_redo(history);
     if (history->undo_count >= history->capacity) {
-        history_entry_free(&history->undo_stack[0]);
-        for (i = 1; i < history->undo_count; ++i) {
-            history->undo_stack[i - 1] = history->undo_stack[i];
-            history_entry_reset(&history->undo_stack[i]);
-            internals->undo_kinds[i - 1] = internals->undo_kinds[i];
-            internals->undo_scalar_edits[i - 1] = internals->undo_scalar_edits[i];
-            internals->undo_transform_edits[i - 1] = internals->undo_transform_edits[i];
-        }
-        history->undo_count--;
+        history_evict_oldest(history, 1);
     }
 
     history->undo_stack[history->undo_count] = entry;
-    internals->undo_kinds[history->undo_count] = HISTORY_ENTRY_TRANSFORM_EDIT;
-    memset(&internals->undo_scalar_edits[history->undo_count], 0, sizeof(HistoryScalarEdit));
-    internals->undo_transform_edits[history->undo_count] = transform;
+    history->undo_kinds[history->undo_count] = DOCUMENT_HISTORY_ENTRY_TRANSFORM_EDIT;
+    history_reset_scalar_edit(&history->undo_scalar_edits[history->undo_count]);
+    history->undo_transform_edits[history->undo_count] = transform;
     history->undo_count++;
     return 1;
 }
 
-/**
- * @brief Frees a history entry.
- * @param entry History entry to free.
- * @return None.
- */
 static void history_entry_free(DocumentHistoryEntry* entry)
 {
     document_snapshot_free(&entry->before);
     document_snapshot_free(&entry->after);
 }
 
-/**
- * @brief Resets a history entry.
- * @param entry History entry to reset.
- * @return None.
- */
 static void history_entry_reset(DocumentHistoryEntry* entry)
 {
     if (!entry) {
@@ -485,13 +294,10 @@ static void history_entry_reset(DocumentHistoryEntry* entry)
 
     document_snapshot_init(&entry->before);
     document_snapshot_init(&entry->after);
+    selection_set_clear(&entry->before_selection);
+    selection_set_clear(&entry->after_selection);
 }
 
-/**
- * @brief Allocates history entries.
- * @param capacity Number of entries to allocate.
- * @return Allocated entries or NULL.
- */
 static DocumentHistoryEntry* history_alloc_entries(int capacity)
 {
     DocumentHistoryEntry* entries = NULL;
@@ -513,18 +319,6 @@ static DocumentHistoryEntry* history_alloc_entries(int capacity)
     return entries;
 }
 
-/**
- * @brief Replaces document contents with deep-cloned snapshot objects.
- * @param document [in,out] Target document.
- * @param snapshot [in] Snapshot data.
- * @return 1 on success, 0 on validation/allocation/clone failure.
- *
- * Risk note:
- * - Uses temporary clone array first; document is only replaced after all clones
- *   succeed, avoiding partial state corruption on failure.
- *
- * Complexity: `O(n)`.
- */
 static int document_restore_snapshot(Document* document, const DocumentSnapshot* snapshot)
 {
     GraphicObject** clones = NULL;
@@ -564,16 +358,10 @@ static int document_restore_snapshot(Document* document, const DocumentSnapshot*
     document->count = snapshot->count;
     document->revision = snapshot->revision;
     document->next_id = snapshot->next_id;
-    document->selection = snapshot->selection;
     free(clones);
     return 1;
 }
 
-/**
- * @brief Initializes a document snapshot.
- * @param snapshot Snapshot to initialize.
- * @return None.
- */
 void document_snapshot_init(DocumentSnapshot* snapshot)
 {
     if (snapshot) {
@@ -581,11 +369,6 @@ void document_snapshot_init(DocumentSnapshot* snapshot)
     }
 }
 
-/**
- * @brief Frees a document snapshot.
- * @param snapshot Snapshot to free.
- * @return None.
- */
 void document_snapshot_free(DocumentSnapshot* snapshot)
 {
     int i = 0;
@@ -601,19 +384,10 @@ void document_snapshot_free(DocumentSnapshot* snapshot)
     snapshot->objects = NULL;
     snapshot->capacity = 0;
     snapshot->count = 0;
-    snapshot->selection.count = 0;
     snapshot->revision = 0;
     snapshot->next_id = 0;
 }
 
-/**
- * @brief Deep copies a document to a snapshot.
- * @param snapshot [in,out] Target snapshot (previous content freed first).
- * @param document [in] Source document.
- * @return 1 on success, 0 on failure.
- *
- * @note Clones objects one by one; failure rolls back allocated content.
- */
 int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* document)
 {
     int i = 0;
@@ -636,7 +410,6 @@ int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* docume
     snapshot->count = document->count;
     snapshot->revision = document->revision;
     snapshot->next_id = document->next_id;
-    snapshot->selection = document->selection;
 
     for (i = 0; i < document->count; ++i) {
         snapshot->objects[i] = object_clone(document->objects[i]);
@@ -649,13 +422,10 @@ int document_snapshot_capture(DocumentSnapshot* snapshot, const Document* docume
     return 1;
 }
 
-/**
- * @brief Initializes document history.
- * @param history History instance to initialize.
- * @return 1 on success, 0 on failure.
- */
 int document_history_init(DocumentHistory* history)
 {
+    size_t cap = 0u;
+
     if (!history) {
         return 0;
     }
@@ -665,13 +435,23 @@ int document_history_init(DocumentHistory* history)
     history->undo_stack = history_alloc_entries(history->capacity);
     history->redo_stack = history_alloc_entries(history->capacity);
 
-    if (!history->undo_stack || !history->redo_stack) {
+    cap = (size_t)history->capacity;
+    history->undo_kinds = (DocumentHistoryEntryKind*)calloc(cap, sizeof(*history->undo_kinds));
+    history->redo_kinds = (DocumentHistoryEntryKind*)calloc(cap, sizeof(*history->redo_kinds));
+    history->undo_scalar_edits =
+        (DocumentHistoryScalarEdit*)calloc(cap, sizeof(*history->undo_scalar_edits));
+    history->redo_scalar_edits =
+        (DocumentHistoryScalarEdit*)calloc(cap, sizeof(*history->redo_scalar_edits));
+    history->undo_transform_edits =
+        (DocumentHistoryTransformEdit*)calloc(cap, sizeof(*history->undo_transform_edits));
+    history->redo_transform_edits =
+        (DocumentHistoryTransformEdit*)calloc(cap, sizeof(*history->redo_transform_edits));
+
+    if (!history->undo_stack || !history->redo_stack ||
+        !history->undo_kinds || !history->redo_kinds ||
+        !history->undo_scalar_edits || !history->redo_scalar_edits ||
+        !history->undo_transform_edits || !history->redo_transform_edits) {
         LOG_ERROR("%s", "Failed to allocate document history stacks");
-        document_history_shutdown(history);
-        return 0;
-    }
-    if (!history_register_internals(history)) {
-        LOG_ERROR("%s", "Failed to allocate document history internals");
         document_history_shutdown(history);
         return 0;
     }
@@ -679,11 +459,6 @@ int document_history_init(DocumentHistory* history)
     return 1;
 }
 
-/**
- * @brief Shuts down document history.
- * @param history History instance.
- * @return None.
- */
 void document_history_shutdown(DocumentHistory* history)
 {
     int i = 0;
@@ -698,35 +473,28 @@ void document_history_shutdown(DocumentHistory* history)
     for (i = 0; i < history->redo_count; ++i) {
         history_entry_free(&history->redo_stack[i]);
     }
-    history->undo_count = 0;
-    history->redo_count = 0;
+
     free(history->undo_stack);
     free(history->redo_stack);
-    history->undo_stack = NULL;
-    history->redo_stack = NULL;
-    history->capacity = 0;
-    history_unregister_internals(history);
+    free(history->undo_kinds);
+    free(history->redo_kinds);
+    free(history->undo_scalar_edits);
+    free(history->redo_scalar_edits);
+    free(history->undo_transform_edits);
+    free(history->redo_transform_edits);
+    memset(history, 0, sizeof(*history));
 }
 
-/**
- * @brief Pushes edit transaction (`before` + captured `after`) to undo stack.
- * @param history [in,out] History instance.
- * @param before [in,out] Before snapshot (consumed/transferred ownership).
- * @param after_document [in] After-edit document.
- * @return 1 on success, 0 on failure.
- *
- * Why clear redo:
- * - Any new forward edit invalidates previous redo chain by definition.
- *
- * Complexity: `O(n + capacity)` worst-case.
- */
-int document_history_push(DocumentHistory* history, DocumentSnapshot* before, const Document* after_document)
+int document_history_push(DocumentHistory* history,
+                          DocumentSnapshot* before,
+                          const SelectionSet* before_selection,
+                          const Document* after_document,
+                          const SelectionSet* after_selection)
 {
     DocumentHistoryEntry entry;
-    HistoryInternals* internals = history_get_internals(history);
 
     if (!history || !history->undo_stack || !history->redo_stack ||
-        !before || !after_document || !internals) {
+        !before || !before_selection || !after_document || !after_selection) {
         if (before) {
             document_snapshot_free(before);
             document_snapshot_init(before);
@@ -736,60 +504,32 @@ int document_history_push(DocumentHistory* history, DocumentSnapshot* before, co
 
     document_snapshot_init(&entry.before);
     document_snapshot_init(&entry.after);
+    entry.before_selection = *before_selection;
+    entry.after_selection = *after_selection;
 
     if (!document_snapshot_capture(&entry.after, after_document)) {
-        document_snapshot_free(&entry.after);
         document_snapshot_free(before);
         document_snapshot_init(before);
         return 0;
     }
 
     snapshot_move(&entry.before, before);
-
-    while (history->redo_count > 0) {
-        history_entry_free(&history->redo_stack[history->redo_count - 1]);
-        history_entry_reset(&history->redo_stack[history->redo_count - 1]);
-        internals->redo_kinds[history->redo_count - 1] = HISTORY_ENTRY_SNAPSHOT;
-        memset(&internals->redo_scalar_edits[history->redo_count - 1], 0, sizeof(HistoryScalarEdit));
-        memset(&internals->redo_transform_edits[history->redo_count - 1], 0, sizeof(HistoryTransformEdit));
-        history->redo_count--;
-    }
-
+    history_clear_redo(history);
     if (history->undo_count >= history->capacity) {
-        int i = 0;
-        history_entry_free(&history->undo_stack[0]);
-        for (i = 1; i < history->undo_count; ++i) {
-            history->undo_stack[i - 1] = history->undo_stack[i];
-            history_entry_reset(&history->undo_stack[i]);
-            internals->undo_kinds[i - 1] = internals->undo_kinds[i];
-            internals->undo_scalar_edits[i - 1] = internals->undo_scalar_edits[i];
-            internals->undo_transform_edits[i - 1] = internals->undo_transform_edits[i];
-        }
-        history->undo_count--;
+        history_evict_oldest(history, 1);
     }
 
     history->undo_stack[history->undo_count] = entry;
-    internals->undo_kinds[history->undo_count] = HISTORY_ENTRY_SNAPSHOT;
-    memset(&internals->undo_scalar_edits[history->undo_count], 0, sizeof(HistoryScalarEdit));
-    memset(&internals->undo_transform_edits[history->undo_count], 0, sizeof(HistoryTransformEdit));
+    history->undo_kinds[history->undo_count] = DOCUMENT_HISTORY_ENTRY_SNAPSHOT;
+    history_reset_scalar_edit(&history->undo_scalar_edits[history->undo_count]);
+    history_reset_transform_edit(&history->undo_transform_edits[history->undo_count]);
     history->undo_count++;
     return 1;
 }
 
-/**
- * @brief Pushes lightweight scalar edit transaction without capturing full document snapshots.
- * @param history [in,out] History instance.
- * @param document [in] Current document.
- * @param object_id [in] Object ID.
- * @param key [in] Property key.
- * @param before_value [in] Value before change.
- * @param after_value [in] Value after change.
- * @param revision_before [in] Revision before change.
- * @param revision_after [in] Revision after change.
- * @return 1 on success, 0 on validation/allocation failure.
- */
 int document_history_push_scalar_edit(DocumentHistory* history,
                                       const Document* document,
+                                      const SelectionSet* selection,
                                       ObjectId object_id,
                                       const char* key,
                                       float before_value,
@@ -797,42 +537,34 @@ int document_history_push_scalar_edit(DocumentHistory* history,
                                       unsigned int revision_before,
                                       unsigned int revision_after)
 {
-    if (!history || !document || !key || key[0] == '\0' || object_id == 0) {
+    if (!history || !document || !selection || !key || key[0] == '\0' || object_id == 0) {
         return 0;
     }
     if (fabsf(after_value - before_value) <= 1e-6f) {
         return 1;
     }
-    return history_push_scalar_edit(history,
-                                    document,
-                                    object_id,
-                                    key,
-                                    before_value,
-                                    after_value,
-                                    revision_before,
-                                    revision_after);
+
+    return history_push_scalar_edit_impl(history,
+                                         document,
+                                         selection,
+                                         object_id,
+                                         key,
+                                         before_value,
+                                         after_value,
+                                         revision_before,
+                                         revision_after);
 }
 
-/**
- * @brief Pushes lightweight translate transaction for a fixed object-id set.
- * @param history [in,out] History instance.
- * @param document [in] Current document.
- * @param object_ids [in] Object ID list.
- * @param object_count [in] Number of objects.
- * @param delta [in] Translation vector.
- * @param revision_before [in] Revision before change.
- * @param revision_after [in] Revision after change.
- * @return 1 on success, 0 on validation/allocation failure.
- */
 int document_history_push_translate_edit(DocumentHistory* history,
                                          const Document* document,
+                                         const SelectionSet* selection,
                                          const ObjectId* object_ids,
                                          int object_count,
                                          Vec2 delta,
                                          unsigned int revision_before,
                                          unsigned int revision_after)
 {
-    if (!history || !document || !object_ids ||
+    if (!history || !document || !selection || !object_ids ||
         object_count <= 0 || object_count > DOCUMENT_MAX_SELECTION) {
         return 0;
     }
@@ -840,159 +572,123 @@ int document_history_push_translate_edit(DocumentHistory* history,
         return 1;
     }
 
-    return history_push_transform_edit(history,
-                                       document,
-                                       object_ids,
-                                       object_count,
-                                       delta,
-                                       revision_before,
-                                       revision_after);
+    return history_push_transform_edit_impl(history,
+                                            document,
+                                            selection,
+                                            object_ids,
+                                            object_count,
+                                            delta,
+                                            revision_before,
+                                            revision_after);
 }
 
-/**
- * @brief Performs one undo and moves entry to redo stack.
- *
- * Algorithm steps:
- * 1. Pops top of undo stack.
- * 2. Applies inverse operation by entry type (snapshot restore/scalar revert/translate reverse).
- * 3. Transfers entry to redo stack.
- * 4. Cleans up auxiliary metadata at original undo slot.
- *
- * @param history [in,out] History instance.
- * @param document [in,out] Target document.
- * @return 1 on success, 0 on failure.
- */
-int document_history_undo(DocumentHistory* history, Document* document)
+int document_history_undo(DocumentHistory* history,
+                          Document* document,
+                          SelectionSet* selection)
 {
     DocumentHistoryEntry entry;
-    HistoryInternals* internals = history_get_internals(history);
-    HistoryEntryKind kind = HISTORY_ENTRY_SNAPSHOT;
+    DocumentHistoryEntryKind kind = DOCUMENT_HISTORY_ENTRY_SNAPSHOT;
 
     if (!history || !history->undo_stack || !history->redo_stack ||
-        !document || history->undo_count <= 0 || !internals) {
+        !document || !selection || history->undo_count <= 0) {
         return 0;
     }
 
-    kind = internals->undo_kinds[history->undo_count - 1];
+    kind = history->undo_kinds[history->undo_count - 1];
     entry = history->undo_stack[history->undo_count - 1];
     history_entry_reset(&history->undo_stack[history->undo_count - 1]);
     history->undo_count--;
 
     if (history->redo_count >= history->capacity) {
-        int i = 0;
-        history_entry_free(&history->redo_stack[0]);
-        for (i = 1; i < history->redo_count; ++i) {
-            history->redo_stack[i - 1] = history->redo_stack[i];
-            history_entry_reset(&history->redo_stack[i]);
-            internals->redo_kinds[i - 1] = internals->redo_kinds[i];
-            internals->redo_scalar_edits[i - 1] = internals->redo_scalar_edits[i];
-            internals->redo_transform_edits[i - 1] = internals->redo_transform_edits[i];
-        }
-        history->redo_count--;
+        history_evict_oldest(history, 0);
     }
 
-    if (kind == HISTORY_ENTRY_SCALAR_EDIT) {
-        if (!history_apply_scalar_edit_undo(document, &internals->undo_scalar_edits[history->undo_count])) {
+    if (kind == DOCUMENT_HISTORY_ENTRY_SCALAR_EDIT) {
+        if (!history_apply_scalar_edit_undo(document, selection,
+                                            &history->undo_scalar_edits[history->undo_count])) {
             history_entry_free(&entry);
             return 0;
         }
-    } else if (kind == HISTORY_ENTRY_TRANSFORM_EDIT) {
-        if (!history_apply_transform_edit_undo(document, &internals->undo_transform_edits[history->undo_count])) {
+    } else if (kind == DOCUMENT_HISTORY_ENTRY_TRANSFORM_EDIT) {
+        if (!history_apply_transform_edit_undo(document, selection,
+                                               &history->undo_transform_edits[history->undo_count])) {
             history_entry_free(&entry);
             return 0;
         }
-    } else if (!document_restore_snapshot(document, &entry.before)) {
-        history_entry_free(&entry);
-        return 0;
+    } else {
+        if (!document_restore_snapshot(document, &entry.before)) {
+            history_entry_free(&entry);
+            return 0;
+        }
+        *selection = entry.before_selection;
     }
 
     history->redo_stack[history->redo_count] = entry;
-    internals->redo_kinds[history->redo_count] = kind;
-    internals->redo_scalar_edits[history->redo_count] = internals->undo_scalar_edits[history->undo_count];
-    internals->redo_transform_edits[history->redo_count] = internals->undo_transform_edits[history->undo_count];
+    history->redo_kinds[history->redo_count] = kind;
+    history->redo_scalar_edits[history->redo_count] = history->undo_scalar_edits[history->undo_count];
+    history->redo_transform_edits[history->redo_count] =
+        history->undo_transform_edits[history->undo_count];
     history->redo_count++;
-    internals->undo_kinds[history->undo_count] = HISTORY_ENTRY_SNAPSHOT;
-    memset(&internals->undo_scalar_edits[history->undo_count], 0, sizeof(HistoryScalarEdit));
-    memset(&internals->undo_transform_edits[history->undo_count], 0, sizeof(HistoryTransformEdit));
+    history_reset_slot(history, history->undo_count, 1);
     return 1;
 }
 
-/**
- * @brief Performs one redo and moves entry back to undo stack.
- * @param history [in,out] History instance.
- * @param document [in,out] Target document.
- * @return 1 on success, 0 on failure.
- */
-int document_history_redo(DocumentHistory* history, Document* document)
+int document_history_redo(DocumentHistory* history,
+                          Document* document,
+                          SelectionSet* selection)
 {
     DocumentHistoryEntry entry;
-    HistoryInternals* internals = history_get_internals(history);
-    HistoryEntryKind kind = HISTORY_ENTRY_SNAPSHOT;
+    DocumentHistoryEntryKind kind = DOCUMENT_HISTORY_ENTRY_SNAPSHOT;
 
     if (!history || !history->undo_stack || !history->redo_stack ||
-        !document || history->redo_count <= 0 || !internals) {
+        !document || !selection || history->redo_count <= 0) {
         return 0;
     }
 
-    kind = internals->redo_kinds[history->redo_count - 1];
+    kind = history->redo_kinds[history->redo_count - 1];
     entry = history->redo_stack[history->redo_count - 1];
     history_entry_reset(&history->redo_stack[history->redo_count - 1]);
     history->redo_count--;
 
     if (history->undo_count >= history->capacity) {
-        int i = 0;
-        history_entry_free(&history->undo_stack[0]);
-        for (i = 1; i < history->undo_count; ++i) {
-            history->undo_stack[i - 1] = history->undo_stack[i];
-            history_entry_reset(&history->undo_stack[i]);
-            internals->undo_kinds[i - 1] = internals->undo_kinds[i];
-            internals->undo_scalar_edits[i - 1] = internals->undo_scalar_edits[i];
-            internals->undo_transform_edits[i - 1] = internals->undo_transform_edits[i];
-        }
-        history->undo_count--;
+        history_evict_oldest(history, 1);
     }
 
-    if (kind == HISTORY_ENTRY_SCALAR_EDIT) {
-        if (!history_apply_scalar_edit_redo(document, &internals->redo_scalar_edits[history->redo_count])) {
+    if (kind == DOCUMENT_HISTORY_ENTRY_SCALAR_EDIT) {
+        if (!history_apply_scalar_edit_redo(document, selection,
+                                            &history->redo_scalar_edits[history->redo_count])) {
             history_entry_free(&entry);
             return 0;
         }
-    } else if (kind == HISTORY_ENTRY_TRANSFORM_EDIT) {
-        if (!history_apply_transform_edit_redo(document, &internals->redo_transform_edits[history->redo_count])) {
+    } else if (kind == DOCUMENT_HISTORY_ENTRY_TRANSFORM_EDIT) {
+        if (!history_apply_transform_edit_redo(document, selection,
+                                               &history->redo_transform_edits[history->redo_count])) {
             history_entry_free(&entry);
             return 0;
         }
-    } else if (!document_restore_snapshot(document, &entry.after)) {
-        history_entry_free(&entry);
-        return 0;
+    } else {
+        if (!document_restore_snapshot(document, &entry.after)) {
+            history_entry_free(&entry);
+            return 0;
+        }
+        *selection = entry.after_selection;
     }
 
     history->undo_stack[history->undo_count] = entry;
-    internals->undo_kinds[history->undo_count] = kind;
-    internals->undo_scalar_edits[history->undo_count] = internals->redo_scalar_edits[history->redo_count];
-    internals->undo_transform_edits[history->undo_count] = internals->redo_transform_edits[history->redo_count];
+    history->undo_kinds[history->undo_count] = kind;
+    history->undo_scalar_edits[history->undo_count] = history->redo_scalar_edits[history->redo_count];
+    history->undo_transform_edits[history->undo_count] =
+        history->redo_transform_edits[history->redo_count];
     history->undo_count++;
-    internals->redo_kinds[history->redo_count] = HISTORY_ENTRY_SNAPSHOT;
-    memset(&internals->redo_scalar_edits[history->redo_count], 0, sizeof(HistoryScalarEdit));
-    memset(&internals->redo_transform_edits[history->redo_count], 0, sizeof(HistoryTransformEdit));
+    history_reset_slot(history, history->redo_count, 0);
     return 1;
 }
 
-/**
- * @brief Checks if undo is available.
- * @param history History instance.
- * @return 1 if undo available, 0 otherwise.
- */
 int document_history_can_undo(const DocumentHistory* history)
 {
     return history && history->undo_count > 0;
 }
 
-/**
- * @brief Checks if redo is available.
- * @param history History instance.
- * @return 1 if redo available, 0 otherwise.
- */
 int document_history_can_redo(const DocumentHistory* history)
 {
     return history && history->redo_count > 0;

--- a/src/document/persistence.c
+++ b/src/document/persistence.c
@@ -1006,7 +1006,6 @@ static int parse_document_root(JsonParser* parser, Document* document)
     }
 
     /* Selection is editor-session state and intentionally not serialized. */
-    document_clear_selection(document);
     if (got_next_id && next_id > document_max_id(document)) {
         document->next_id = next_id;
     } else {

--- a/src/input/input_router.c
+++ b/src/input/input_router.c
@@ -32,7 +32,7 @@ int input_router_handle_key(const InputRouterContext* context, const KeyEvent* e
 
     chord.key = event->key;
     chord.mods = event->mods;
-    command_id = keymap_lookup_command(&context->workspace->keymap, scope, chord);
+    command_id = keymap_lookup_command(&context->workspace->session.keymap, scope, chord);
     if (command_id) {
         descriptor = command_registry_find_by_id(command_id);
         if (descriptor &&
@@ -48,7 +48,7 @@ int input_router_handle_key(const InputRouterContext* context, const KeyEvent* e
         return 0;
     }
 
-    tool_controller_key_down(&context->workspace->tools,
+    tool_controller_key_down(&context->workspace->core.tools,
                              context->tool_context,
                              event->key,
                              event->mods);

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -1041,6 +1041,7 @@ void render_system_resize(RenderSystem* renderer,
  */
 void render_system_draw(RenderSystem* renderer,
                         const Document* document,
+                        const SelectionSet* selection,
                         const CanvasView* canvas,
                         const GraphicObject* overlay_object)
 {
@@ -1086,7 +1087,7 @@ void render_system_draw(RenderSystem* renderer,
 
     for (i = 0; i < document->count; ++i) {
         const GraphicObject* object = document->objects[i];
-        int selected = document_selection_contains(document, object->id);
+        int selected = selection_set_contains(selection, object->id);
         draw_object(renderer, canvas, object, selected);
     }
 

--- a/src/tools/tool_controller.c
+++ b/src/tools/tool_controller.c
@@ -110,7 +110,6 @@ static GraphicObject* build_shape_object(ToolKind kind, Vec2 anchor, Vec2 curren
 }
 
 /**
-/**
  * @brief Update an existing preview shape object in place.
  * @param object Preview object to update.
  * @param kind Shape tool kind associated with the preview.
@@ -151,33 +150,6 @@ static int update_shape_object(GraphicObject* object, ToolKind kind, Vec2 anchor
 }
 
 /**
- * @brief Checks if selection matches a snapshot.
- * @param document Document instance.
- * @param snapshot Snapshot to compare.
- * @return 1 if matches, 0 otherwise.
- */
-static int selection_matches_snapshot(const Document* document, const DocumentSnapshot* snapshot)
-{
-    int i = 0;
-
-    if (!document || !snapshot) {
-        return 0;
-    }
-
-    if (document->selection.count != snapshot->selection.count) {
-        return 0;
-    }
-
-    for (i = 0; i < document->selection.count; ++i) {
-        if (document->selection.ids[i] != snapshot->selection.ids[i]) {
-            return 0;
-        }
-    }
-
-    return 1;
-}
-
-/**
  * @brief Pushes document edit to history and syncs dirty flag.
  * @param context [in,out] Tool context.
  * @param before_snapshot [in,out] Before snapshot (consumed and reset by this function).
@@ -185,16 +157,22 @@ static int selection_matches_snapshot(const Document* document, const DocumentSn
  *
  * @remark Safely resets snapshot even when context/history is invalid.
  */
-static void tool_commit_document_change(ToolContext* context, DocumentSnapshot* before_snapshot)
+static void tool_commit_document_change(ToolContext* context,
+                                        DocumentSnapshot* before_snapshot,
+                                        const SelectionSet* before_selection)
 {
-    if (!context || !context->history || !before_snapshot) {
+    if (!context || !context->history || !before_snapshot || !before_selection || !context->selection) {
         if (before_snapshot) {
             snapshot_reset(before_snapshot);
         }
         return;
     }
 
-    if (!document_history_push(context->history, before_snapshot, context->document)) {
+    if (!document_history_push(context->history,
+                               before_snapshot,
+                               before_selection,
+                               context->document,
+                               context->selection)) {
         snapshot_reset(before_snapshot);
         return;
     }
@@ -255,32 +233,32 @@ static int select_tool_pointer_down(Tool* tool, ToolContext* context, const Tool
     hit = canvas_view_pick_object(context->canvas, event->screen_pos, 8.0f);
     if (!hit) {
         if ((event->mods & GLFW_MOD_SHIFT) == 0) {
-            document_clear_selection(context->document);
+            selection_set_clear(context->selection);
         }
         return 0;
     }
 
     if ((event->mods & GLFW_MOD_SHIFT) != 0) {
-        document_selection_toggle(context->document, hit->id);
-        state->dragging = document_selection_contains(context->document, hit->id);
+        selection_set_toggle(context->selection, hit->id);
+        state->dragging = selection_set_contains(context->selection, hit->id);
     } else {
-        if (!document_selection_contains(context->document, hit->id) || context->document->selection.count != 1) {
-            document_clear_selection(context->document);
-            document_selection_add(context->document, hit->id);
+        if (!selection_set_contains(context->selection, hit->id) || context->selection->count != 1) {
+            selection_set_clear(context->selection);
+            selection_set_add(context->selection, hit->id);
         }
-        state->dragging = document_selection_contains(context->document, hit->id);
+        state->dragging = selection_set_contains(context->selection, hit->id);
     }
 
-    if (!state->dragging || context->document->selection.count <= 0) {
+    if (!state->dragging || context->selection->count <= 0) {
         return 0;
     }
 
-    state->drag_object_count = context->document->selection.count;
+    state->drag_object_count = context->selection->count;
     if (state->drag_object_count > DOCUMENT_MAX_SELECTION) {
         state->drag_object_count = DOCUMENT_MAX_SELECTION;
     }
     for (i = 0; i < state->drag_object_count; ++i) {
-        state->drag_object_ids[i] = context->document->selection.ids[i];
+        state->drag_object_ids[i] = context->selection->ids[i];
     }
     state->last_world = event->world_pos;
     state->drag_revision_before = context->document->revision;
@@ -342,6 +320,7 @@ static void select_tool_pointer_up(Tool* tool, ToolContext* context, const ToolE
         context->history) {
         document_history_push_translate_edit(context->history,
                                              context->document,
+                                             context->selection,
                                              state->drag_object_ids,
                                              state->drag_object_count,
                                              state->drag_delta_total,
@@ -370,7 +349,7 @@ static void select_tool_key_down(Tool* tool, ToolContext* context, int key, int 
     (void)tool;
     (void)mods;
     if (key == GLFW_KEY_ESCAPE) {
-        document_clear_selection(context->document);
+        selection_set_clear(context->selection);
     }
 }
 
@@ -563,6 +542,7 @@ static void shape_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEv
     GraphicStyle style = object_default_style();
     GraphicObject* object = NULL;
     DocumentSnapshot before_snapshot;
+    SelectionSet before_selection;
 
     (void)event;
     if (!state->drawing) {
@@ -570,6 +550,7 @@ static void shape_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEv
     }
 
     document_snapshot_init(&before_snapshot);
+    before_selection = *context->selection;
     document_snapshot_capture(&before_snapshot, context->document);
     state->drawing = 0;
     object = build_shape_object(tool->kind, state->anchor, state->current, style);
@@ -586,9 +567,9 @@ static void shape_tool_pointer_up(Tool* tool, ToolContext* context, const ToolEv
         return;
     }
 
-    document_clear_selection(context->document);
-    document_selection_add(context->document, object->id);
-    tool_commit_document_change(context, &before_snapshot);
+    selection_set_clear(context->selection);
+    selection_set_add(context->selection, object->id);
+    tool_commit_document_change(context, &before_snapshot, &before_selection);
 }
 
 /** Escape cancels in-progress shape drawing. */

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -53,11 +53,22 @@
 #define UI_THEME_DESCRIPTOR_CACHE_MAX 64
 #define UI_THEME_WATCH_INTERVAL_SECONDS 0.35
 #define UI_CONTEXT_MENU_WIDTH 220.0f
+#define UI_CONTEXT_MENU_HEIGHT 240.0f
+#define UI_CONTEXT_MENU_ANCHOR_SIZE 1.0f
 
 typedef enum UiContextMenuMode {
   UI_CONTEXT_MENU_MODE_TOOLS = 0,
   UI_CONTEXT_MENU_MODE_SELECTION
 } UiContextMenuMode;
+
+typedef struct UiContextMenuState {
+  int open;
+  int close_requested;
+  UiContextMenuMode mode;
+  Vec2 anchor_screen;
+  RectF canvas_bounds;
+  RectF popup_bounds;
+} UiContextMenuState;
 
 struct UiSystem {
   struct nk_glfw glfw;
@@ -82,9 +93,7 @@ struct UiSystem {
   int inspector_edit_active;
   DocumentSnapshot inspector_edit_before_snapshot;
   int modal_active;
-  int context_menu_visible;
-  int context_menu_close_requested;
-  UiContextMenuMode context_menu_mode;
+  UiContextMenuState context_menu;
   double last_frame_seconds;
 };
 
@@ -95,6 +104,10 @@ typedef enum UiThemeReloadReason {
 } UiThemeReloadReason;
 
 static ToolContext ui_tool_context(Workspace *workspace);
+static void ui_context_menu_reset(UiSystem *ui);
+static RectF ui_context_menu_popup_bounds(const UiContextMenuState *menu);
+static void ui_context_menu_open(UiSystem *ui, Workspace *workspace,
+                                 Vec2 screen_pos);
 
 /**
  * @brief Clamps a float value.
@@ -361,6 +374,63 @@ static RectF ui_clamp_rect_to_window(RectF rect, RectF window_bounds) {
   return rect;
 }
 
+static void ui_context_menu_reset(UiSystem *ui) {
+  if (!ui) {
+    return;
+  }
+
+  ui->context_menu.open = 0;
+  ui->context_menu.close_requested = 0;
+  ui->context_menu.mode = UI_CONTEXT_MENU_MODE_TOOLS;
+  ui->context_menu.anchor_screen = vec2_make(0.0f, 0.0f);
+  ui->context_menu.canvas_bounds = (RectF){0.0f, 0.0f, 0.0f, 0.0f};
+  ui->context_menu.popup_bounds = (RectF){0.0f, 0.0f, 0.0f, 0.0f};
+}
+
+static RectF ui_context_menu_popup_bounds(const UiContextMenuState *menu) {
+  RectF bounds = {0.0f, 0.0f, UI_CONTEXT_MENU_WIDTH, UI_CONTEXT_MENU_HEIGHT};
+
+  if (!menu) {
+    return bounds;
+  }
+
+  bounds.x = ui_clampf(menu->anchor_screen.x, menu->canvas_bounds.x,
+                       menu->canvas_bounds.x + menu->canvas_bounds.w -
+                           UI_CONTEXT_MENU_WIDTH);
+  bounds.y = ui_clampf(menu->anchor_screen.y, menu->canvas_bounds.y,
+                       menu->canvas_bounds.y + menu->canvas_bounds.h -
+                           UI_CONTEXT_MENU_HEIGHT);
+  return bounds;
+}
+
+static void ui_context_menu_open(UiSystem *ui, Workspace *workspace,
+                                 Vec2 screen_pos) {
+  RectF canvas_bounds;
+
+  if (!ui || !workspace) {
+    return;
+  }
+
+  canvas_bounds = ui->layout_snapshot.canvas_content_bounds;
+  if (canvas_bounds.w <= 1.0f || canvas_bounds.h <= 1.0f) {
+    canvas_bounds = ui->content_bounds;
+  }
+
+  if (canvas_bounds.w <= 0.0f || canvas_bounds.h <= 0.0f ||
+      !rectf_contains_point(&canvas_bounds, screen_pos)) {
+    return;
+  }
+
+  ui->context_menu.open = 1;
+  ui->context_menu.close_requested = 0;
+  ui->context_menu.mode = workspace->document.selection.count > 0
+                              ? UI_CONTEXT_MENU_MODE_SELECTION
+                              : UI_CONTEXT_MENU_MODE_TOOLS;
+  ui->context_menu.anchor_screen = screen_pos;
+  ui->context_menu.canvas_bounds = canvas_bounds;
+  ui->context_menu.popup_bounds = ui_context_menu_popup_bounds(&ui->context_menu);
+}
+
 static void ui_format_command_label(const Workspace *workspace,
                                     const char *label,
                                     const char *command_id, KeyScope scope,
@@ -401,7 +471,7 @@ static int ui_context_menu_item(UiSystem *ui, const char *label,
 
   ui_format_command_label(workspace, label, command_id, KEY_SCOPE_GLOBAL,
                           item_label, sizeof(item_label));
-  if (!nk_contextual_item_label(ui->ctx, item_label, NK_TEXT_LEFT)) {
+  if (!nk_button_label(ui->ctx, item_label)) {
     return 0;
   }
 
@@ -419,7 +489,7 @@ static void ui_context_menu_separator(UiSystem *ui) {
   nk_spacing(ui->ctx, 1);
 }
 
-static void ui_context_menu_build_tools(UiSystem *ui, Workspace *workspace) {
+static int ui_context_menu_build_tools(UiSystem *ui, Workspace *workspace) {
   const ToolKind active_tool = workspace->tools.active_kind;
 
   nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
@@ -427,42 +497,42 @@ static void ui_context_menu_build_tools(UiSystem *ui, Workspace *workspace) {
     nk_label(ui->ctx, "Select Tool (V)", NK_TEXT_LEFT);
   } else if (ui_context_menu_item(ui, "Select Tool", "tool.select",
                                   EDITOR_COMMAND_TOOL_SELECT, workspace)) {
-    return;
+    return 1;
   }
 
   if (active_tool == TOOL_KIND_PAN) {
     nk_label(ui->ctx, "Pan Tool (H)", NK_TEXT_LEFT);
   } else if (ui_context_menu_item(ui, "Pan Tool", "tool.pan",
                                   EDITOR_COMMAND_TOOL_PAN, workspace)) {
-    return;
+    return 1;
   }
 
   if (active_tool == TOOL_KIND_LINE) {
     nk_label(ui->ctx, "Line Tool (L)", NK_TEXT_LEFT);
   } else if (ui_context_menu_item(ui, "Line Tool", "tool.line",
                                   EDITOR_COMMAND_TOOL_LINE, workspace)) {
-    return;
+    return 1;
   }
 
   if (active_tool == TOOL_KIND_RECT) {
     nk_label(ui->ctx, "Rectangle Tool (R)", NK_TEXT_LEFT);
   } else if (ui_context_menu_item(ui, "Rectangle Tool", "tool.rect",
                                   EDITOR_COMMAND_TOOL_RECT, workspace)) {
-    return;
+    return 1;
   }
 
   if (active_tool == TOOL_KIND_ELLIPSE) {
     nk_label(ui->ctx, "Ellipse Tool (E)", NK_TEXT_LEFT);
   } else if (ui_context_menu_item(ui, "Ellipse Tool", "tool.ellipse",
                                   EDITOR_COMMAND_TOOL_ELLIPSE, workspace)) {
-    return;
+    return 1;
   }
 
   ui_context_menu_separator(ui);
   nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
   if (ui_context_menu_item(ui, "Zoom to Fit", "view.zoom_fit",
                            EDITOR_COMMAND_VIEW_ZOOM_FIT, workspace)) {
-    return;
+    return 1;
   }
 
   ui_context_menu_separator(ui);
@@ -470,72 +540,94 @@ static void ui_context_menu_build_tools(UiSystem *ui, Workspace *workspace) {
   if (workspace->canvas.show_grid) {
     if (ui_context_menu_item(ui, "Hide Grid", "view.toggle_grid",
                              EDITOR_COMMAND_VIEW_TOGGLE_GRID, workspace)) {
-      return;
+      return 1;
     }
   } else if (ui_context_menu_item(ui, "Show Grid", "view.toggle_grid",
                                   EDITOR_COMMAND_VIEW_TOGGLE_GRID,
                                   workspace)) {
-    return;
+    return 1;
   }
+
+  return 0;
 }
 
-static void ui_context_menu_build_selection(UiSystem *ui, Workspace *workspace) {
+static int ui_context_menu_build_selection(UiSystem *ui, Workspace *workspace) {
   nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
   if (ui_context_menu_item(ui, "Copy", "edit.copy", EDITOR_COMMAND_EDIT_COPY,
                            workspace)) {
-    return;
+    return 1;
   }
   if (ui_context_menu_item(ui, "Paste", "edit.paste", EDITOR_COMMAND_EDIT_PASTE,
                            workspace)) {
-    return;
+    return 1;
   }
   if (ui_context_menu_item(ui, "Delete", "edit.delete",
                            EDITOR_COMMAND_EDIT_DELETE, workspace)) {
-    return;
+    return 1;
   }
+
+  return 0;
 }
 
-static void ui_canvas_context_menu(UiSystem *ui, Workspace *workspace,
-                                   RectF canvas_bounds) {
-  struct nk_rect trigger_bounds;
-  struct nk_vec2 popup_size;
+static void ui_canvas_context_menu(UiSystem *ui, Workspace *workspace) {
+  RectF canvas_bounds;
+  RectF host_bounds;
+  RectF popup_bounds;
+  struct nk_rect nk_host_bounds;
+  struct nk_rect nk_popup_bounds;
   int is_open = 0;
+  int menu_action_triggered = 0;
 
-  if (!ui || !ui->ctx || !workspace || canvas_bounds.w <= 0.0f ||
-      canvas_bounds.h <= 0.0f) {
+  if (!ui || !ui->ctx || !workspace || !ui->context_menu.open) {
     return;
   }
 
-  trigger_bounds =
-      nk_rect(canvas_bounds.x, canvas_bounds.y, canvas_bounds.w, canvas_bounds.h);
-  popup_size = nk_vec2(UI_CONTEXT_MENU_WIDTH, 240.0f);
-
-  if (nk_input_mouse_clicked(&ui->ctx->input, NK_BUTTON_RIGHT, trigger_bounds)) {
-    ui->context_menu_mode = workspace->document.selection.count > 0
-                                ? UI_CONTEXT_MENU_MODE_SELECTION
-                                : UI_CONTEXT_MENU_MODE_TOOLS;
+  canvas_bounds = ui->context_menu.canvas_bounds;
+  if (canvas_bounds.w <= 0.0f || canvas_bounds.h <= 0.0f) {
+    ui_context_menu_reset(ui);
+    return;
   }
 
-  if (nk_begin(ui->ctx, "Canvas Overlay", trigger_bounds,
+  popup_bounds = ui_context_menu_popup_bounds(&ui->context_menu);
+  ui->context_menu.popup_bounds = popup_bounds;
+
+  host_bounds.x = popup_bounds.x;
+  host_bounds.y = popup_bounds.y;
+  host_bounds.w = UI_CONTEXT_MENU_ANCHOR_SIZE;
+  host_bounds.h = UI_CONTEXT_MENU_ANCHOR_SIZE;
+
+  /* Popup APIs need an active Nuklear window/panel. Keep the host window to a
+   * single pixel so the menu does not visually cover the canvas. */
+  nk_host_bounds =
+      nk_rect(host_bounds.x, host_bounds.y, host_bounds.w, host_bounds.h);
+  nk_popup_bounds =
+      nk_rect(0.0f, 0.0f, popup_bounds.w, popup_bounds.h);
+
+  if (nk_begin(ui->ctx, "Canvas Context Host", nk_host_bounds,
                NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND |
                    NK_WINDOW_NO_INPUT)) {
-    is_open = nk_contextual_begin(ui->ctx, 0, popup_size, trigger_bounds);
+    is_open = nk_popup_begin(ui->ctx, NK_POPUP_DYNAMIC, "Canvas Context Menu",
+                             NK_WINDOW_NO_SCROLLBAR, nk_popup_bounds);
     if (is_open) {
-      if (ui->context_menu_close_requested) {
-        nk_contextual_close(ui->ctx);
-      } else if (ui->context_menu_mode == UI_CONTEXT_MENU_MODE_SELECTION) {
-        ui_context_menu_build_selection(ui, workspace);
+      if (ui->context_menu.close_requested) {
+        nk_popup_close(ui->ctx);
+      } else if (ui->context_menu.mode == UI_CONTEXT_MENU_MODE_SELECTION) {
+        menu_action_triggered = ui_context_menu_build_selection(ui, workspace);
       } else {
-        ui_context_menu_build_tools(ui, workspace);
+        menu_action_triggered = ui_context_menu_build_tools(ui, workspace);
       }
 
-      nk_contextual_end(ui->ctx);
+      if (ui->context_menu.close_requested || menu_action_triggered) {
+        nk_popup_close(ui->ctx);
+      }
+      nk_popup_end(ui->ctx);
     }
   }
   nk_end(ui->ctx);
 
-  ui->context_menu_visible = is_open && !ui->context_menu_close_requested;
-  ui->context_menu_close_requested = 0;
+  if (!is_open || ui->context_menu.close_requested || menu_action_triggered) {
+    ui_context_menu_reset(ui);
+  }
 }
 
 static void ui_publish_layout(UiSystem *ui, Workspace *workspace, int width,
@@ -1087,8 +1179,7 @@ void ui_system_build(UiSystem *ui, Workspace *workspace) {
 
   ui->modal_active = workspace_modal_is_active(workspace);
   if (ui->modal_active) {
-    ui->context_menu_visible = 0;
-    ui->context_menu_close_requested = 0;
+    ui_context_menu_reset(ui);
   }
 
   if (ui->window_handle) {
@@ -1227,7 +1318,7 @@ void ui_system_build(UiSystem *ui, Workspace *workspace) {
   }
 
   if (!ui->modal_active) {
-    ui_canvas_context_menu(ui, workspace, ui->content_bounds);
+    ui_canvas_context_menu(ui, workspace);
   }
 
   ui_publish_layout(ui, workspace, width, height);
@@ -1242,9 +1333,34 @@ int ui_system_handle_key(UiSystem *ui, int key, int action) {
     return 0;
   }
 
-  if (key == GLFW_KEY_ESCAPE && ui->context_menu_visible) {
-    ui->context_menu_close_requested = 1;
+  if (key == GLFW_KEY_ESCAPE && ui->context_menu.open) {
+    ui->context_menu.close_requested = 1;
     return 1;
+  }
+
+  return 0;
+}
+
+int ui_system_handle_mouse_button(UiSystem *ui, Workspace *workspace,
+                                  Vec2 screen_pos, int button, int action) {
+  if (!ui || !workspace || action != GLFW_PRESS || ui->modal_active) {
+    return 0;
+  }
+
+  if (ui->context_menu.open && button == GLFW_MOUSE_BUTTON_LEFT) {
+    /* Match common desktop behavior: clicking blank canvas dismisses the
+     * context menu immediately instead of waiting for popup internals. */
+    if (!rectf_contains_point(&ui->context_menu.popup_bounds, screen_pos)) {
+      ui_context_menu_reset(ui);
+      return 1;
+    }
+  }
+
+  if (button == GLFW_MOUSE_BUTTON_RIGHT) {
+    /* Open the canvas menu from the input path so tools never see the same
+     * right-click as a drawing gesture. */
+    ui_context_menu_open(ui, workspace, screen_pos);
+    return ui->context_menu.open;
   }
 
   return 0;
@@ -1263,7 +1379,7 @@ int ui_system_has_active_interaction(const UiSystem *ui) {
     return 0;
   }
 
-  return ui->context_menu_visible || nk_item_is_any_active(ui->ctx);
+  return ui->context_menu.open || nk_item_is_any_active(ui->ctx);
 }
 
 int ui_system_blocks_pointer(const UiSystem *ui, Vec2 screen_pos) {

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -92,6 +92,7 @@ struct UiSystem {
   int inspector_anim_initialized;
   int inspector_edit_active;
   DocumentSnapshot inspector_edit_before_snapshot;
+  SelectionSet inspector_edit_before_selection;
   int modal_active;
   UiContextMenuState context_menu;
   double last_frame_seconds;
@@ -252,7 +253,8 @@ static void ui_system_reload_themes(UiSystem *ui, Workspace *workspace,
         ui_theme_external_signature(UI_THEME_DIRECTORY_PATH);
     if (notify_status && workspace) {
       const char *error_summary = ui_theme_last_reload_error();
-      snprintf(workspace->status_message, sizeof(workspace->status_message),
+      snprintf(workspace->session.status_message,
+               sizeof(workspace->session.status_message),
                "Theme reload failed: %s",
                (error_summary && error_summary[0] != '\0')
                    ? error_summary
@@ -273,11 +275,13 @@ static void ui_system_reload_themes(UiSystem *ui, Workspace *workspace,
     const char *reason_label = ui_theme_reload_reason_label(reason);
     if (fallback_to_default) {
       snprintf(
-          workspace->status_message, sizeof(workspace->status_message),
+          workspace->session.status_message,
+          sizeof(workspace->session.status_message),
           "Themes %s reloaded (%d custom), active theme missing -> fallback",
           reason_label, custom_theme_count);
     } else {
-      snprintf(workspace->status_message, sizeof(workspace->status_message),
+      snprintf(workspace->session.status_message,
+               sizeof(workspace->session.status_message),
                "Themes %s reloaded (%d custom)", reason_label,
                custom_theme_count);
     }
@@ -423,7 +427,7 @@ static void ui_context_menu_open(UiSystem *ui, Workspace *workspace,
 
   ui->context_menu.open = 1;
   ui->context_menu.close_requested = 0;
-  ui->context_menu.mode = workspace->document.selection.count > 0
+  ui->context_menu.mode = workspace->session.selection.count > 0
                               ? UI_CONTEXT_MENU_MODE_SELECTION
                               : UI_CONTEXT_MENU_MODE_TOOLS;
   ui->context_menu.anchor_screen = screen_pos;
@@ -448,7 +452,7 @@ static void ui_format_command_label(const Workspace *workspace,
 
   shortcut[0] = '\0';
   if (workspace && command_id && command_id[0] != '\0') {
-    keymap_format_command_shortcut(&workspace->keymap, command_id, scope,
+    keymap_format_command_shortcut(&workspace->session.keymap, command_id, scope,
                                    shortcut, sizeof(shortcut));
   }
 
@@ -490,7 +494,7 @@ static void ui_context_menu_separator(UiSystem *ui) {
 }
 
 static int ui_context_menu_build_tools(UiSystem *ui, Workspace *workspace) {
-  const ToolKind active_tool = workspace->tools.active_kind;
+  const ToolKind active_tool = workspace->core.tools.active_kind;
 
   nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
   if (active_tool == TOOL_KIND_SELECT) {
@@ -537,7 +541,7 @@ static int ui_context_menu_build_tools(UiSystem *ui, Workspace *workspace) {
 
   ui_context_menu_separator(ui);
   nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
-  if (workspace->canvas.show_grid) {
+  if (workspace->core.canvas.show_grid) {
     if (ui_context_menu_item(ui, "Hide Grid", "view.toggle_grid",
                              EDITOR_COMMAND_VIEW_TOGGLE_GRID, workspace)) {
       return 1;
@@ -645,7 +649,7 @@ static void ui_publish_layout(UiSystem *ui, Workspace *workspace, int width,
   window_bounds.w = (float)width;
   window_bounds.h = (float)height;
 
-  next_layout = workspace->layout;
+  next_layout = workspace->session.layout;
   next_layout.window_bounds = window_bounds;
   next_layout.appbar_bounds =
       ui_clamp_rect_to_window(ui->appbar_bounds, window_bounds);
@@ -658,33 +662,34 @@ static void ui_publish_layout(UiSystem *ui, Workspace *workspace, int width,
   next_layout.canvas_content_bounds =
       ui_clamp_rect_to_window(ui->content_bounds, window_bounds);
 
-  changed = !ui_rectf_equals(workspace->layout.window_bounds,
+  changed = !ui_rectf_equals(workspace->session.layout.window_bounds,
                              next_layout.window_bounds) ||
-            !ui_rectf_equals(workspace->layout.appbar_bounds,
+            !ui_rectf_equals(workspace->session.layout.appbar_bounds,
                              next_layout.appbar_bounds) ||
-            !ui_rectf_equals(workspace->layout.rail_bounds,
+            !ui_rectf_equals(workspace->session.layout.rail_bounds,
                              next_layout.rail_bounds) ||
-            !ui_rectf_equals(workspace->layout.panel_bounds,
+            !ui_rectf_equals(workspace->session.layout.panel_bounds,
                              next_layout.panel_bounds) ||
-            !ui_rectf_equals(workspace->layout.status_bounds,
+            !ui_rectf_equals(workspace->session.layout.status_bounds,
                              next_layout.status_bounds) ||
-            !ui_rectf_equals(workspace->layout.canvas_content_bounds,
+            !ui_rectf_equals(workspace->session.layout.canvas_content_bounds,
                              next_layout.canvas_content_bounds);
 
   if (changed) {
-    next_layout.layout_revision = workspace->layout.layout_revision + 1u;
-    workspace->layout = next_layout;
+    next_layout.layout_revision = workspace->session.layout.layout_revision + 1u;
+    workspace->session.layout = next_layout;
   }
 
-  ui->layout_snapshot = workspace->layout;
+  ui->layout_snapshot = workspace->session.layout;
 }
 
 static ToolContext ui_tool_context(Workspace *workspace) {
   ToolContext context;
   context.workspace = workspace;
-  context.document = &workspace->document;
-  context.history = &workspace->history;
-  context.canvas = &workspace->canvas;
+  context.document = &workspace->core.document;
+  context.history = &workspace->core.history;
+  context.canvas = &workspace->core.canvas;
+  context.selection = &workspace->session.selection;
   return context;
 }
 
@@ -695,6 +700,7 @@ static void ui_reset_inspector_edit_session(UiSystem *ui) {
 
   document_snapshot_free(&ui->inspector_edit_before_snapshot);
   document_snapshot_init(&ui->inspector_edit_before_snapshot);
+  selection_set_clear(&ui->inspector_edit_before_selection);
   ui->inspector_edit_active = 0;
 }
 
@@ -708,8 +714,9 @@ static int ui_begin_inspector_edit_session(UiSystem *ui, Workspace *workspace) {
   }
 
   document_snapshot_init(&ui->inspector_edit_before_snapshot);
+  ui->inspector_edit_before_selection = workspace->session.selection;
   if (!document_snapshot_capture(&ui->inspector_edit_before_snapshot,
-                                 &workspace->document)) {
+                                 &workspace->core.document)) {
     ui_reset_inspector_edit_session(ui);
     return 0;
   }
@@ -724,11 +731,13 @@ static void ui_finalize_inspector_edit_session(UiSystem *ui,
     return;
   }
 
-  if (workspace->document.revision !=
+  if (workspace->core.document.revision !=
       ui->inspector_edit_before_snapshot.revision) {
-    if (!document_history_push(&workspace->history,
+    if (!document_history_push(&workspace->core.history,
                                &ui->inspector_edit_before_snapshot,
-                               &workspace->document)) {
+                               &ui->inspector_edit_before_selection,
+                               &workspace->core.document,
+                               &workspace->session.selection)) {
       ui_reset_inspector_edit_session(ui);
       workspace_sync_document_dirty(workspace);
       return;
@@ -862,7 +871,7 @@ static int ui_tool_button(UiSystem *ui, const char *label, int active,
 static void ui_tool_rail(UiSystem *ui, Workspace *workspace, RectF bounds) {
   struct nk_context *ctx = ui->ctx;
   ToolContext context = ui_tool_context(workspace);
-  ToolKind active = workspace->tools.active_kind;
+  ToolKind active = workspace->core.tools.active_kind;
 
   ui->rail_bounds = bounds;
   if (bounds.w <= 0.0f || bounds.h <= 0.0f) {
@@ -876,29 +885,29 @@ static void ui_tool_rail(UiSystem *ui, Workspace *workspace, RectF bounds) {
 
     if (ui_tool_button(ui, "Select (V)", active == TOOL_KIND_SELECT,
                        "Select and edit objects")) {
-      tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_SELECT);
+      tool_controller_set_active(&workspace->core.tools, &context, TOOL_KIND_SELECT);
     }
     if (ui_tool_button(ui, "Hand (H)", active == TOOL_KIND_PAN,
                        "Pan canvas view")) {
-      tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_PAN);
+      tool_controller_set_active(&workspace->core.tools, &context, TOOL_KIND_PAN);
     }
     if (ui_tool_button(ui, "Line (L)", active == TOOL_KIND_LINE, "Draw line")) {
-      tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_LINE);
+      tool_controller_set_active(&workspace->core.tools, &context, TOOL_KIND_LINE);
     }
     if (ui_tool_button(ui, "Rect (R)", active == TOOL_KIND_RECT,
                        "Draw rectangle")) {
-      tool_controller_set_active(&workspace->tools, &context, TOOL_KIND_RECT);
+      tool_controller_set_active(&workspace->core.tools, &context, TOOL_KIND_RECT);
     }
     if (ui_tool_button(ui, "Ellipse (E)", active == TOOL_KIND_ELLIPSE,
                        "Draw ellipse")) {
-      tool_controller_set_active(&workspace->tools, &context,
+      tool_controller_set_active(&workspace->core.tools, &context,
                                  TOOL_KIND_ELLIPSE);
     }
 
     nk_layout_row_dynamic(ctx, ui->theme.row_height * 0.9f, 1);
     nk_label(ctx, "", NK_TEXT_LEFT);
     nk_labelf(ctx, NK_TEXT_LEFT, "Active:");
-    nk_label(ctx, tool_controller_active_label(&workspace->tools),
+    nk_label(ctx, tool_controller_active_label(&workspace->core.tools),
              NK_TEXT_LEFT);
   }
   nk_end(ctx);
@@ -913,15 +922,16 @@ static void ui_inspector_empty_hint(struct nk_context *ctx) {
 }
 
 static void ui_inspector_overview(struct nk_context *ctx,
+                                  const SelectionSet *selection,
                                   const Document *document,
                                   const GraphicObject *object) {
-  if (!ctx || !document || !object) {
+  if (!ctx || !selection || !document || !object) {
     return;
   }
 
   nk_layout_row_dynamic(ctx, 20.0f, 1);
   nk_labelf(ctx, NK_TEXT_LEFT, "Type: %s", object_type_name(object->type));
-  nk_labelf(ctx, NK_TEXT_LEFT, "Selected: %d", document->selection.count);
+  nk_labelf(ctx, NK_TEXT_LEFT, "Selected: %d", selection->count);
 }
 
 static void ui_inspector_style(UiSystem *ui, struct nk_context *ctx,
@@ -1004,8 +1014,9 @@ static void ui_inspector_geometry(UiSystem *ui, struct nk_context *ctx,
 static void ui_selection_panel(UiSystem *ui, Workspace *workspace,
                                RectF bounds) {
   struct nk_context *ctx = ui->ctx;
-  Document *document = &workspace->document;
-  GraphicObject *object = document_primary_selection(document);
+  Document *document = &workspace->core.document;
+  GraphicObject *object =
+      selection_set_primary_object(&workspace->session.selection, document);
 
   ui->panel_bounds = bounds;
   if (bounds.w <= 0.0f || bounds.h <= 0.0f) {
@@ -1019,7 +1030,7 @@ static void ui_selection_panel(UiSystem *ui, Workspace *workspace,
     if (!object) {
       ui_inspector_empty_hint(ctx);
     } else {
-      ui_inspector_overview(ctx, document, object);
+      ui_inspector_overview(ctx, &workspace->session.selection, document, object);
       ui_inspector_style(ui, ctx, workspace, object);
       ui_inspector_geometry(ui, ctx, workspace, object);
     }
@@ -1032,7 +1043,7 @@ static void ui_status_bar(UiSystem *ui, Workspace *workspace, int window_width,
   struct nk_context *ctx = ui->ctx;
   const float status_h = ui->theme.status_height;
   const char *status_text =
-      workspace->status_message[0] ? workspace->status_message : "Ready";
+      workspace->session.status_message[0] ? workspace->session.status_message : "Ready";
   float status_row_h = ui->theme.row_height * 0.65f;
   char zoom_text[24];
 
@@ -1046,7 +1057,7 @@ static void ui_status_bar(UiSystem *ui, Workspace *workspace, int window_width,
   }
 
   snprintf(zoom_text, sizeof(zoom_text), "Zoom: %.0f%%",
-           canvas_view_zoom(&workspace->canvas) * 100.0f);
+           canvas_view_zoom(&workspace->core.canvas) * 100.0f);
 
   if (nk_begin(ctx, "Status",
                nk_rect(ui->status_bounds.x, ui->status_bounds.y,
@@ -1054,18 +1065,18 @@ static void ui_status_bar(UiSystem *ui, Workspace *workspace, int window_width,
                NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BORDER)) {
     nk_layout_row_begin(ctx, NK_DYNAMIC, status_row_h, 5);
     nk_layout_row_push(ctx, 0.12f);
-    nk_labelf(ctx, NK_TEXT_LEFT, "Objects: %d", workspace->document.count);
+    nk_labelf(ctx, NK_TEXT_LEFT, "Objects: %d", workspace->core.document.count);
     nk_layout_row_push(ctx, 0.13f);
     nk_label(ctx, zoom_text, NK_TEXT_LEFT);
     nk_layout_row_push(ctx, 0.35f);
     nk_labelf(ctx, NK_TEXT_LEFT, "File: %s%s",
-              workspace->current_document_path[0]
-                  ? workspace->current_document_path
+              workspace->session.current_document_path[0]
+                  ? workspace->session.current_document_path
                   : "(default)",
-              workspace->document_dirty ? " *" : "");
+              workspace->session.document_dirty ? " *" : "");
     nk_layout_row_push(ctx, 0.18f);
     nk_labelf(ctx, NK_TEXT_LEFT, "Undo:%d Redo:%d",
-              workspace->history.undo_count, workspace->history.redo_count);
+              workspace->core.history.undo_count, workspace->core.history.redo_count);
     nk_layout_row_push(ctx, 0.22f);
     nk_label(ctx, status_text, NK_TEXT_RIGHT);
     nk_layout_row_end(ctx);
@@ -1090,7 +1101,7 @@ static void ui_modal_dialogs(UiSystem *ui, Workspace *workspace,
   }
 
   result =
-      ui_dialog_show(ui->ctx, &workspace->active_dialog, window_width, window_height);
+      ui_dialog_show(ui->ctx, &workspace->session.active_dialog, window_width, window_height);
   if (result != UI_DIALOG_RESULT_NONE) {
     workspace_resolve_active_dialog(workspace, result);
   }
@@ -1221,7 +1232,8 @@ void ui_system_build(UiSystem *ui, Workspace *workspace) {
     if (requested_theme_index >= 0) {
       requested_theme = ui_theme_descriptor_at(requested_theme_index);
       if (requested_theme && ui_system_set_theme(ui, requested_theme->id, 1)) {
-        snprintf(workspace->status_message, sizeof(workspace->status_message),
+        snprintf(workspace->session.status_message,
+                 sizeof(workspace->session.status_message),
                  "Theme: %s",
                  requested_theme->label ? requested_theme->label
                                         : requested_theme->id);

--- a/tests/test_document_core.c
+++ b/tests/test_document_core.c
@@ -1,3 +1,4 @@
+#include <app/editor_session.h>
 #include <document/document.h>
 #include <document/history.h>
 #include <document/object.h>
@@ -153,8 +154,11 @@ static int make_temp_path(char* buffer, size_t buffer_size, const char* suffix)
 static int test_document_selection_and_deletion(void)
 {
     Document document;
+    SelectionSet selection = {0};
     GraphicObject* first = NULL;
     GraphicObject* second = NULL;
+    ObjectId ids[DOCUMENT_MAX_SELECTION];
+    int i = 0;
 
     document_init(&document);
 
@@ -168,24 +172,31 @@ static int test_document_selection_and_deletion(void)
     EXPECT_UINT_EQ(document.objects[1]->id, 2u);
     EXPECT_UINT_EQ(document.next_id, 3u);
 
-    EXPECT_TRUE(document_selection_add(&document, 1u));
-    EXPECT_TRUE(document_selection_add(&document, 2u));
-    EXPECT_TRUE(document_selection_contains(&document, 1u));
-    EXPECT_TRUE(document_selection_contains(&document, 2u));
+    EXPECT_TRUE(selection_set_add(&selection, 1u));
+    EXPECT_TRUE(selection_set_add(&selection, 2u));
+    EXPECT_TRUE(selection_set_contains(&selection, 1u));
+    EXPECT_TRUE(selection_set_contains(&selection, 2u));
 
-    document_selection_toggle(&document, 2u);
-    EXPECT_FALSE(document_selection_contains(&document, 2u));
-    EXPECT_INT_EQ(document.selection.count, 1);
+    selection_set_toggle(&selection, 2u);
+    EXPECT_FALSE(selection_set_contains(&selection, 2u));
+    EXPECT_INT_EQ(selection.count, 1);
 
     EXPECT_TRUE(document_remove_object(&document, 1u));
     EXPECT_INT_EQ(document.count, 1);
-    EXPECT_FALSE(document_selection_contains(&document, 1u));
+    selection_set_remove(&selection, 1u);
+    EXPECT_FALSE(selection_set_contains(&selection, 1u));
     EXPECT_UINT_EQ(document.objects[0]->id, 2u);
 
-    EXPECT_TRUE(document_selection_add(&document, 2u));
-    document_delete_selection(&document);
+    EXPECT_TRUE(selection_set_add(&selection, 2u));
+    for (i = 0; i < selection.count; ++i) {
+        ids[i] = selection.ids[i];
+    }
+    for (i = 0; i < selection.count; ++i) {
+        EXPECT_TRUE(document_remove_object(&document, ids[i]));
+    }
+    selection_set_clear(&selection);
     EXPECT_INT_EQ(document.count, 0);
-    EXPECT_INT_EQ(document.selection.count, 0);
+    EXPECT_INT_EQ(selection.count, 0);
 
     document_shutdown(&document);
     return g_failures == 0;
@@ -196,6 +207,7 @@ static int test_history_snapshot_undo_redo(void)
     Document document;
     DocumentHistory history;
     DocumentSnapshot before;
+    SelectionSet selection = {0};
 
     document_init(&document);
     EXPECT_TRUE(document_history_init(&history));
@@ -204,15 +216,15 @@ static int test_history_snapshot_undo_redo(void)
     EXPECT_TRUE(document_add_object(&document, create_rect(0.0f, 0.0f, 10.0f, 20.0f)));
     EXPECT_TRUE(document_snapshot_capture(&before, &document));
     EXPECT_TRUE(document_add_object(&document, create_rect(10.0f, 10.0f, 5.0f, 5.0f)));
-    EXPECT_TRUE(document_history_push(&history, &before, &document));
+    EXPECT_TRUE(document_history_push(&history, &before, &selection, &document, &selection));
     EXPECT_TRUE(document_history_can_undo(&history));
 
-    EXPECT_TRUE(document_history_undo(&history, &document));
+    EXPECT_TRUE(document_history_undo(&history, &document, &selection));
     EXPECT_INT_EQ(document.count, 1);
     EXPECT_FALSE(document_history_can_undo(&history));
     EXPECT_TRUE(document_history_can_redo(&history));
 
-    EXPECT_TRUE(document_history_redo(&history, &document));
+    EXPECT_TRUE(document_history_redo(&history, &document, &selection));
     EXPECT_INT_EQ(document.count, 2);
     EXPECT_TRUE(document_history_can_undo(&history));
 
@@ -225,6 +237,7 @@ static int test_history_scalar_edit_undo_redo(void)
 {
     Document document;
     DocumentHistory history;
+    SelectionSet selection = {0};
     GraphicObject* object = NULL;
     float value = 0.0f;
     unsigned int revision_before = 0u;
@@ -242,6 +255,7 @@ static int test_history_scalar_edit_undo_redo(void)
     revision_after = document.revision;
     EXPECT_TRUE(document_history_push_scalar_edit(&history,
                                                   &document,
+                                                  &selection,
                                                   object->id,
                                                   "width",
                                                   10.0f,
@@ -249,12 +263,12 @@ static int test_history_scalar_edit_undo_redo(void)
                                                   revision_before,
                                                   revision_after));
 
-    EXPECT_TRUE(document_history_undo(&history, &document));
+    EXPECT_TRUE(document_history_undo(&history, &document, &selection));
     EXPECT_TRUE(object_get_scalar(object, "width", &value));
     EXPECT_FLOAT_EQ(value, 10.0f);
     EXPECT_UINT_EQ(document.revision, revision_before);
 
-    EXPECT_TRUE(document_history_redo(&history, &document));
+    EXPECT_TRUE(document_history_redo(&history, &document, &selection));
     EXPECT_TRUE(object_get_scalar(object, "width", &value));
     EXPECT_FLOAT_EQ(value, 42.0f);
     EXPECT_UINT_EQ(document.revision, revision_after);
@@ -268,6 +282,7 @@ static int test_history_translate_edit_undo_redo(void)
 {
     Document document;
     DocumentHistory history;
+    SelectionSet selection = {0};
     GraphicObject* object = NULL;
     ObjectId ids[1] = {0u};
     Vec2 delta = {3.0f, -4.0f};
@@ -289,20 +304,21 @@ static int test_history_translate_edit_undo_redo(void)
     revision_after = document.revision;
     EXPECT_TRUE(document_history_push_translate_edit(&history,
                                                      &document,
+                                                     &selection,
                                                      ids,
                                                      1,
                                                      delta,
                                                      revision_before,
                                                      revision_after));
 
-    EXPECT_TRUE(document_history_undo(&history, &document));
+    EXPECT_TRUE(document_history_undo(&history, &document, &selection));
     EXPECT_TRUE(object_get_scalar(object, "x", &x));
     EXPECT_TRUE(object_get_scalar(object, "y", &y));
     EXPECT_FLOAT_EQ(x, 2.0f);
     EXPECT_FLOAT_EQ(y, 8.0f);
     EXPECT_UINT_EQ(document.revision, revision_before);
 
-    EXPECT_TRUE(document_history_redo(&history, &document));
+    EXPECT_TRUE(document_history_redo(&history, &document, &selection));
     EXPECT_TRUE(object_get_scalar(object, "x", &x));
     EXPECT_TRUE(object_get_scalar(object, "y", &y));
     EXPECT_FLOAT_EQ(x, 5.0f);
@@ -318,6 +334,7 @@ static int test_persistence_round_trip(void)
 {
     Document saved;
     Document loaded;
+    SelectionSet saved_selection = {0};
     char path[L_tmpnam + 16];
     float width = 0.0f;
 
@@ -326,7 +343,7 @@ static int test_persistence_round_trip(void)
 
     EXPECT_TRUE(document_add_object(&saved, create_rect(3.0f, 4.0f, 20.0f, 30.0f)));
     EXPECT_TRUE(document_add_object(&saved, create_line(1.0f, 2.0f, 9.0f, 10.0f)));
-    EXPECT_TRUE(document_selection_add(&saved, 2u));
+    EXPECT_TRUE(selection_set_add(&saved_selection, 2u));
 
     EXPECT_TRUE(make_temp_path(path, sizeof(path), ".json"));
     EXPECT_TRUE(document_save_json(&saved, path));
@@ -334,7 +351,6 @@ static int test_persistence_round_trip(void)
 
     EXPECT_INT_EQ(loaded.count, 2);
     EXPECT_UINT_EQ(loaded.next_id, saved.next_id);
-    EXPECT_INT_EQ(loaded.selection.count, 0);
     EXPECT_TRUE(object_get_scalar(document_find_object(&loaded, 1u), "width", &width));
     EXPECT_FLOAT_EQ(width, 20.0f);
 


### PR DESCRIPTION
Closes #55

## Summary
- split workspace-owned state into explicit editor core, session, and services layers
- move selection and other editor-only state out of Document and into session-owned helpers
- make DocumentHistory self-contained and add an architecture note plus updated tests for the new boundaries

## Testing
- cmake --build build --config Release
- .\\build\\bin\\gldraw_document_core_tests.exe
