### PR TITLE
refactor: extract png writer module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,12 +41,37 @@ endif()
 
 find_package(OpenGL REQUIRED)
 
+function(gldraw_apply_compile_options target_name)
+    if(MSVC)
+        target_compile_options(${target_name} PRIVATE
+            /W4
+            /permissive-
+            /utf-8
+            $<$<CONFIG:Release>:/O2 /Ob2 /DNDEBUG>
+            $<$<CONFIG:Debug>:/Od /Zi>
+        )
+    elseif(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(${target_name} PRIVATE
+            -Wall
+            -Wextra
+            -Wpedantic
+            -Wshadow
+            $<$<CONFIG:Release>:-O2 -DNDEBUG>
+            $<$<CONFIG:Debug>:-g -O0>
+        )
+    endif()
+endfunction()
+
 set(GLDRAW_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/base/file_utils.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/object.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/document.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/history.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/persistence.c
+)
+
+set(GLDRAW_IMAGE_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/image/png_writer.c
 )
 
 set(GLDRAW_SOURCES
@@ -58,6 +83,7 @@ set(GLDRAW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/file_dialog.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/window.c
     ${GLDRAW_CORE_SOURCES}
+    ${GLDRAW_IMAGE_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/canvas/canvas_view.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/input/key_chord.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/input/keymap.c
@@ -108,24 +134,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     OpenGL::GL
 )
 
-if(MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE
-        /W4
-        /permissive-
-        /utf-8
-        $<$<CONFIG:Release>:/O2 /Ob2 /DNDEBUG>
-        $<$<CONFIG:Debug>:/Od /Zi>
-    )
-elseif(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
-    target_compile_options(${PROJECT_NAME} PRIVATE
-        -Wall
-        -Wextra
-        -Wpedantic
-        -Wshadow
-        $<$<CONFIG:Release>:-O2 -DNDEBUG>
-        $<$<CONFIG:Debug>:-g -O0>
-    )
-endif()
+gldraw_apply_compile_options(${PROJECT_NAME})
 
 if(WIN32)
     target_link_libraries(${PROJECT_NAME} PRIVATE gdi32 comdlg32)
@@ -149,24 +158,7 @@ target_include_directories(gldraw_document_core_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-if(MSVC)
-    target_compile_options(gldraw_document_core_tests PRIVATE
-        /W4
-        /permissive-
-        /utf-8
-        $<$<CONFIG:Release>:/O2 /Ob2 /DNDEBUG>
-        $<$<CONFIG:Debug>:/Od /Zi>
-    )
-elseif(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
-    target_compile_options(gldraw_document_core_tests PRIVATE
-        -Wall
-        -Wextra
-        -Wpedantic
-        -Wshadow
-        $<$<CONFIG:Release>:-O2 -DNDEBUG>
-        $<$<CONFIG:Debug>:-g -O0>
-    )
-endif()
+gldraw_apply_compile_options(gldraw_document_core_tests)
 
 if(UNIX AND NOT APPLE)
     target_link_libraries(gldraw_document_core_tests PRIVATE m)
@@ -177,6 +169,24 @@ set_target_properties(gldraw_document_core_tests PROPERTIES
 )
 
 add_test(NAME gldraw_document_core_tests COMMAND $<TARGET_FILE:gldraw_document_core_tests>)
+
+add_executable(gldraw_png_writer_tests
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_png_writer.c
+    ${GLDRAW_IMAGE_SOURCES}
+)
+
+target_include_directories(gldraw_png_writer_tests
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+gldraw_apply_compile_options(gldraw_png_writer_tests)
+
+set_target_properties(gldraw_png_writer_tests PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+
+add_test(NAME gldraw_png_writer_tests COMMAND $<TARGET_FILE:gldraw_png_writer_tests>)
 
 install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION bin

--- a/include/image/png_writer.h
+++ b/include/image/png_writer.h
@@ -1,0 +1,25 @@
+/**
+ * @file png_writer.h
+ * @brief Minimal PNG writer for RGBA framebuffer exports.
+ */
+#ifndef GLDRAW_IMAGE_PNG_WRITER_H
+#define GLDRAW_IMAGE_PNG_WRITER_H
+
+/**
+ * @brief Write RGBA pixels to a PNG file.
+ *
+ * The input buffer is expected in OpenGL readback order: bottom row first,
+ * four bytes per pixel, RGBA channel order.
+ *
+ * @param path Destination file path.
+ * @param rgba_bottom_up Pixel buffer in bottom-up RGBA order.
+ * @param width Image width in pixels.
+ * @param height Image height in pixels.
+ * @return Non-zero on success, zero on failure.
+ */
+int png_writer_write_rgba_file(const char* path,
+                               const unsigned char* rgba_bottom_up,
+                               int width,
+                               int height);
+
+#endif /* GLDRAW_IMAGE_PNG_WRITER_H */

--- a/src/image/png_writer.c
+++ b/src/image/png_writer.c
@@ -1,0 +1,215 @@
+/**
+ * @file png_writer.c
+ * @brief Minimal PNG encoder used by canvas export.
+ */
+#include <image/png_writer.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static unsigned int png_crc32_update(unsigned int crc,
+                                     const unsigned char* data,
+                                     size_t size)
+{
+    size_t i = 0u;
+    int bit = 0;
+
+    crc = ~crc;
+    for (i = 0u; i < size; ++i) {
+        crc ^= data[i];
+        for (bit = 0; bit < 8; ++bit) {
+            crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
+        }
+    }
+
+    return ~crc;
+}
+
+static unsigned int png_adler32(const unsigned char* data, size_t size)
+{
+    const unsigned int mod_adler = 65521u;
+    unsigned int a = 1u;
+    unsigned int b = 0u;
+    size_t i = 0u;
+
+    for (i = 0u; i < size; ++i) {
+        a = (a + data[i]) % mod_adler;
+        b = (b + a) % mod_adler;
+    }
+
+    return (b << 16) | a;
+}
+
+static void png_store_u32_be(unsigned char bytes[4], unsigned int value)
+{
+    bytes[0] = (unsigned char)((value >> 24) & 0xFFu);
+    bytes[1] = (unsigned char)((value >> 16) & 0xFFu);
+    bytes[2] = (unsigned char)((value >> 8) & 0xFFu);
+    bytes[3] = (unsigned char)(value & 0xFFu);
+}
+
+static int png_write_u32_be(FILE* file, unsigned int value)
+{
+    unsigned char bytes[4];
+
+    if (!file) {
+        return 0;
+    }
+
+    png_store_u32_be(bytes, value);
+    return fwrite(bytes, 1u, sizeof(bytes), file) == sizeof(bytes);
+}
+
+static int png_write_chunk(FILE* file,
+                           const char type[4],
+                           const unsigned char* data,
+                           size_t size)
+{
+    unsigned int crc = 0u;
+
+    if (!file || !type || size > 0xFFFFFFFFu) {
+        return 0;
+    }
+
+    if (!png_write_u32_be(file, (unsigned int)size)) {
+        return 0;
+    }
+    if (fwrite(type, 1u, 4u, file) != 4u) {
+        return 0;
+    }
+    if (size > 0u && fwrite(data, 1u, size, file) != size) {
+        return 0;
+    }
+
+    crc = png_crc32_update(0u, (const unsigned char*)type, 4u);
+    if (size > 0u) {
+        crc = png_crc32_update(crc, data, size);
+    }
+    return png_write_u32_be(file, crc);
+}
+
+static int png_build_uncompressed_zlib(const unsigned char* data,
+                                       size_t data_size,
+                                       unsigned char** out_data,
+                                       size_t* out_size)
+{
+    size_t block_count = 0u;
+    size_t capacity = 0u;
+    size_t source_offset = 0u;
+    size_t write_offset = 0u;
+    unsigned char* output = NULL;
+    unsigned int adler = 0u;
+
+    if (!data || !out_data || !out_size) {
+        return 0;
+    }
+
+    block_count = (data_size + 65534u) / 65535u;
+    capacity = 2u + data_size + block_count * 5u + 4u;
+    output = (unsigned char*)malloc(capacity);
+    if (!output) {
+        return 0;
+    }
+
+    output[write_offset++] = 0x78u;
+    output[write_offset++] = 0x01u;
+
+    while (source_offset < data_size || (data_size == 0u && source_offset == 0u)) {
+        size_t remaining = data_size - source_offset;
+        unsigned int block_size = (remaining > 65535u) ? 65535u : (unsigned int)remaining;
+        unsigned int final_block = (source_offset + block_size >= data_size) ? 1u : 0u;
+
+        output[write_offset++] = (unsigned char)final_block;
+        output[write_offset++] = (unsigned char)(block_size & 0xFFu);
+        output[write_offset++] = (unsigned char)((block_size >> 8) & 0xFFu);
+        output[write_offset++] = (unsigned char)((~block_size) & 0xFFu);
+        output[write_offset++] = (unsigned char)(((~block_size) >> 8) & 0xFFu);
+
+        if (block_size > 0u) {
+            memcpy(output + write_offset, data + source_offset, block_size);
+            write_offset += block_size;
+            source_offset += block_size;
+        } else {
+            break;
+        }
+    }
+
+    adler = png_adler32(data, data_size);
+    output[write_offset++] = (unsigned char)((adler >> 24) & 0xFFu);
+    output[write_offset++] = (unsigned char)((adler >> 16) & 0xFFu);
+    output[write_offset++] = (unsigned char)((adler >> 8) & 0xFFu);
+    output[write_offset++] = (unsigned char)(adler & 0xFFu);
+
+    *out_data = output;
+    *out_size = write_offset;
+    return 1;
+}
+
+int png_writer_write_rgba_file(const char* path,
+                               const unsigned char* rgba_bottom_up,
+                               int width,
+                               int height)
+{
+    static const unsigned char signature[8] = {137u, 80u, 78u, 71u, 13u, 10u, 26u, 10u};
+    FILE* file = NULL;
+    unsigned char ihdr[13];
+    unsigned char* filtered = NULL;
+    unsigned char* zlib_data = NULL;
+    size_t filtered_stride = 0u;
+    size_t filtered_size = 0u;
+    size_t zlib_size = 0u;
+    int row = 0;
+    int ok = 0;
+
+    if (!path || !rgba_bottom_up || width <= 0 || height <= 0) {
+        return 0;
+    }
+
+    filtered_stride = (size_t)width * 4u + 1u;
+    filtered_size = filtered_stride * (size_t)height;
+    filtered = (unsigned char*)malloc(filtered_size);
+    if (!filtered) {
+        return 0;
+    }
+
+    for (row = 0; row < height; ++row) {
+        const unsigned char* source =
+            rgba_bottom_up + (size_t)(height - 1 - row) * (size_t)width * 4u;
+        unsigned char* target = filtered + (size_t)row * filtered_stride;
+
+        target[0] = 0u;
+        memcpy(target + 1u, source, (size_t)width * 4u);
+    }
+
+    if (!png_build_uncompressed_zlib(filtered, filtered_size, &zlib_data, &zlib_size)) {
+        free(filtered);
+        return 0;
+    }
+
+    file = fopen(path, "wb");
+    if (!file) {
+        free(zlib_data);
+        free(filtered);
+        return 0;
+    }
+
+    memset(ihdr, 0, sizeof(ihdr));
+    png_store_u32_be(&ihdr[0], (unsigned int)width);
+    png_store_u32_be(&ihdr[4], (unsigned int)height);
+    ihdr[8] = 8u;
+    ihdr[9] = 6u;
+
+    ok = fwrite(signature, 1u, sizeof(signature), file) == sizeof(signature) &&
+         png_write_chunk(file, "IHDR", ihdr, sizeof(ihdr)) &&
+         png_write_chunk(file, "IDAT", zlib_data, zlib_size) &&
+         png_write_chunk(file, "IEND", NULL, 0u);
+
+    if (fclose(file) != 0) {
+        ok = 0;
+    }
+
+    free(zlib_data);
+    free(filtered);
+    return ok;
+}

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -15,13 +15,12 @@
 #include <base/file_utils.h>
 #include <base/log.h>
 #include <base/math2d.h>
+#include <image/png_writer.h>
 
 #include <glad/glad.h>
 
 #include <math.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #define RENDER_VERTEX_STRIDE_FLOATS 6u
 
@@ -888,213 +887,6 @@ static int render_canvas_scissor_box(const RectF* viewport,
     return 1;
 }
 
-static unsigned int png_crc32_update(unsigned int crc,
-                                     const unsigned char* data,
-                                     size_t size)
-{
-    size_t i = 0u;
-    int bit = 0;
-
-    crc = ~crc;
-    for (i = 0u; i < size; ++i) {
-        crc ^= data[i];
-        for (bit = 0; bit < 8; ++bit) {
-            crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
-        }
-    }
-
-    return ~crc;
-}
-
-static unsigned int png_adler32(const unsigned char* data, size_t size)
-{
-    const unsigned int mod_adler = 65521u;
-    unsigned int a = 1u;
-    unsigned int b = 0u;
-    size_t i = 0u;
-
-    for (i = 0u; i < size; ++i) {
-        a = (a + data[i]) % mod_adler;
-        b = (b + a) % mod_adler;
-    }
-
-    return (b << 16) | a;
-}
-
-static int png_write_u32_be(FILE* file, unsigned int value)
-{
-    unsigned char bytes[4];
-
-    if (!file) {
-        return 0;
-    }
-
-    bytes[0] = (unsigned char)((value >> 24) & 0xFFu);
-    bytes[1] = (unsigned char)((value >> 16) & 0xFFu);
-    bytes[2] = (unsigned char)((value >> 8) & 0xFFu);
-    bytes[3] = (unsigned char)(value & 0xFFu);
-    return fwrite(bytes, 1u, sizeof(bytes), file) == sizeof(bytes);
-}
-
-static int png_write_chunk(FILE* file,
-                           const char type[4],
-                           const unsigned char* data,
-                           size_t size)
-{
-    unsigned int crc = 0u;
-
-    if (!file || !type || size > 0xFFFFFFFFu) {
-        return 0;
-    }
-
-    if (!png_write_u32_be(file, (unsigned int)size)) {
-        return 0;
-    }
-    if (fwrite(type, 1u, 4u, file) != 4u) {
-        return 0;
-    }
-    if (size > 0u && fwrite(data, 1u, size, file) != size) {
-        return 0;
-    }
-
-    crc = png_crc32_update(0u, (const unsigned char*)type, 4u);
-    if (size > 0u) {
-        crc = png_crc32_update(crc, data, size);
-    }
-    return png_write_u32_be(file, crc);
-}
-
-static int png_build_uncompressed_zlib(const unsigned char* data,
-                                       size_t data_size,
-                                       unsigned char** out_data,
-                                       size_t* out_size)
-{
-    size_t block_count = 0u;
-    size_t capacity = 0u;
-    size_t source_offset = 0u;
-    size_t write_offset = 0u;
-    unsigned char* output = NULL;
-    unsigned int adler = 0u;
-
-    if (!data || !out_data || !out_size) {
-        return 0;
-    }
-
-    block_count = (data_size + 65534u) / 65535u;
-    capacity = 2u + data_size + block_count * 5u + 4u;
-    output = (unsigned char*)malloc(capacity);
-    if (!output) {
-        return 0;
-    }
-
-    output[write_offset++] = 0x78u;
-    output[write_offset++] = 0x01u;
-
-    while (source_offset < data_size || (data_size == 0u && source_offset == 0u)) {
-        size_t remaining = data_size - source_offset;
-        unsigned int block_size = (remaining > 65535u) ? 65535u : (unsigned int)remaining;
-        unsigned int final_block = (source_offset + block_size >= data_size) ? 1u : 0u;
-
-        output[write_offset++] = (unsigned char)final_block;
-        output[write_offset++] = (unsigned char)(block_size & 0xFFu);
-        output[write_offset++] = (unsigned char)((block_size >> 8) & 0xFFu);
-        output[write_offset++] = (unsigned char)((~block_size) & 0xFFu);
-        output[write_offset++] = (unsigned char)(((~block_size) >> 8) & 0xFFu);
-
-        if (block_size > 0u) {
-            memcpy(output + write_offset, data + source_offset, block_size);
-            write_offset += block_size;
-            source_offset += block_size;
-        } else {
-            break;
-        }
-    }
-
-    adler = png_adler32(data, data_size);
-    output[write_offset++] = (unsigned char)((adler >> 24) & 0xFFu);
-    output[write_offset++] = (unsigned char)((adler >> 16) & 0xFFu);
-    output[write_offset++] = (unsigned char)((adler >> 8) & 0xFFu);
-    output[write_offset++] = (unsigned char)(adler & 0xFFu);
-
-    *out_data = output;
-    *out_size = write_offset;
-    return 1;
-}
-
-static int png_write_rgba_file(const char* path,
-                               const unsigned char* rgba_bottom_up,
-                               int width,
-                               int height)
-{
-    static const unsigned char signature[8] = {137u, 80u, 78u, 71u, 13u, 10u, 26u, 10u};
-    FILE* file = NULL;
-    unsigned char ihdr[13];
-    unsigned char* filtered = NULL;
-    unsigned char* zlib_data = NULL;
-    size_t filtered_stride = 0u;
-    size_t filtered_size = 0u;
-    size_t zlib_size = 0u;
-    int row = 0;
-    int ok = 0;
-
-    if (!path || !rgba_bottom_up || width <= 0 || height <= 0) {
-        return 0;
-    }
-
-    filtered_stride = (size_t)width * 4u + 1u;
-    filtered_size = filtered_stride * (size_t)height;
-    filtered = (unsigned char*)malloc(filtered_size);
-    if (!filtered) {
-        return 0;
-    }
-
-    for (row = 0; row < height; ++row) {
-        const unsigned char* source =
-            rgba_bottom_up + (size_t)(height - 1 - row) * (size_t)width * 4u;
-        unsigned char* target = filtered + (size_t)row * filtered_stride;
-
-        target[0] = 0u;
-        memcpy(target + 1u, source, (size_t)width * 4u);
-    }
-
-    if (!png_build_uncompressed_zlib(filtered, filtered_size, &zlib_data, &zlib_size)) {
-        free(filtered);
-        return 0;
-    }
-
-    file = fopen(path, "wb");
-    if (!file) {
-        free(zlib_data);
-        free(filtered);
-        return 0;
-    }
-
-    memset(ihdr, 0, sizeof(ihdr));
-    ihdr[0] = (unsigned char)(((unsigned int)width >> 24) & 0xFFu);
-    ihdr[1] = (unsigned char)(((unsigned int)width >> 16) & 0xFFu);
-    ihdr[2] = (unsigned char)(((unsigned int)width >> 8) & 0xFFu);
-    ihdr[3] = (unsigned char)((unsigned int)width & 0xFFu);
-    ihdr[4] = (unsigned char)(((unsigned int)height >> 24) & 0xFFu);
-    ihdr[5] = (unsigned char)(((unsigned int)height >> 16) & 0xFFu);
-    ihdr[6] = (unsigned char)(((unsigned int)height >> 8) & 0xFFu);
-    ihdr[7] = (unsigned char)((unsigned int)height & 0xFFu);
-    ihdr[8] = 8u;
-    ihdr[9] = 6u;
-
-    ok = fwrite(signature, 1u, sizeof(signature), file) == sizeof(signature) &&
-         png_write_chunk(file, "IHDR", ihdr, sizeof(ihdr)) &&
-         png_write_chunk(file, "IDAT", zlib_data, zlib_size) &&
-         png_write_chunk(file, "IEND", NULL, 0u);
-
-    if (fclose(file) != 0) {
-        ok = 0;
-    }
-
-    free(zlib_data);
-    free(filtered);
-    return ok;
-}
-
 /**
  * @brief Create the rendering system and initialize GPU resources.
  * @param window Already-initialized platform window.
@@ -1360,7 +1152,7 @@ int render_system_export_png(RenderSystem* renderer,
     glPixelStorei(GL_PACK_ALIGNMENT, previous_pack_alignment);
 
     if (glGetError() == GL_NO_ERROR) {
-        ok = png_write_rgba_file(path, pixels, canvas_box[2], canvas_box[3]);
+        ok = png_writer_write_rgba_file(path, pixels, canvas_box[2], canvas_box[3]);
     }
 
     free(pixels);

--- a/tests/test_png_writer.c
+++ b/tests/test_png_writer.c
@@ -1,0 +1,111 @@
+#include <image/png_writer.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int make_temp_path(char* buffer, size_t buffer_size, const char* suffix)
+{
+    char base_name[L_tmpnam];
+
+    if (!buffer || buffer_size == 0u || !suffix) {
+        return 0;
+    }
+
+#ifdef _WIN32
+    if (tmpnam_s(base_name, sizeof(base_name)) != 0) {
+        return 0;
+    }
+#else
+    if (!tmpnam(base_name)) {
+        return 0;
+    }
+#endif
+
+    if (snprintf(buffer, buffer_size, "%s%s", base_name, suffix) >= (int)buffer_size) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static unsigned int read_u32_be(const unsigned char bytes[4])
+{
+    return ((unsigned int)bytes[0] << 24) |
+           ((unsigned int)bytes[1] << 16) |
+           ((unsigned int)bytes[2] << 8) |
+           (unsigned int)bytes[3];
+}
+
+int main(void)
+{
+    static const unsigned char expected_signature[8] = {
+        137u, 80u, 78u, 71u, 13u, 10u, 26u, 10u
+    };
+    const unsigned char pixels[16] = {
+        255u, 0u, 0u, 255u,
+        0u, 255u, 0u, 255u,
+        0u, 0u, 255u, 255u,
+        255u, 255u, 255u, 255u
+    };
+    unsigned char header[33];
+    char path[L_tmpnam + 16];
+    FILE* file = NULL;
+    int failed = 0;
+
+    if (!make_temp_path(path, sizeof(path), ".png")) {
+        fprintf(stderr, "failed to create temporary path\n");
+        return 1;
+    }
+
+    if (!png_writer_write_rgba_file(path, pixels, 2, 2)) {
+        fprintf(stderr, "failed to write png\n");
+        return 1;
+    }
+
+    file = fopen(path, "rb");
+    if (!file) {
+        fprintf(stderr, "failed to reopen png\n");
+        remove(path);
+        return 1;
+    }
+
+    if (fread(header, 1u, sizeof(header), file) != sizeof(header)) {
+        fprintf(stderr, "failed to read png header\n");
+        failed = 1;
+    }
+    fclose(file);
+
+    if (!failed && memcmp(header, expected_signature, sizeof(expected_signature)) != 0) {
+        fprintf(stderr, "invalid png signature\n");
+        failed = 1;
+    }
+    if (!failed && read_u32_be(&header[8]) != 13u) {
+        fprintf(stderr, "invalid IHDR chunk length\n");
+        failed = 1;
+    }
+    if (!failed && memcmp(&header[12], "IHDR", 4u) != 0) {
+        fprintf(stderr, "missing IHDR chunk\n");
+        failed = 1;
+    }
+    if (!failed && read_u32_be(&header[16]) != 2u) {
+        fprintf(stderr, "invalid IHDR width\n");
+        failed = 1;
+    }
+    if (!failed && read_u32_be(&header[20]) != 2u) {
+        fprintf(stderr, "invalid IHDR height\n");
+        failed = 1;
+    }
+    if (!failed && (header[24] != 8u || header[25] != 6u)) {
+        fprintf(stderr, "invalid IHDR color format\n");
+        failed = 1;
+    }
+
+    remove(path);
+    if (failed) {
+        return 1;
+    }
+
+    printf("[PASS] png writer creates rgba png header\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- move PNG encoding from render_system into image/png_writer
- keep render_system focused on framebuffer readback and export orchestration
- add a png writer test that verifies PNG signature and IHDR metadata
- centralize repeated C target warning options in CMake

## Validation
- cmake --build build --config Release
- ctest --test-dir build --output-on-failure
- git diff --check