### PR TITLE
refactor: centralize path utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ find_package(OpenGL REQUIRED)
 
 set(GLDRAW_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/base/file_utils.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/base/path_utils.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/object.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/document.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/history.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,12 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     )
 endif()
 
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ui/ui_system.c
+        PROPERTIES COMPILE_FLAGS "-Wno-c23-extensions"
+    )
+endif()
+
 add_executable(${PROJECT_NAME} ${GLDRAW_SOURCES})
 
 target_include_directories(${PROJECT_NAME}

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -6,6 +6,7 @@
 #define GLDRAW_APP_WORKSPACE_H
 
 #include <app/editor_session.h>
+#include <base/path_utils.h>
 #include <canvas/canvas_view.h>
 #include <document/history.h>
 #include <input/keymap.h>
@@ -191,7 +192,7 @@ typedef struct EditorSession {
     GraphicObject* clipboard_objects[DOCUMENT_MAX_SELECTION];
     int clipboard_count;
     unsigned int clipboard_paste_serial;
-    char current_document_path[260];
+    char current_document_path[GLDRAW_PATH_MAX];
     char status_message[256];
     unsigned int saved_revision;
     int document_dirty;

--- a/include/base/path_utils.h
+++ b/include/base/path_utils.h
@@ -1,0 +1,29 @@
+/**
+ * @file path_utils.h
+ * @brief Shared path and filename helpers.
+ */
+#ifndef GLDRAW_BASE_PATH_UTILS_H
+#define GLDRAW_BASE_PATH_UTILS_H
+
+#include <stddef.h>
+
+#define GLDRAW_PATH_MAX 260
+
+/** Return the basename portion of a path, or fallback when the path is empty. */
+const char* path_utils_basename_or_default(const char* path, const char* fallback);
+/** Copy the directory portion of a path, or "." when the path has no directory. */
+int path_utils_dirname(const char* path, char* buffer, size_t buffer_size);
+/** Case-insensitive extension test. Extension should include the leading dot. */
+int path_utils_has_extension(const char* path, const char* extension);
+/** Copy input without leading/trailing whitespace. */
+int path_utils_copy_trimmed(const char* input, char* output, size_t output_size);
+/** Validate a simple filename without path separators or reserved characters. */
+int path_utils_is_safe_filename(const char* filename);
+/** Join filename into the same directory as base_path, adding default_extension when missing. */
+int path_utils_join_same_directory(const char* base_path,
+                                   const char* filename,
+                                   const char* default_extension,
+                                   char* output,
+                                   size_t output_size);
+
+#endif /* GLDRAW_BASE_PATH_UTILS_H */

--- a/include/input/keymap.h
+++ b/include/input/keymap.h
@@ -5,6 +5,7 @@
 #ifndef GLDRAW_INPUT_KEYMAP_H
 #define GLDRAW_INPUT_KEYMAP_H
 
+#include <base/path_utils.h>
 #include <input/key_chord.h>
 
 #define KEYMAP_MAX_BINDINGS 64
@@ -28,7 +29,7 @@ typedef struct EditorKeymap {
     int default_count;
     KeyBinding user_overrides[KEYMAP_MAX_BINDINGS];
     int user_override_count;
-    char settings_path[260];
+    char settings_path[GLDRAW_PATH_MAX];
     char last_error[256];
 } EditorKeymap;
 

--- a/include/platform/file_dialog.h
+++ b/include/platform/file_dialog.h
@@ -5,6 +5,8 @@
 #ifndef GLDRAW_PLATFORM_FILE_DIALOG_H
 #define GLDRAW_PLATFORM_FILE_DIALOG_H
 
+#include <base/path_utils.h>
+
 #include <stddef.h>
 
 typedef enum PlatformFileDialogResult {

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -17,6 +17,7 @@
 #include <app/workspace.h>
 #include <base/log.h>
 #include <base/math2d.h>
+#include <base/path_utils.h>
 #include <document/persistence.h>
 #include <input/input_router.h>
 #include <platform/file_dialog.h>
@@ -28,7 +29,6 @@
 
 #include <GLFW/glfw3.h>
 
-#include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -44,7 +44,7 @@ typedef struct {
   Vec2 cursor_screen;
   int cursor_inside_canvas;
   int pending_export_png;
-  char pending_export_png_path[260];
+  char pending_export_png_path[GLDRAW_PATH_MAX];
 } Application;
 
 static int app_workspace_save(Workspace *workspace, void *user_data);
@@ -129,51 +129,17 @@ static const char *app_current_document_path(const Application *app) {
   return app_default_document_path();
 }
 
-static void app_current_document_directory(const Application *app, char *buffer,
-                                           size_t buffer_size) {
-  const char *path = app_current_document_path(app);
-  const char *cursor = NULL;
-  const char *last_separator = NULL;
-  size_t length = 0u;
-
-  if (!buffer || buffer_size == 0u) {
-    return;
-  }
-
-  buffer[0] = '\0';
-  for (cursor = path; cursor && *cursor != '\0'; ++cursor) {
-    if (*cursor == '/' || *cursor == '\\') {
-      last_separator = cursor;
-    }
-  }
-
-  if (!last_separator) {
-    snprintf(buffer, buffer_size, ".");
-    return;
-  }
-
-  length = (size_t)(last_separator - path);
-  if (length == 0u) {
-    length = 1u;
-  } else if (length == 2u && path[1] == ':') {
-    length = 3u;
-  }
-  if (length >= buffer_size) {
-    length = buffer_size - 1u;
-  }
-  memcpy(buffer, path, length);
-  buffer[length] = '\0';
-}
-
 static void app_update_save_as_dialog_message(Application *app,
                                               const char *error_text) {
-  char directory[260];
+  char directory[GLDRAW_PATH_MAX];
 
   if (!app) {
     return;
   }
 
-  app_current_document_directory(app, directory, sizeof(directory));
+  if (!path_utils_dirname(app_current_document_path(app), directory, sizeof(directory))) {
+    snprintf(directory, sizeof(directory), ".");
+  }
   if (error_text && error_text[0] != '\0') {
     snprintf(app->workspace.session.active_dialog.message,
              sizeof(app->workspace.session.active_dialog.message),
@@ -211,159 +177,11 @@ static void app_set_document_path(Application *app, const char *path) {
                              1u] = '\0';
 }
 
-static int app_copy_trimmed_filename(const char *input, char *output,
-                                     size_t output_size) {
-  const char *start = input;
-  const char *end = NULL;
-  size_t length = 0u;
-
-  if (!input || !output || output_size == 0u) {
-    return 0;
-  }
-
-  while (*start != '\0' && isspace((unsigned char)*start)) {
-    start++;
-  }
-  end = start + strlen(start);
-  while (end > start && isspace((unsigned char)*(end - 1))) {
-    end--;
-  }
-
-  length = (size_t)(end - start);
-  if (length == 0u || length >= output_size) {
-    output[0] = '\0';
-    return 0;
-  }
-
-  memcpy(output, start, length);
-  output[length] = '\0';
-  return 1;
-}
-
-static int app_filename_has_json_extension(const char *filename) {
-  size_t length = 0u;
-  const char *extension = ".json";
-  size_t extension_length = strlen(extension);
-  size_t i = 0u;
-
-  if (!filename) {
-    return 0;
-  }
-
-  length = strlen(filename);
-  if (length < extension_length) {
-    return 0;
-  }
-
-  filename += length - extension_length;
-  for (i = 0u; i < extension_length; ++i) {
-    if (tolower((unsigned char)filename[i]) !=
-        tolower((unsigned char)extension[i])) {
-      return 0;
-    }
-  }
-
-  return 1;
-}
-
-static int app_path_has_extension(const char *path, const char *extension) {
-  size_t path_length = 0u;
-  size_t extension_length = 0u;
-  size_t i = 0u;
-
-  if (!path || !extension) {
-    return 0;
-  }
-
-  path_length = strlen(path);
-  extension_length = strlen(extension);
-  if (path_length < extension_length) {
-    return 0;
-  }
-
-  path += path_length - extension_length;
-  for (i = 0u; i < extension_length; ++i) {
-    if (tolower((unsigned char)path[i]) !=
-        tolower((unsigned char)extension[i])) {
-      return 0;
-    }
-  }
-
-  return 1;
-}
-
-static int app_validate_save_as_filename(const char *filename) {
-  const char *cursor = NULL;
-
-  if (!filename || filename[0] == '\0') {
-    return 0;
-  }
-  if (strcmp(filename, ".") == 0 || strcmp(filename, "..") == 0) {
-    return 0;
-  }
-
-  for (cursor = filename; *cursor != '\0'; ++cursor) {
-    unsigned char ch = (unsigned char)*cursor;
-    if (ch < 32u || strchr("/\\:*?\"<>|", *cursor)) {
-      return 0;
-    }
-  }
-
-  return 1;
-}
-
-static int app_build_save_as_path(Application *app, const char *filename,
-                                  char *output, size_t output_size) {
-  const char *current_path = app_current_document_path(app);
-  const char *cursor = NULL;
-  const char *last_separator = NULL;
-  char final_filename[260];
-  size_t directory_length = 0u;
-  size_t filename_length = 0u;
-
-  if (!app || !filename || !output || output_size == 0u) {
-    return 0;
-  }
-
-  if (app_filename_has_json_extension(filename)) {
-    snprintf(final_filename, sizeof(final_filename), "%s", filename);
-  } else if (strlen(filename) + 5u < sizeof(final_filename)) {
-    snprintf(final_filename, sizeof(final_filename), "%s.json", filename);
-  } else {
-    return 0;
-  }
-
-  for (cursor = current_path; cursor && *cursor != '\0'; ++cursor) {
-    if (*cursor == '/' || *cursor == '\\') {
-      last_separator = cursor;
-    }
-  }
-
-  filename_length = strlen(final_filename);
-  if (!last_separator) {
-    if (filename_length + 1u > output_size) {
-      return 0;
-    }
-    snprintf(output, output_size, "%s", final_filename);
-    return 1;
-  }
-
-  directory_length = (size_t)(last_separator - current_path) + 1u;
-  if (directory_length + filename_length + 1u > output_size) {
-    return 0;
-  }
-
-  memcpy(output, current_path, directory_length);
-  memcpy(output + directory_length, final_filename, filename_length + 1u);
-  return 1;
-}
-
 static void app_suggest_png_export_filename(const Application *app,
                                             char *buffer,
                                             size_t buffer_size) {
-  const char *path = app_current_document_path(app);
-  const char *basename = path;
-  const char *cursor = NULL;
+  const char *basename = path_utils_basename_or_default(app_current_document_path(app),
+                                                        "document.json");
   size_t length = 0u;
 
   if (!buffer || buffer_size == 0u) {
@@ -371,14 +189,8 @@ static void app_suggest_png_export_filename(const Application *app,
   }
 
   buffer[0] = '\0';
-  for (cursor = path; cursor && *cursor != '\0'; ++cursor) {
-    if (*cursor == '/' || *cursor == '\\') {
-      basename = cursor + 1;
-    }
-  }
-
   length = strlen(basename);
-  if (length > 5u && app_path_has_extension(basename, ".json")) {
+  if (length > 5u && path_utils_has_extension(basename, ".json")) {
     length -= 5u;
   }
   if (length == 0u) {
@@ -404,7 +216,7 @@ static int app_copy_png_export_path(const char *selected_path,
   }
 
   path_length = strlen(selected_path);
-  if (app_path_has_extension(selected_path, ".png")) {
+  if (path_utils_has_extension(selected_path, ".png")) {
     if (path_length + 1u > output_size) {
       return 0;
     }
@@ -488,8 +300,8 @@ static int app_save_document(Application *app) {
 }
 
 static int app_save_as_document(Application *app) {
-  char filename[260];
-  char target_path[260];
+  char filename[GLDRAW_PATH_MAX];
+  char target_path[GLDRAW_PATH_MAX];
   const char *input = NULL;
 
   if (!app) {
@@ -497,14 +309,18 @@ static int app_save_as_document(Application *app) {
   }
 
   input = app->workspace.session.active_dialog.payload.text;
-  if (!app_copy_trimmed_filename(input, filename, sizeof(filename)) ||
-      !app_validate_save_as_filename(filename)) {
+  if (!path_utils_copy_trimmed(input, filename, sizeof(filename)) ||
+      !path_utils_is_safe_filename(filename)) {
     app_set_status(app, "Save As failed: invalid filename");
     app_update_save_as_dialog_message(app, "Invalid filename. Use a simple file name without path separators or reserved characters.");
     return 0;
   }
 
-  if (!app_build_save_as_path(app, filename, target_path, sizeof(target_path))) {
+  if (!path_utils_join_same_directory(app_current_document_path(app),
+                                      filename,
+                                      ".json",
+                                      target_path,
+                                      sizeof(target_path))) {
     app_set_status(app, "Save As failed: path too long");
     app_update_save_as_dialog_message(app, "Invalid filename. The resulting path is too long.");
     return 0;
@@ -561,7 +377,7 @@ static int app_load_document(Application *app) {
 }
 
 static int app_open_document_with_picker(Application *app) {
-  char selected_path[260];
+  char selected_path[GLDRAW_PATH_MAX];
   PlatformFileDialogResult result;
 
   if (!app) {
@@ -582,8 +398,8 @@ static int app_open_document_with_picker(Application *app) {
 }
 
 static int app_request_export_png(Application *app) {
-  char suggested_filename[260];
-  char selected_path[260];
+  char suggested_filename[GLDRAW_PATH_MAX];
+  char selected_path[GLDRAW_PATH_MAX];
   PlatformFileDialogResult result;
 
   if (!app) {
@@ -616,7 +432,7 @@ static int app_request_export_png(Application *app) {
 }
 
 static void app_flush_pending_export_png(Application *app) {
-  char export_path[260];
+  char export_path[GLDRAW_PATH_MAX];
 
   if (!app || !app->pending_export_png) {
     return;

--- a/src/app/command_registry.c
+++ b/src/app/command_registry.c
@@ -8,6 +8,7 @@
 #include <app/workspace_actions.h>
 #include <app/workspace_dialogs.h>
 #include <base/math2d.h>
+#include <base/path_utils.h>
 #include <canvas/canvas_view.h>
 #include <document/document.h>
 #include <document/history.h>
@@ -19,70 +20,9 @@
 
 #define CLIPBOARD_PASTE_OFFSET_PIXELS 10.0f
 
-static const char* command_registry_path_basename(const char* path)
-{
-    const char* basename = path;
-    const char* cursor = NULL;
-
-    if (!path || path[0] == '\0') {
-        return "document.json";
-    }
-
-    for (cursor = path; *cursor != '\0'; ++cursor) {
-        if (*cursor == '/' || *cursor == '\\') {
-            basename = cursor + 1;
-        }
-    }
-
-    return (basename && basename[0] != '\0') ? basename : "document.json";
-}
-
-static void command_registry_format_path_directory(const char* path,
-                                                   char* buffer,
-                                                   size_t buffer_size)
-{
-    const char* cursor = NULL;
-    const char* last_separator = NULL;
-    size_t length = 0u;
-
-    if (!buffer || buffer_size == 0u) {
-        return;
-    }
-
-    buffer[0] = '\0';
-    if (!path || path[0] == '\0') {
-        snprintf(buffer, buffer_size, ".");
-        return;
-    }
-
-    for (cursor = path; *cursor != '\0'; ++cursor) {
-        if (*cursor == '/' || *cursor == '\\') {
-            last_separator = cursor;
-        }
-    }
-
-    if (!last_separator) {
-        snprintf(buffer, buffer_size, ".");
-        return;
-    }
-
-    length = (size_t)(last_separator - path);
-    if (length == 0u) {
-        length = 1u;
-    } else if (length == 2u && path[1] == ':') {
-        length = 3u;
-    }
-    if (length >= buffer_size) {
-        length = buffer_size - 1u;
-    }
-
-    memcpy(buffer, path, length);
-    buffer[length] = '\0';
-}
-
 static int command_registry_open_save_as_dialog(Workspace* workspace)
 {
-    char directory[260];
+    char directory[GLDRAW_PATH_MAX];
     const char* path = NULL;
 
     if (!workspace) {
@@ -95,9 +35,11 @@ static int command_registry_open_save_as_dialog(Workspace* workspace)
     path = workspace->session.current_document_path[0] != '\0'
                ? workspace->session.current_document_path
                : "document.json";
-    command_registry_format_path_directory(path, directory, sizeof(directory));
+    if (!path_utils_dirname(path, directory, sizeof(directory))) {
+        snprintf(directory, sizeof(directory), ".");
+    }
     return workspace_dialog_open_save_as(workspace,
-                                         command_registry_path_basename(path),
+                                         path_utils_basename_or_default(path, "document.json"),
                                          directory);
 }
 

--- a/src/base/path_utils.c
+++ b/src/base/path_utils.c
@@ -1,0 +1,213 @@
+/**
+ * @file path_utils.c
+ * @brief Shared path and filename helpers.
+ */
+#include <base/path_utils.h>
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+static int path_utils_copy_literal(const char* text, char* buffer, size_t buffer_size)
+{
+    int written = 0;
+
+    if (!text || !buffer || buffer_size == 0u) {
+        return 0;
+    }
+
+    written = snprintf(buffer, buffer_size, "%s", text);
+    return written >= 0 && (size_t)written < buffer_size;
+}
+
+const char* path_utils_basename_or_default(const char* path, const char* fallback)
+{
+    const char* basename = path;
+    const char* cursor = NULL;
+
+    if (!fallback || fallback[0] == '\0') {
+        fallback = "";
+    }
+    if (!path || path[0] == '\0') {
+        return fallback;
+    }
+
+    for (cursor = path; *cursor != '\0'; ++cursor) {
+        if (*cursor == '/' || *cursor == '\\') {
+            basename = cursor + 1;
+        }
+    }
+
+    return (basename && basename[0] != '\0') ? basename : fallback;
+}
+
+int path_utils_dirname(const char* path, char* buffer, size_t buffer_size)
+{
+    const char* cursor = NULL;
+    const char* last_separator = NULL;
+    size_t length = 0u;
+
+    if (!buffer || buffer_size == 0u) {
+        return 0;
+    }
+
+    buffer[0] = '\0';
+    if (!path || path[0] == '\0') {
+        return path_utils_copy_literal(".", buffer, buffer_size);
+    }
+
+    for (cursor = path; *cursor != '\0'; ++cursor) {
+        if (*cursor == '/' || *cursor == '\\') {
+            last_separator = cursor;
+        }
+    }
+
+    if (!last_separator) {
+        return path_utils_copy_literal(".", buffer, buffer_size);
+    }
+
+    length = (size_t)(last_separator - path);
+    if (length == 0u) {
+        length = 1u;
+    } else if (length == 2u && path[1] == ':') {
+        length = 3u;
+    }
+    if (length >= buffer_size) {
+        return 0;
+    }
+
+    memcpy(buffer, path, length);
+    buffer[length] = '\0';
+    return 1;
+}
+
+int path_utils_has_extension(const char* path, const char* extension)
+{
+    size_t path_length = 0u;
+    size_t extension_length = 0u;
+    size_t i = 0u;
+
+    if (!path || !extension || extension[0] == '\0') {
+        return 0;
+    }
+
+    path_length = strlen(path);
+    extension_length = strlen(extension);
+    if (path_length < extension_length) {
+        return 0;
+    }
+
+    path += path_length - extension_length;
+    for (i = 0u; i < extension_length; ++i) {
+        if (tolower((unsigned char)path[i]) !=
+            tolower((unsigned char)extension[i])) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+int path_utils_copy_trimmed(const char* input, char* output, size_t output_size)
+{
+    const char* start = input;
+    const char* end = NULL;
+    size_t length = 0u;
+
+    if (!input || !output || output_size == 0u) {
+        return 0;
+    }
+
+    while (*start != '\0' && isspace((unsigned char)*start)) {
+        start++;
+    }
+    end = start + strlen(start);
+    while (end > start && isspace((unsigned char)*(end - 1))) {
+        end--;
+    }
+
+    length = (size_t)(end - start);
+    if (length == 0u || length >= output_size) {
+        output[0] = '\0';
+        return 0;
+    }
+
+    memcpy(output, start, length);
+    output[length] = '\0';
+    return 1;
+}
+
+int path_utils_is_safe_filename(const char* filename)
+{
+    const char* cursor = NULL;
+
+    if (!filename || filename[0] == '\0') {
+        return 0;
+    }
+    if (strcmp(filename, ".") == 0 || strcmp(filename, "..") == 0) {
+        return 0;
+    }
+
+    for (cursor = filename; *cursor != '\0'; ++cursor) {
+        unsigned char ch = (unsigned char)*cursor;
+        if (ch < 32u || strchr("/\\:*?\"<>|", *cursor)) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+int path_utils_join_same_directory(const char* base_path,
+                                   const char* filename,
+                                   const char* default_extension,
+                                   char* output,
+                                   size_t output_size)
+{
+    const char* cursor = NULL;
+    const char* last_separator = NULL;
+    char final_filename[GLDRAW_PATH_MAX];
+    size_t filename_length = 0u;
+    size_t directory_length = 0u;
+    size_t extension_length = default_extension ? strlen(default_extension) : 0u;
+
+    if (!base_path || !filename || !output || output_size == 0u) {
+        return 0;
+    }
+
+    if (extension_length > 0u && !path_utils_has_extension(filename, default_extension)) {
+        if (strlen(filename) + extension_length + 1u > sizeof(final_filename)) {
+            return 0;
+        }
+        snprintf(final_filename, sizeof(final_filename), "%s%s", filename, default_extension);
+    } else {
+        if (strlen(filename) + 1u > sizeof(final_filename)) {
+            return 0;
+        }
+        snprintf(final_filename, sizeof(final_filename), "%s", filename);
+    }
+
+    for (cursor = base_path; cursor && *cursor != '\0'; ++cursor) {
+        if (*cursor == '/' || *cursor == '\\') {
+            last_separator = cursor;
+        }
+    }
+
+    filename_length = strlen(final_filename);
+    if (!last_separator) {
+        if (filename_length + 1u > output_size) {
+            return 0;
+        }
+        snprintf(output, output_size, "%s", final_filename);
+        return 1;
+    }
+
+    directory_length = (size_t)(last_separator - base_path) + 1u;
+    if (directory_length + filename_length + 1u > output_size) {
+        return 0;
+    }
+
+    memcpy(output, base_path, directory_length);
+    memcpy(output + directory_length, final_filename, filename_length + 1u);
+    return 1;
+}

--- a/src/platform/file_dialog.c
+++ b/src/platform/file_dialog.c
@@ -26,7 +26,7 @@ PlatformFileDialogResult platform_file_dialog_open_document(char* out_path,
 #ifdef _WIN32
     {
         OPENFILENAMEA dialog;
-        char path_buffer[260];
+        char path_buffer[GLDRAW_PATH_MAX];
 
         memset(&dialog, 0, sizeof(dialog));
         memset(path_buffer, 0, sizeof(path_buffer));
@@ -75,7 +75,7 @@ PlatformFileDialogResult platform_file_dialog_save_png(char* out_path,
 #ifdef _WIN32
     {
         OPENFILENAMEA dialog;
-        char path_buffer[260];
+        char path_buffer[GLDRAW_PATH_MAX];
 
         memset(&dialog, 0, sizeof(dialog));
         memset(path_buffer, 0, sizeof(path_buffer));

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -214,6 +214,7 @@ static void render_prepare_pass_state(const RenderSystem* renderer)
  * @param user_param User parameter.
  * @return No return value.
  */
+#if !defined(NDEBUG)
 static void APIENTRY render_debug_callback(GLenum source,
                                            GLenum type,
                                            GLuint id,
@@ -228,7 +229,6 @@ static void APIENTRY render_debug_callback(GLenum source,
     (void)length;
     (void)user_param;
 
-#if !defined(NDEBUG)
     if (severity == GL_DEBUG_SEVERITY_NOTIFICATION) {
         return;
     }
@@ -236,11 +236,8 @@ static void APIENTRY render_debug_callback(GLenum source,
               (unsigned int)severity,
               (unsigned int)id,
               message ? (const char*)message : "(null)");
-#else
-    (void)severity;
-    (void)message;
-#endif
 }
+#endif
 
 /**
  * @brief Log frame statistics every 120 frames (debug builds only).

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -18,6 +18,7 @@
 #include <app/command_registry.h>
 #include <app/workspace_actions.h>
 #include <base/math2d.h>
+#include <base/path_utils.h>
 #include <canvas/canvas_view.h>
 #include <document/document.h>
 #include <document/history.h>
@@ -77,7 +78,7 @@ struct UiSystem {
   UiMenuBar *menu_bar;
   UiThemeTokens theme;
   char active_theme_id[UI_THEME_ID_CAPACITY];
-  char theme_settings_path[260];
+  char theme_settings_path[GLDRAW_PATH_MAX];
   UiThemeDescriptor theme_descriptors_cache[UI_THEME_DESCRIPTOR_CACHE_MAX];
   unsigned long long theme_directory_signature;
   double theme_watch_last_check_seconds;

--- a/src/ui/ui_theme.c
+++ b/src/ui/ui_theme.c
@@ -13,9 +13,9 @@
 #include <nuklear/nuklear.h>
 #include <base/file_utils.h>
 #include <base/log.h>
+#include <base/path_utils.h>
 #include <ui/ui_theme.h>
 
-#include <ctype.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -665,33 +665,6 @@ static int ui_parse_hex_color(const char* hex_text, struct nk_color* out_color)
 }
 
 /**
- * @brief Checks if path has .json extension.
- * @param path File path.
- * @return 1 if has .json extension, 0 otherwise.
- */
-static int ui_theme_path_has_json_extension(const char* path)
-{
-    size_t length = 0u;
-    const char* ext = NULL;
-
-    if (!path) {
-        return 0;
-    }
-
-    length = strlen(path);
-    if (length < 5u) {
-        return 0;
-    }
-
-    ext = path + length - 5u;
-    return (tolower((unsigned char)ext[0]) == '.') &&
-           (tolower((unsigned char)ext[1]) == 'j') &&
-           (tolower((unsigned char)ext[2]) == 's') &&
-           (tolower((unsigned char)ext[3]) == 'o') &&
-           (tolower((unsigned char)ext[4]) == 'n');
-}
-
-/**
  * @brief Computes hash of byte data.
  * @param seed Hash seed.
  * @param data Data bytes.
@@ -813,7 +786,7 @@ static int ui_theme_id_from_path(const char* path, char* out_id, size_t out_id_s
     }
 
     length = strlen(filename);
-    if (length > 5u && ui_theme_path_has_json_extension(filename)) {
+    if (length > 5u && path_utils_has_extension(filename, ".json")) {
         length -= 5u;
     }
     if (length == 0u) {
@@ -1184,7 +1157,7 @@ int ui_theme_reload_external(const char* directory_path)
             if (entry->d_name[0] == '.') {
                 continue;
             }
-            if (!ui_theme_path_has_json_extension(entry->d_name)) {
+            if (!path_utils_has_extension(entry->d_name, ".json")) {
                 continue;
             }
 
@@ -1303,7 +1276,7 @@ unsigned long long ui_theme_external_signature(const char* directory_path)
             if (entry->d_name[0] == '.') {
                 continue;
             }
-            if (!ui_theme_path_has_json_extension(entry->d_name)) {
+            if (!path_utils_has_extension(entry->d_name, ".json")) {
                 continue;
             }
 

--- a/tests/test_document_core.c
+++ b/tests/test_document_core.c
@@ -1,4 +1,5 @@
 #include <app/editor_session.h>
+#include <base/path_utils.h>
 #include <document/document.h>
 #include <document/history.h>
 #include <document/object.h>
@@ -86,6 +87,26 @@ static void expect_float_eq_impl(float actual,
     }
 }
 
+static void expect_str_eq_impl(const char* actual,
+                               const char* expected,
+                               const char* actual_expr,
+                               const char* expected_expr,
+                               const char* file,
+                               int line)
+{
+    if (!actual || !expected || strcmp(actual, expected) != 0) {
+        fprintf(stderr,
+                "%s:%d: expected %s == %s (\"%s\" != \"%s\")\n",
+                file,
+                line,
+                actual_expr,
+                expected_expr,
+                actual ? actual : "(null)",
+                expected ? expected : "(null)");
+        g_failures++;
+    }
+}
+
 #define EXPECT_TRUE(expr) expect_true_impl((expr), #expr, __FILE__, __LINE__)
 #define EXPECT_FALSE(expr) expect_true_impl(!(expr), "!(" #expr ")", __FILE__, __LINE__)
 #define EXPECT_UINT_EQ(actual, expected) \
@@ -94,6 +115,8 @@ static void expect_float_eq_impl(float actual,
     expect_int_eq_impl((actual), (expected), #actual, #expected, __FILE__, __LINE__)
 #define EXPECT_FLOAT_EQ(actual, expected) \
     expect_float_eq_impl((actual), (expected), #actual, #expected, __FILE__, __LINE__)
+#define EXPECT_STR_EQ(actual, expected) \
+    expect_str_eq_impl((actual), (expected), #actual, #expected, __FILE__, __LINE__)
 
 static GraphicObject* create_rect(float x, float y, float w, float h)
 {
@@ -379,6 +402,56 @@ static int test_persistence_rejects_invalid_json(void)
     return g_failures == 0;
 }
 
+static int test_path_utils_common_cases(void)
+{
+    char buffer[GLDRAW_PATH_MAX];
+    char small_buffer[1];
+
+    EXPECT_STR_EQ(path_utils_basename_or_default("C:\\dir\\file.json", "fallback.json"),
+                  "file.json");
+    EXPECT_STR_EQ(path_utils_basename_or_default("dir/file.json", "fallback.json"),
+                  "file.json");
+    EXPECT_STR_EQ(path_utils_basename_or_default("", "fallback.json"), "fallback.json");
+    EXPECT_STR_EQ(path_utils_basename_or_default("dir/", "fallback.json"), "fallback.json");
+
+    EXPECT_TRUE(path_utils_dirname("C:\\file.json", buffer, sizeof(buffer)));
+    EXPECT_STR_EQ(buffer, "C:\\");
+    EXPECT_TRUE(path_utils_dirname("dir/file.json", buffer, sizeof(buffer)));
+    EXPECT_STR_EQ(buffer, "dir");
+    EXPECT_TRUE(path_utils_dirname("file.json", buffer, sizeof(buffer)));
+    EXPECT_STR_EQ(buffer, ".");
+    EXPECT_FALSE(path_utils_dirname("file.json", small_buffer, sizeof(small_buffer)));
+
+    EXPECT_TRUE(path_utils_has_extension("theme.JSON", ".json"));
+    EXPECT_FALSE(path_utils_has_extension("theme.json.bak", ".json"));
+
+    EXPECT_TRUE(path_utils_copy_trimmed("  copy  ", buffer, sizeof(buffer)));
+    EXPECT_STR_EQ(buffer, "copy");
+    EXPECT_FALSE(path_utils_copy_trimmed("   ", buffer, sizeof(buffer)));
+
+    EXPECT_TRUE(path_utils_is_safe_filename("copy.json"));
+    EXPECT_FALSE(path_utils_is_safe_filename("dir/copy.json"));
+    EXPECT_FALSE(path_utils_is_safe_filename("dir\\copy.json"));
+    EXPECT_FALSE(path_utils_is_safe_filename("bad:name.json"));
+    EXPECT_FALSE(path_utils_is_safe_filename("."));
+    EXPECT_FALSE(path_utils_is_safe_filename(".."));
+
+    EXPECT_TRUE(path_utils_join_same_directory("dir/base.json",
+                                               "copy",
+                                               ".json",
+                                               buffer,
+                                               sizeof(buffer)));
+    EXPECT_STR_EQ(buffer, "dir/copy.json");
+    EXPECT_TRUE(path_utils_join_same_directory("C:\\dir\\base.json",
+                                               "copy.JSON",
+                                               ".json",
+                                               buffer,
+                                               sizeof(buffer)));
+    EXPECT_STR_EQ(buffer, "C:\\dir\\copy.JSON");
+
+    return g_failures == 0;
+}
+
 int main(void)
 {
     static const struct {
@@ -390,7 +463,8 @@ int main(void)
         {"history scalar edit undo/redo", test_history_scalar_edit_undo_redo},
         {"history translate edit undo/redo", test_history_translate_edit_undo_redo},
         {"persistence round trip", test_persistence_round_trip},
-        {"persistence rejects invalid json", test_persistence_rejects_invalid_json}
+        {"persistence rejects invalid json", test_persistence_rejects_invalid_json},
+        {"path utils common cases", test_path_utils_common_cases}
     };
     int i = 0;
     int test_count = (int)(sizeof(tests) / sizeof(tests[0]));


### PR DESCRIPTION
## Summary
- centralize shared path and filename helpers in base/path_utils
- reuse extension and path buffer rules across file workflows, keymap, and theme loading
- add focused coverage for path utility edge cases

## Validation
- cmake --build build --config Release
- ctest --test-dir build --output-on-failure
- git diff --check