### PR TITLE
feat: add save as workflow

### DIFF
--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -50,7 +50,8 @@ typedef enum UiDialogKind {
     UI_DIALOG_NONE = 0,
     UI_DIALOG_CONFIRM_UNSAVED,
     UI_DIALOG_SHORTCUTS,
-    UI_DIALOG_INFO
+    UI_DIALOG_INFO,
+    UI_DIALOG_SAVE_AS
 } UiDialogKind;
 
 /**
@@ -204,6 +205,7 @@ typedef struct EditorSession {
  */
 typedef struct EditorServices {
     WorkspaceCommandFn save_document;
+    WorkspaceCommandFn save_as_document;
     WorkspaceCommandFn load_document;
     WorkspaceActionExecutorFn execute_action;
     void* command_user_data;

--- a/include/app/workspace_dialogs.h
+++ b/include/app/workspace_dialogs.h
@@ -77,5 +77,9 @@ int workspace_dialog_open_shortcuts(Workspace* workspace, const char* content_te
 int workspace_dialog_open_info(Workspace* workspace,
                                const char* title,
                                const char* message);
+/** Open the Save As filename dialog. */
+int workspace_dialog_open_save_as(Workspace* workspace,
+                                  const char* initial_filename,
+                                  const char* target_directory);
 
 #endif /* GLDRAW_APP_WORKSPACE_DIALOGS_H */

--- a/include/ui/ui_dialog.h
+++ b/include/ui/ui_dialog.h
@@ -13,7 +13,7 @@ struct nk_context;
 
 /** Render one workspace-owned dialog and return the user result for this frame. */
 UiDialogResult ui_dialog_show(struct nk_context* ctx,
-                              const UiDialogState* dialog,
+                              UiDialogState* dialog,
                               int window_width,
                               int window_height);
 

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -28,6 +28,7 @@
 
 #include <GLFW/glfw3.h>
 
+#include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -45,6 +46,7 @@ typedef struct {
 } Application;
 
 static int app_workspace_save(Workspace *workspace, void *user_data);
+static int app_workspace_save_as(Workspace *workspace, void *user_data);
 static int app_workspace_load(Workspace *workspace, void *user_data);
 static int app_workspace_execute_action(Workspace *workspace,
                                         WorkspaceActionType action,
@@ -124,6 +126,66 @@ static const char *app_current_document_path(const Application *app) {
   return app_default_document_path();
 }
 
+static void app_current_document_directory(const Application *app, char *buffer,
+                                           size_t buffer_size) {
+  const char *path = app_current_document_path(app);
+  const char *cursor = NULL;
+  const char *last_separator = NULL;
+  size_t length = 0u;
+
+  if (!buffer || buffer_size == 0u) {
+    return;
+  }
+
+  buffer[0] = '\0';
+  for (cursor = path; cursor && *cursor != '\0'; ++cursor) {
+    if (*cursor == '/' || *cursor == '\\') {
+      last_separator = cursor;
+    }
+  }
+
+  if (!last_separator) {
+    snprintf(buffer, buffer_size, ".");
+    return;
+  }
+
+  length = (size_t)(last_separator - path);
+  if (length == 0u) {
+    length = 1u;
+  } else if (length == 2u && path[1] == ':') {
+    length = 3u;
+  }
+  if (length >= buffer_size) {
+    length = buffer_size - 1u;
+  }
+  memcpy(buffer, path, length);
+  buffer[length] = '\0';
+}
+
+static void app_update_save_as_dialog_message(Application *app,
+                                              const char *error_text) {
+  char directory[260];
+
+  if (!app) {
+    return;
+  }
+
+  app_current_document_directory(app, directory, sizeof(directory));
+  if (error_text && error_text[0] != '\0') {
+    snprintf(app->workspace.session.active_dialog.message,
+             sizeof(app->workspace.session.active_dialog.message),
+             "%s\n\nEnter a new filename.\nThe file will be saved in the same directory:\n%s",
+             error_text,
+             directory);
+    return;
+  }
+
+  snprintf(app->workspace.session.active_dialog.message,
+           sizeof(app->workspace.session.active_dialog.message),
+           "Enter a new filename.\nThe file will be saved in the same directory:\n%s",
+           directory);
+}
+
 /**
  * @brief Copy document path into workspace path buffer.
  * @param app [in,out] Application state.
@@ -144,6 +206,127 @@ static void app_set_document_path(Application *app, const char *path) {
   app->workspace.session
       .current_document_path[sizeof(app->workspace.session.current_document_path) -
                              1u] = '\0';
+}
+
+static int app_copy_trimmed_filename(const char *input, char *output,
+                                     size_t output_size) {
+  const char *start = input;
+  const char *end = NULL;
+  size_t length = 0u;
+
+  if (!input || !output || output_size == 0u) {
+    return 0;
+  }
+
+  while (*start != '\0' && isspace((unsigned char)*start)) {
+    start++;
+  }
+  end = start + strlen(start);
+  while (end > start && isspace((unsigned char)*(end - 1))) {
+    end--;
+  }
+
+  length = (size_t)(end - start);
+  if (length == 0u || length >= output_size) {
+    output[0] = '\0';
+    return 0;
+  }
+
+  memcpy(output, start, length);
+  output[length] = '\0';
+  return 1;
+}
+
+static int app_filename_has_json_extension(const char *filename) {
+  size_t length = 0u;
+  const char *extension = ".json";
+  size_t extension_length = strlen(extension);
+  size_t i = 0u;
+
+  if (!filename) {
+    return 0;
+  }
+
+  length = strlen(filename);
+  if (length < extension_length) {
+    return 0;
+  }
+
+  filename += length - extension_length;
+  for (i = 0u; i < extension_length; ++i) {
+    if (tolower((unsigned char)filename[i]) !=
+        tolower((unsigned char)extension[i])) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+static int app_validate_save_as_filename(const char *filename) {
+  const char *cursor = NULL;
+
+  if (!filename || filename[0] == '\0') {
+    return 0;
+  }
+  if (strcmp(filename, ".") == 0 || strcmp(filename, "..") == 0) {
+    return 0;
+  }
+
+  for (cursor = filename; *cursor != '\0'; ++cursor) {
+    unsigned char ch = (unsigned char)*cursor;
+    if (ch < 32u || strchr("/\\:*?\"<>|", *cursor)) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+static int app_build_save_as_path(Application *app, const char *filename,
+                                  char *output, size_t output_size) {
+  const char *current_path = app_current_document_path(app);
+  const char *cursor = NULL;
+  const char *last_separator = NULL;
+  char final_filename[260];
+  size_t directory_length = 0u;
+  size_t filename_length = 0u;
+
+  if (!app || !filename || !output || output_size == 0u) {
+    return 0;
+  }
+
+  if (app_filename_has_json_extension(filename)) {
+    snprintf(final_filename, sizeof(final_filename), "%s", filename);
+  } else if (strlen(filename) + 5u < sizeof(final_filename)) {
+    snprintf(final_filename, sizeof(final_filename), "%s.json", filename);
+  } else {
+    return 0;
+  }
+
+  for (cursor = current_path; cursor && *cursor != '\0'; ++cursor) {
+    if (*cursor == '/' || *cursor == '\\') {
+      last_separator = cursor;
+    }
+  }
+
+  filename_length = strlen(final_filename);
+  if (!last_separator) {
+    if (filename_length + 1u > output_size) {
+      return 0;
+    }
+    snprintf(output, output_size, "%s", final_filename);
+    return 1;
+  }
+
+  directory_length = (size_t)(last_separator - current_path) + 1u;
+  if (directory_length + filename_length + 1u > output_size) {
+    return 0;
+  }
+
+  memcpy(output, current_path, directory_length);
+  memcpy(output + directory_length, final_filename, filename_length + 1u);
+  return 1;
 }
 
 /**
@@ -194,9 +377,7 @@ static int app_new_document(Application *app) {
  *
  * Time complexity: dominated by serialization, roughly `O(object_count)`.
  */
-static int app_save_document(Application *app) {
-  const char *path = app_current_document_path(app);
-
+static int app_save_document_to_path(Application *app, const char *path) {
   if (!document_save_json(&app->workspace.core.document, path)) {
     LOG_ERROR("%s", "Save document failed");
     app_set_status(app, "Save failed: %s", path);
@@ -208,6 +389,36 @@ static int app_save_document(Application *app) {
   app_set_status(app, "Saved document: %s", path);
   LOG_INFO("Saved document: %s", path);
   return 1;
+}
+
+static int app_save_document(Application *app) {
+  return app_save_document_to_path(app, app_current_document_path(app));
+}
+
+static int app_save_as_document(Application *app) {
+  char filename[260];
+  char target_path[260];
+  const char *input = NULL;
+
+  if (!app) {
+    return 0;
+  }
+
+  input = app->workspace.session.active_dialog.payload.text;
+  if (!app_copy_trimmed_filename(input, filename, sizeof(filename)) ||
+      !app_validate_save_as_filename(filename)) {
+    app_set_status(app, "Save As failed: invalid filename");
+    app_update_save_as_dialog_message(app, "Invalid filename. Use a simple file name without path separators or reserved characters.");
+    return 0;
+  }
+
+  if (!app_build_save_as_path(app, filename, target_path, sizeof(target_path))) {
+    app_set_status(app, "Save As failed: path too long");
+    app_update_save_as_dialog_message(app, "Invalid filename. The resulting path is too long.");
+    return 0;
+  }
+
+  return app_save_document_to_path(app, target_path);
 }
 
 /**
@@ -297,6 +508,11 @@ static int app_exit_application(Application *app) {
 static int app_workspace_save(Workspace *workspace, void *user_data) {
   (void)workspace;
   return app_save_document((Application *)user_data);
+}
+
+static int app_workspace_save_as(Workspace *workspace, void *user_data) {
+  (void)workspace;
+  return app_save_as_document((Application *)user_data);
 }
 
 /**
@@ -692,6 +908,7 @@ static int app_init(Application *app) {
   keymap_init(&app->workspace.session.keymap, APP_KEYMAP_SETTINGS_PATH);
   app_set_document_path(app, app_default_document_path());
   app->workspace.services.save_document = app_workspace_save;
+  app->workspace.services.save_as_document = app_workspace_save_as;
   app->workspace.services.load_document = app_workspace_load;
   app->workspace.services.execute_action = app_workspace_execute_action;
   app->workspace.services.command_user_data = app;

--- a/src/app/command_registry.c
+++ b/src/app/command_registry.c
@@ -19,6 +19,88 @@
 
 #define CLIPBOARD_PASTE_OFFSET_PIXELS 10.0f
 
+static const char* command_registry_path_basename(const char* path)
+{
+    const char* basename = path;
+    const char* cursor = NULL;
+
+    if (!path || path[0] == '\0') {
+        return "document.json";
+    }
+
+    for (cursor = path; *cursor != '\0'; ++cursor) {
+        if (*cursor == '/' || *cursor == '\\') {
+            basename = cursor + 1;
+        }
+    }
+
+    return (basename && basename[0] != '\0') ? basename : "document.json";
+}
+
+static void command_registry_format_path_directory(const char* path,
+                                                   char* buffer,
+                                                   size_t buffer_size)
+{
+    const char* cursor = NULL;
+    const char* last_separator = NULL;
+    size_t length = 0u;
+
+    if (!buffer || buffer_size == 0u) {
+        return;
+    }
+
+    buffer[0] = '\0';
+    if (!path || path[0] == '\0') {
+        snprintf(buffer, buffer_size, ".");
+        return;
+    }
+
+    for (cursor = path; *cursor != '\0'; ++cursor) {
+        if (*cursor == '/' || *cursor == '\\') {
+            last_separator = cursor;
+        }
+    }
+
+    if (!last_separator) {
+        snprintf(buffer, buffer_size, ".");
+        return;
+    }
+
+    length = (size_t)(last_separator - path);
+    if (length == 0u) {
+        length = 1u;
+    } else if (length == 2u && path[1] == ':') {
+        length = 3u;
+    }
+    if (length >= buffer_size) {
+        length = buffer_size - 1u;
+    }
+
+    memcpy(buffer, path, length);
+    buffer[length] = '\0';
+}
+
+static int command_registry_open_save_as_dialog(Workspace* workspace)
+{
+    char directory[260];
+    const char* path = NULL;
+
+    if (!workspace) {
+        return 0;
+    }
+    if (workspace_modal_is_active(workspace)) {
+        return 0;
+    }
+
+    path = workspace->session.current_document_path[0] != '\0'
+               ? workspace->session.current_document_path
+               : "document.json";
+    command_registry_format_path_directory(path, directory, sizeof(directory));
+    return workspace_dialog_open_save_as(workspace,
+                                         command_registry_path_basename(path),
+                                         directory);
+}
+
 static const CommandDescriptor g_commands[] = {
     {EDITOR_COMMAND_FILE_NEW, "file.new", "New", KEY_SCOPE_GLOBAL, MENU_ID_FILE_NEW},
     {EDITOR_COMMAND_FILE_OPEN, "file.open", "Open", KEY_SCOPE_GLOBAL, MENU_ID_FILE_OPEN},
@@ -464,7 +546,7 @@ int command_registry_is_available(const Workspace* workspace,
     case EDITOR_COMMAND_FILE_SAVE:
         return workspace && workspace->services.save_document;
     case EDITOR_COMMAND_FILE_SAVE_AS:
-        return 0;
+        return workspace && workspace->services.save_as_document;
     case EDITOR_COMMAND_HELP_SHORTCUTS:
         return 1;
     case EDITOR_COMMAND_EDIT_CUT:
@@ -530,8 +612,7 @@ int command_registry_execute(Workspace* workspace,
         return workspace->services.save_document ?
                workspace->services.save_document(workspace, workspace->services.command_user_data) : 0;
     case EDITOR_COMMAND_FILE_SAVE_AS:
-        return workspace->services.save_document ?
-               workspace->services.save_document(workspace, workspace->services.command_user_data) : 0;
+        return command_registry_open_save_as_dialog(workspace);
     case EDITOR_COMMAND_FILE_EXIT:
         return workspace_request_action(workspace, WORKSPACE_ACTION_EXIT_APPLICATION);
     case EDITOR_COMMAND_EDIT_UNDO:

--- a/src/app/workspace_dialogs.c
+++ b/src/app/workspace_dialogs.c
@@ -13,6 +13,8 @@ static int workspace_dialog_resolve_shortcuts(Workspace* workspace,
                                               UiDialogResult result);
 static int workspace_dialog_resolve_info(Workspace* workspace,
                                          UiDialogResult result);
+static int workspace_dialog_resolve_save_as(Workspace* workspace,
+                                            UiDialogResult result);
 
 static const UiDialogButtonDefinition UI_DIALOG_BUTTONS_CONFIRM_UNSAVED[] = {
     {"Save", UI_DIALOG_RESULT_PRIMARY, 1},
@@ -68,6 +70,25 @@ static const UiDialogDefinition UI_DIALOG_DEFINITION_INFO = {
     UI_DIALOG_BUTTONS_INFO,
     (int)(sizeof(UI_DIALOG_BUTTONS_INFO) / sizeof(UI_DIALOG_BUTTONS_INFO[0])),
     workspace_dialog_resolve_info
+};
+
+static const UiDialogButtonDefinition UI_DIALOG_BUTTONS_SAVE_AS[] = {
+    {"Save", UI_DIALOG_RESULT_PRIMARY, 1},
+    {"Cancel", UI_DIALOG_RESULT_CANCEL, 0}
+};
+
+static const UiDialogDefinition UI_DIALOG_DEFINITION_SAVE_AS = {
+    {
+        UI_DIALOG_SAVE_AS,
+        "Save As",
+        "",
+        460.0f,
+        220.0f,
+        1
+    },
+    UI_DIALOG_BUTTONS_SAVE_AS,
+    (int)(sizeof(UI_DIALOG_BUTTONS_SAVE_AS) / sizeof(UI_DIALOG_BUTTONS_SAVE_AS[0])),
+    workspace_dialog_resolve_save_as
 };
 
 static int workspace_dialog_execute_action_now(Workspace* workspace,
@@ -154,6 +175,35 @@ static int workspace_dialog_resolve_info(Workspace* workspace,
     }
 }
 
+static int workspace_dialog_resolve_save_as(Workspace* workspace,
+                                            UiDialogResult result)
+{
+    if (!workspace) {
+        return 0;
+    }
+
+    switch (result) {
+    case UI_DIALOG_RESULT_PRIMARY:
+        if (!workspace->services.save_as_document ||
+            !workspace->services.save_as_document(workspace,
+                                                  workspace->services.command_user_data)) {
+            return 0;
+        }
+        workspace_dialog_close(workspace);
+        return 1;
+    case UI_DIALOG_RESULT_CANCEL:
+        workspace_dialog_close(workspace);
+        snprintf(workspace->session.status_message,
+                 sizeof(workspace->session.status_message),
+                 "Save As cancelled.");
+        return 1;
+    case UI_DIALOG_RESULT_NONE:
+    case UI_DIALOG_RESULT_SECONDARY:
+    default:
+        return 0;
+    }
+}
+
 const UiDialogDefinition* workspace_dialog_definition(UiDialogKind kind)
 {
     switch (kind) {
@@ -163,6 +213,8 @@ const UiDialogDefinition* workspace_dialog_definition(UiDialogKind kind)
         return &UI_DIALOG_DEFINITION_SHORTCUTS;
     case UI_DIALOG_INFO:
         return &UI_DIALOG_DEFINITION_INFO;
+    case UI_DIALOG_SAVE_AS:
+        return &UI_DIALOG_DEFINITION_SAVE_AS;
     case UI_DIALOG_NONE:
     default:
         return NULL;
@@ -346,5 +398,35 @@ int workspace_dialog_open_info(Workspace* workspace,
     snprintf(dialog.title, sizeof(dialog.title), "%s", title);
     snprintf(dialog.message, sizeof(dialog.message), "%s", message);
     return workspace_dialog_add_button(&dialog, &UI_DIALOG_BUTTONS_INFO[0]) &&
+           workspace_dialog_open(workspace, &dialog);
+}
+
+int workspace_dialog_open_save_as(Workspace* workspace,
+                                  const char* initial_filename,
+                                  const char* target_directory)
+{
+    UiDialogState dialog;
+    const char* directory = target_directory;
+
+    if (!workspace) {
+        return 0;
+    }
+
+    if (!directory || directory[0] == '\0') {
+        directory = ".";
+    }
+
+    workspace_dialog_apply_template(&dialog,
+                                    &UI_DIALOG_DEFINITION_SAVE_AS.dialog_template);
+    snprintf(dialog.message,
+             sizeof(dialog.message),
+             "Enter a new filename.\nThe file will be saved in the same directory:\n%s",
+             directory);
+    if (initial_filename && initial_filename[0] != '\0') {
+        snprintf(dialog.payload.text, sizeof(dialog.payload.text), "%s", initial_filename);
+    }
+
+    return workspace_dialog_add_button(&dialog, &UI_DIALOG_BUTTONS_SAVE_AS[0]) &&
+           workspace_dialog_add_button(&dialog, &UI_DIALOG_BUTTONS_SAVE_AS[1]) &&
            workspace_dialog_open(workspace, &dialog);
 }

--- a/src/ui/ui_dialog.c
+++ b/src/ui/ui_dialog.c
@@ -46,7 +46,7 @@ static void ui_dialog_render_message_lines(struct nk_context* ctx,
 }
 
 UiDialogResult ui_dialog_show(struct nk_context* ctx,
-                              const UiDialogState* dialog,
+                              UiDialogState* dialog,
                               int window_width,
                               int window_height)
 {
@@ -113,6 +113,16 @@ UiDialogResult ui_dialog_show(struct nk_context* ctx,
 
     if (nk_begin(ctx, window_title, bounds, window_flags)) {
         ui_dialog_render_message_lines(ctx, dialog);
+        if (dialog->kind == UI_DIALOG_SAVE_AS) {
+            nk_layout_row_dynamic(ctx, 20.0f, 1);
+            nk_label(ctx, "Filename", NK_TEXT_LEFT);
+            nk_layout_row_dynamic(ctx, 28.0f, 1);
+            nk_edit_string_zero_terminated(ctx,
+                                           NK_EDIT_FIELD,
+                                           dialog->payload.text,
+                                           (int)sizeof(dialog->payload.text),
+                                           nk_filter_default);
+        }
         nk_layout_row_dynamic(ctx, 12.0f, 1);
         nk_label(ctx, "", NK_TEXT_LEFT);
         if (dialog->button_count > 0) {


### PR DESCRIPTION
## Summary
- add a workspace-owned Save As dialog with editable filename input
- enable File > Save As through the command registry
- save renamed documents into the same directory as the current document
- validate filenames and keep the dialog open with a visible error when input is invalid

## Validation
- cmake --build build --config Release
- ctest --test-dir build --output-on-failure

## Releated

Closes #83 