### PR TITLE
fix: add file picker for opening documents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(GLDRAW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/command_registry.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_actions.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_dialogs.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/file_dialog.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/window.c
     ${GLDRAW_CORE_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/canvas/canvas_view.c
@@ -127,7 +128,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
 endif()
 
 if(WIN32)
-    target_link_libraries(${PROJECT_NAME} PRIVATE gdi32)
+    target_link_libraries(${PROJECT_NAME} PRIVATE gdi32 comdlg32)
 endif()
 
 if(UNIX AND NOT APPLE)

--- a/include/platform/file_dialog.h
+++ b/include/platform/file_dialog.h
@@ -1,0 +1,25 @@
+/**
+ * @file file_dialog.h
+ * @brief Native file dialog helpers.
+ */
+#ifndef GLDRAW_PLATFORM_FILE_DIALOG_H
+#define GLDRAW_PLATFORM_FILE_DIALOG_H
+
+#include <stddef.h>
+
+typedef enum PlatformFileDialogResult {
+    PLATFORM_FILE_DIALOG_ERROR = -1,
+    PLATFORM_FILE_DIALOG_CANCELLED = 0,
+    PLATFORM_FILE_DIALOG_SELECTED = 1
+} PlatformFileDialogResult;
+
+/**
+ * @brief Open a native file picker for GLDraw JSON documents.
+ * @param out_path Destination buffer for the selected path.
+ * @param out_path_size Destination buffer size.
+ * @return Selection, cancellation, or error result.
+ */
+PlatformFileDialogResult platform_file_dialog_open_document(char* out_path,
+                                                            size_t out_path_size);
+
+#endif /* GLDRAW_PLATFORM_FILE_DIALOG_H */

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -19,6 +19,7 @@
 #include <base/math2d.h>
 #include <document/persistence.h>
 #include <input/input_router.h>
+#include <platform/file_dialog.h>
 #include <platform/window.h>
 #include <render/render_system.h>
 #include <ui/ui_menu_actions.h>
@@ -221,9 +222,7 @@ static int app_save_document(Application *app) {
  * Time complexity: dominated by parse/build, roughly `O(file_size +
  * object_count)`.
  */
-static int app_load_document(Application *app) {
-  const char *path = app_current_document_path(app);
-
+static int app_load_document_from_path(Application *app, const char *path) {
   if (!app_file_exists(path)) {
     LOG_WARN("Document file not found: %s", path);
     app_set_status(app, "Document not found: %s", path);
@@ -252,6 +251,31 @@ static int app_load_document(Application *app) {
   app_set_status(app, "Loaded document: %s", path);
   LOG_INFO("Loaded document: %s", path);
   return 1;
+}
+
+static int app_load_document(Application *app) {
+  return app_load_document_from_path(app, app_current_document_path(app));
+}
+
+static int app_open_document_with_picker(Application *app) {
+  char selected_path[260];
+  PlatformFileDialogResult result;
+
+  if (!app) {
+    return 0;
+  }
+
+  result = platform_file_dialog_open_document(selected_path, sizeof(selected_path));
+  if (result == PLATFORM_FILE_DIALOG_CANCELLED) {
+    app_set_status(app, "Open cancelled.");
+    return 1;
+  }
+  if (result == PLATFORM_FILE_DIALOG_ERROR) {
+    app_set_status(app, "Open failed: file picker unavailable or failed.");
+    return 0;
+  }
+
+  return app_load_document_from_path(app, selected_path);
 }
 
 static int app_exit_application(Application *app) {
@@ -296,7 +320,7 @@ static int app_workspace_execute_action(Workspace *workspace,
   case WORKSPACE_ACTION_NEW_DOCUMENT:
     return app_new_document(app);
   case WORKSPACE_ACTION_OPEN_DOCUMENT:
-    return app_load_document(app);
+    return app_open_document_with_picker(app);
   case WORKSPACE_ACTION_EXIT_APPLICATION:
     return app_exit_application(app);
   case WORKSPACE_ACTION_NONE:

--- a/src/platform/file_dialog.c
+++ b/src/platform/file_dialog.c
@@ -1,0 +1,63 @@
+/**
+ * @file file_dialog.c
+ * @brief Native file dialog implementation.
+ */
+#include <platform/file_dialog.h>
+
+#include <string.h>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <commdlg.h>
+#endif
+
+PlatformFileDialogResult platform_file_dialog_open_document(char* out_path,
+                                                            size_t out_path_size)
+{
+    if (!out_path || out_path_size == 0u) {
+        return PLATFORM_FILE_DIALOG_ERROR;
+    }
+
+    out_path[0] = '\0';
+
+#ifdef _WIN32
+    {
+        OPENFILENAMEA dialog;
+        char path_buffer[260];
+
+        memset(&dialog, 0, sizeof(dialog));
+        memset(path_buffer, 0, sizeof(path_buffer));
+
+        dialog.lStructSize = sizeof(dialog);
+        dialog.hwndOwner = NULL;
+        dialog.lpstrFilter = "GLDraw Documents (*.json)\0*.json\0All Files (*.*)\0*.*\0";
+        dialog.lpstrFile = path_buffer;
+        dialog.nMaxFile = sizeof(path_buffer);
+        dialog.lpstrDefExt = "json";
+        dialog.Flags = OFN_FILEMUSTEXIST |
+                       OFN_PATHMUSTEXIST |
+                       OFN_NOCHANGEDIR |
+                       OFN_HIDEREADONLY;
+
+        if (GetOpenFileNameA(&dialog)) {
+            if (strlen(path_buffer) + 1u > out_path_size) {
+                return PLATFORM_FILE_DIALOG_ERROR;
+            }
+            memcpy(out_path, path_buffer, strlen(path_buffer) + 1u);
+            return PLATFORM_FILE_DIALOG_SELECTED;
+        }
+
+        if (CommDlgExtendedError() == 0) {
+            return PLATFORM_FILE_DIALOG_CANCELLED;
+        }
+        return PLATFORM_FILE_DIALOG_ERROR;
+    }
+#else
+    (void)out_path;
+    (void)out_path_size;
+    return PLATFORM_FILE_DIALOG_ERROR;
+#endif
+}


### PR DESCRIPTION
## Summary
- add a platform file dialog abstraction
- wire File > Open to a native Windows JSON picker
- preserve cancellation and load-failure behavior without changing the current document path

## Validation
- cmake --build build --config Release
- ctest --test-dir build --output-on-failure

## Releated

Closes #80.