### PR TITLE
fix：menu hover ownership leak

### DIFF
--- a/src/ui/ui_menubar.c
+++ b/src/ui/ui_menubar.c
@@ -147,6 +147,11 @@ bool ui_menubar_inspector_visible(const UiMenuBar* menubar)
     return menubar ? menubar->show_inspector : true;
 }
 
+int ui_menubar_menu_open(const UiMenuBar* menubar)
+{
+    return menubar ? menubar->menu_open : 0;
+}
+
 /**
  * @brief Get the current menu bar height.
  * @param menubar [in] Menu bar instance; defaults to `MENU_BAR_HEIGHT` when `NULL`.
@@ -380,6 +385,7 @@ static int ui_render_top_menu(UiMenuBar* menubar, Workspace* workspace, const Ui
     }
 
     if (nk_menu_begin_label(ctx, menu->label, NK_TEXT_LEFT, menu->popup_size)) {
+        menubar->menu_open = 1;
         nk_layout_row_dynamic(ctx, 25.0f, 1);
         if (menu->parent_id == MENU_PARENT_THEME) {
             int theme_index = ui_render_theme_dropdown(menubar);
@@ -437,6 +443,7 @@ void ui_menubar_build(UiMenuBar* menubar, Workspace* workspace, int window_width
     if (!ctx) {
         return;
     }
+    menubar->menu_open = 0;
 
     for (size_t i = 0; i < menu_count; i++) {
         left_width_total += g_top_menus[i].item_width;

--- a/src/ui/ui_menubar.h
+++ b/src/ui/ui_menubar.h
@@ -25,6 +25,7 @@ typedef struct UiThemeDescriptor UiThemeDescriptor;
  * @member active_theme_index Currently active theme index.
  * @member requested_theme_index Pending theme index to apply (-1 means no request).
  * @member requested_theme_reload Whether a reload of external themes is requested.
+ * @member menu_open Whether a menu popup was open during the latest build.
  */
 typedef struct UiMenuBar {
     struct nk_context* ctx;
@@ -35,6 +36,7 @@ typedef struct UiMenuBar {
     int active_theme_index;
     int requested_theme_index;
     int requested_theme_reload;
+    int menu_open;
 } UiMenuBar;
 
 /**
@@ -66,6 +68,13 @@ void ui_menubar_build(UiMenuBar* menubar, struct Workspace* workspace, int windo
  * @return `true` if visible, `false` otherwise.
  */
 bool ui_menubar_inspector_visible(const UiMenuBar* menubar);
+
+/**
+ * @brief Query whether a top-level menu popup is currently open.
+ * @param menubar Menu bar object.
+ * @return Non-zero when any menu popup was open during the latest frame.
+ */
+int ui_menubar_menu_open(const UiMenuBar* menubar);
 
 /**
  * @brief Get the menu bar height.

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -109,6 +109,7 @@ static void ui_context_menu_reset(UiSystem *ui);
 static RectF ui_context_menu_popup_bounds(const UiContextMenuState *menu);
 static void ui_context_menu_open(UiSystem *ui, Workspace *workspace,
                                  Vec2 screen_pos);
+static int ui_hover_overlays_allowed(const UiSystem *ui);
 
 /**
  * @brief Clamps a float value.
@@ -825,6 +826,15 @@ static void ui_property_apply_float(UiSystem *ui, struct nk_context *ctx,
   }
 }
 
+static int ui_hover_overlays_allowed(const UiSystem *ui) {
+  if (!ui) {
+    return 0;
+  }
+
+  return !ui->modal_active && !ui->context_menu.open &&
+         !ui_menubar_menu_open(ui->menu_bar);
+}
+
 static int ui_tool_button(UiSystem *ui, const char *label, int active,
                           const char *tooltip) {
   struct nk_context *ctx = ui->ctx;
@@ -852,7 +862,8 @@ static int ui_tool_button(UiSystem *ui, const char *label, int active,
   widget_bounds = nk_widget_bounds(ctx);
   pressed = nk_button_label(ctx, label);
   hovered = nk_input_is_mouse_hovering_rect(&ctx->input, widget_bounds);
-  if (tooltip && tooltip[0] != '\0' && hovered) {
+  if (tooltip && tooltip[0] != '\0' && hovered &&
+      ui_hover_overlays_allowed(ui)) {
     nk_tooltip(ctx, tooltip);
   }
 
@@ -1391,7 +1402,8 @@ int ui_system_has_active_interaction(const UiSystem *ui) {
     return 0;
   }
 
-  return ui->context_menu.open || nk_item_is_any_active(ui->ctx);
+  return ui->context_menu.open || ui_menubar_menu_open(ui->menu_bar) ||
+         nk_item_is_any_active(ui->ctx);
 }
 
 int ui_system_blocks_pointer(const UiSystem *ui, Vec2 screen_pos) {


### PR DESCRIPTION
## Summary
- track whether a menubar popup is open during the current frame
- suppress Tool Rail hover tooltips while menu, modal, or context menu layers own interaction
- treat open menus as active UI interactions for pointer blocking

## Validation
- cmake --build build --config Release
- ctest --test-dir build --output-on-failure

## Releated

Closes #81 