### PR TITLE
refactor: split ui context menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ set(GLDRAW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/input/input_router.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/tool_controller.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_system.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_context_menu.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_system.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_dialog.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_menu_def.c

--- a/src/ui/ui_context_menu.c
+++ b/src/ui/ui_context_menu.c
@@ -1,0 +1,339 @@
+/**
+ * @file ui_context_menu.c
+ * @brief Canvas context menu implementation.
+ */
+#include "ui/ui_context_menu.h"
+#include "ui/ui_system_internal.h"
+
+#include <app/command_registry.h>
+#include <base/math2d.h>
+#include <tools/tool_controller.h>
+
+#include <stdio.h>
+
+#define UI_CONTEXT_MENU_WIDTH 220.0f
+#define UI_CONTEXT_MENU_HEIGHT 240.0f
+#define UI_CONTEXT_MENU_ANCHOR_SIZE 1.0f
+
+static float ui_context_menu_clampf(float value, float min_value, float max_value) {
+  if (value < min_value) {
+    return min_value;
+  }
+  if (value > max_value) {
+    return max_value;
+  }
+  return value;
+}
+
+static ToolContext ui_context_menu_tool_context(Workspace *workspace) {
+  ToolContext context;
+
+  context.workspace = workspace;
+  context.document = &workspace->core.document;
+  context.history = &workspace->core.history;
+  context.canvas = &workspace->core.canvas;
+  context.selection = &workspace->session.selection;
+  return context;
+}
+
+static RectF ui_context_menu_popup_bounds(const UiContextMenuState *menu) {
+  RectF bounds = {0.0f, 0.0f, UI_CONTEXT_MENU_WIDTH, UI_CONTEXT_MENU_HEIGHT};
+
+  if (!menu) {
+    return bounds;
+  }
+
+  bounds.x = ui_context_menu_clampf(
+      menu->anchor_screen.x, menu->canvas_bounds.x,
+      menu->canvas_bounds.x + menu->canvas_bounds.w - UI_CONTEXT_MENU_WIDTH);
+  bounds.y = ui_context_menu_clampf(
+      menu->anchor_screen.y, menu->canvas_bounds.y,
+      menu->canvas_bounds.y + menu->canvas_bounds.h - UI_CONTEXT_MENU_HEIGHT);
+  return bounds;
+}
+
+static void ui_context_menu_open(UiSystem *ui, Workspace *workspace,
+                                 Vec2 screen_pos) {
+  RectF canvas_bounds;
+
+  if (!ui || !workspace) {
+    return;
+  }
+
+  canvas_bounds = ui->layout_snapshot.canvas_content_bounds;
+  if (canvas_bounds.w <= 1.0f || canvas_bounds.h <= 1.0f) {
+    canvas_bounds = ui->content_bounds;
+  }
+
+  if (canvas_bounds.w <= 0.0f || canvas_bounds.h <= 0.0f ||
+      !rectf_contains_point(&canvas_bounds, screen_pos)) {
+    return;
+  }
+
+  ui->context_menu.open = 1;
+  ui->context_menu.close_requested = 0;
+  ui->context_menu.mode = workspace->session.selection.count > 0
+                              ? UI_CONTEXT_MENU_MODE_SELECTION
+                              : UI_CONTEXT_MENU_MODE_TOOLS;
+  ui->context_menu.anchor_screen = screen_pos;
+  ui->context_menu.canvas_bounds = canvas_bounds;
+  ui->context_menu.popup_bounds = ui_context_menu_popup_bounds(&ui->context_menu);
+}
+
+static void ui_context_menu_format_command_label(const Workspace *workspace,
+                                                 const char *label,
+                                                 const char *command_id,
+                                                 KeyScope scope,
+                                                 char *buffer,
+                                                 size_t buffer_size) {
+  char shortcut[64];
+
+  if (!buffer || buffer_size == 0u) {
+    return;
+  }
+
+  buffer[0] = '\0';
+  if (!label) {
+    return;
+  }
+
+  shortcut[0] = '\0';
+  if (workspace && command_id && command_id[0] != '\0') {
+    keymap_format_command_shortcut(&workspace->session.keymap, command_id, scope,
+                                   shortcut, sizeof(shortcut));
+  }
+
+  if (shortcut[0] != '\0') {
+    snprintf(buffer, buffer_size, "%-18s %s", label, shortcut);
+  } else {
+    snprintf(buffer, buffer_size, "%s", label);
+  }
+}
+
+static int ui_context_menu_item(UiSystem *ui, const char *label,
+                                const char *command_id, EditorCommand command,
+                                Workspace *workspace) {
+  char item_label[96];
+  ToolContext context;
+
+  if (!ui || !ui->ctx || !label || !workspace) {
+    return 0;
+  }
+
+  ui_context_menu_format_command_label(workspace, label, command_id,
+                                       KEY_SCOPE_GLOBAL, item_label,
+                                       sizeof(item_label));
+  if (!nk_button_label(ui->ctx, item_label)) {
+    return 0;
+  }
+
+  context = ui_context_menu_tool_context(workspace);
+  command_registry_execute(workspace, &context, command);
+  return 1;
+}
+
+static void ui_context_menu_separator(UiSystem *ui) {
+  if (!ui || !ui->ctx) {
+    return;
+  }
+
+  nk_layout_row_dynamic(ui->ctx, 8.0f, 1);
+  nk_spacing(ui->ctx, 1);
+}
+
+static int ui_context_menu_build_tools(UiSystem *ui, Workspace *workspace) {
+  const ToolKind active_tool = workspace->core.tools.active_kind;
+
+  nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
+  if (active_tool == TOOL_KIND_SELECT) {
+    nk_label(ui->ctx, "Select Tool (V)", NK_TEXT_LEFT);
+  } else if (ui_context_menu_item(ui, "Select Tool", "tool.select",
+                                  EDITOR_COMMAND_TOOL_SELECT, workspace)) {
+    return 1;
+  }
+
+  if (active_tool == TOOL_KIND_PAN) {
+    nk_label(ui->ctx, "Pan Tool (H)", NK_TEXT_LEFT);
+  } else if (ui_context_menu_item(ui, "Pan Tool", "tool.pan",
+                                  EDITOR_COMMAND_TOOL_PAN, workspace)) {
+    return 1;
+  }
+
+  if (active_tool == TOOL_KIND_LINE) {
+    nk_label(ui->ctx, "Line Tool (L)", NK_TEXT_LEFT);
+  } else if (ui_context_menu_item(ui, "Line Tool", "tool.line",
+                                  EDITOR_COMMAND_TOOL_LINE, workspace)) {
+    return 1;
+  }
+
+  if (active_tool == TOOL_KIND_RECT) {
+    nk_label(ui->ctx, "Rectangle Tool (R)", NK_TEXT_LEFT);
+  } else if (ui_context_menu_item(ui, "Rectangle Tool", "tool.rect",
+                                  EDITOR_COMMAND_TOOL_RECT, workspace)) {
+    return 1;
+  }
+
+  if (active_tool == TOOL_KIND_ELLIPSE) {
+    nk_label(ui->ctx, "Ellipse Tool (E)", NK_TEXT_LEFT);
+  } else if (ui_context_menu_item(ui, "Ellipse Tool", "tool.ellipse",
+                                  EDITOR_COMMAND_TOOL_ELLIPSE, workspace)) {
+    return 1;
+  }
+
+  ui_context_menu_separator(ui);
+  nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
+  if (ui_context_menu_item(ui, "Zoom to Fit", "view.zoom_fit",
+                           EDITOR_COMMAND_VIEW_ZOOM_FIT, workspace)) {
+    return 1;
+  }
+
+  ui_context_menu_separator(ui);
+  nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
+  if (workspace->core.canvas.show_grid) {
+    if (ui_context_menu_item(ui, "Hide Grid", "view.toggle_grid",
+                             EDITOR_COMMAND_VIEW_TOGGLE_GRID, workspace)) {
+      return 1;
+    }
+  } else if (ui_context_menu_item(ui, "Show Grid", "view.toggle_grid",
+                                  EDITOR_COMMAND_VIEW_TOGGLE_GRID,
+                                  workspace)) {
+    return 1;
+  }
+
+  return 0;
+}
+
+static int ui_context_menu_build_selection(UiSystem *ui, Workspace *workspace) {
+  nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
+  if (ui_context_menu_item(ui, "Copy", "edit.copy", EDITOR_COMMAND_EDIT_COPY,
+                           workspace)) {
+    return 1;
+  }
+  if (ui_context_menu_item(ui, "Paste", "edit.paste", EDITOR_COMMAND_EDIT_PASTE,
+                           workspace)) {
+    return 1;
+  }
+  if (ui_context_menu_item(ui, "Delete", "edit.delete",
+                           EDITOR_COMMAND_EDIT_DELETE, workspace)) {
+    return 1;
+  }
+
+  return 0;
+}
+
+void ui_context_menu_reset(UiSystem *ui) {
+  if (!ui) {
+    return;
+  }
+
+  ui->context_menu.open = 0;
+  ui->context_menu.close_requested = 0;
+  ui->context_menu.mode = UI_CONTEXT_MENU_MODE_TOOLS;
+  ui->context_menu.anchor_screen = vec2_make(0.0f, 0.0f);
+  ui->context_menu.canvas_bounds = (RectF){0.0f, 0.0f, 0.0f, 0.0f};
+  ui->context_menu.popup_bounds = (RectF){0.0f, 0.0f, 0.0f, 0.0f};
+}
+
+int ui_context_menu_is_open(const UiSystem *ui) {
+  return ui && ui->context_menu.open;
+}
+
+void ui_context_menu_build(UiSystem *ui, Workspace *workspace) {
+  RectF canvas_bounds;
+  RectF host_bounds;
+  RectF popup_bounds;
+  struct nk_rect nk_host_bounds;
+  struct nk_rect nk_popup_bounds;
+  int is_open = 0;
+  int menu_action_triggered = 0;
+
+  if (!ui || !ui->ctx || !workspace || !ui->context_menu.open) {
+    return;
+  }
+
+  canvas_bounds = ui->context_menu.canvas_bounds;
+  if (canvas_bounds.w <= 0.0f || canvas_bounds.h <= 0.0f) {
+    ui_context_menu_reset(ui);
+    return;
+  }
+
+  popup_bounds = ui_context_menu_popup_bounds(&ui->context_menu);
+  ui->context_menu.popup_bounds = popup_bounds;
+
+  host_bounds.x = popup_bounds.x;
+  host_bounds.y = popup_bounds.y;
+  host_bounds.w = UI_CONTEXT_MENU_ANCHOR_SIZE;
+  host_bounds.h = UI_CONTEXT_MENU_ANCHOR_SIZE;
+
+  /* Popup APIs need an active Nuklear window/panel. Keep the host window to a
+   * single pixel so the menu does not visually cover the canvas. */
+  nk_host_bounds =
+      nk_rect(host_bounds.x, host_bounds.y, host_bounds.w, host_bounds.h);
+  nk_popup_bounds =
+      nk_rect(0.0f, 0.0f, popup_bounds.w, popup_bounds.h);
+
+  if (nk_begin(ui->ctx, "Canvas Context Host", nk_host_bounds,
+               NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND |
+                   NK_WINDOW_NO_INPUT)) {
+    is_open = nk_popup_begin(ui->ctx, NK_POPUP_DYNAMIC, "Canvas Context Menu",
+                             NK_WINDOW_NO_SCROLLBAR, nk_popup_bounds);
+    if (is_open) {
+      if (ui->context_menu.close_requested) {
+        nk_popup_close(ui->ctx);
+      } else if (ui->context_menu.mode == UI_CONTEXT_MENU_MODE_SELECTION) {
+        menu_action_triggered = ui_context_menu_build_selection(ui, workspace);
+      } else {
+        menu_action_triggered = ui_context_menu_build_tools(ui, workspace);
+      }
+
+      if (ui->context_menu.close_requested || menu_action_triggered) {
+        nk_popup_close(ui->ctx);
+      }
+      nk_popup_end(ui->ctx);
+    }
+  }
+  nk_end(ui->ctx);
+
+  if (!is_open || ui->context_menu.close_requested || menu_action_triggered) {
+    ui_context_menu_reset(ui);
+  }
+}
+
+int ui_context_menu_handle_key(UiSystem *ui, int key, int action) {
+  if (!ui || action != GLFW_PRESS) {
+    return 0;
+  }
+
+  if (key == GLFW_KEY_ESCAPE && ui->context_menu.open) {
+    ui->context_menu.close_requested = 1;
+    return 1;
+  }
+
+  return 0;
+}
+
+int ui_context_menu_handle_mouse_button(UiSystem *ui, Workspace *workspace,
+                                        Vec2 screen_pos, int button,
+                                        int action) {
+  if (!ui || !workspace || action != GLFW_PRESS || ui->modal_active) {
+    return 0;
+  }
+
+  if (ui->context_menu.open && button == GLFW_MOUSE_BUTTON_LEFT) {
+    /* Match common desktop behavior: clicking blank canvas dismisses the
+     * context menu immediately instead of waiting for popup internals. */
+    if (!rectf_contains_point(&ui->context_menu.popup_bounds, screen_pos)) {
+      ui_context_menu_reset(ui);
+      return 1;
+    }
+  }
+
+  if (button == GLFW_MOUSE_BUTTON_RIGHT) {
+    /* Open the canvas menu from the input path so tools never see the same
+     * right-click as a drawing gesture. */
+    ui_context_menu_open(ui, workspace, screen_pos);
+    return ui->context_menu.open;
+  }
+
+  return 0;
+}

--- a/src/ui/ui_context_menu.h
+++ b/src/ui/ui_context_menu.h
@@ -1,0 +1,23 @@
+/**
+ * @file ui_context_menu.h
+ * @brief Canvas context menu behavior for the UI system.
+ */
+#ifndef GLDRAW_UI_CONTEXT_MENU_H
+#define GLDRAW_UI_CONTEXT_MENU_H
+
+#include <base/types.h>
+
+struct UiSystem;
+struct Workspace;
+
+void ui_context_menu_reset(struct UiSystem *ui);
+int ui_context_menu_is_open(const struct UiSystem *ui);
+void ui_context_menu_build(struct UiSystem *ui, struct Workspace *workspace);
+int ui_context_menu_handle_key(struct UiSystem *ui, int key, int action);
+int ui_context_menu_handle_mouse_button(struct UiSystem *ui,
+                                        struct Workspace *workspace,
+                                        Vec2 screen_pos,
+                                        int button,
+                                        int action);
+
+#endif /* GLDRAW_UI_CONTEXT_MENU_H */

--- a/src/ui/ui_system.c
+++ b/src/ui/ui_system.c
@@ -15,7 +15,6 @@
 #include <ui/ui_dialog.h>
 
 #include <app/workspace.h>
-#include <app/command_registry.h>
 #include <app/workspace_actions.h>
 #include <base/math2d.h>
 #include <canvas/canvas_view.h>
@@ -37,6 +36,8 @@
 
 #include "nuklear/nuklear.h"
 #include "nuklear/nuklear_glfw_gl3.h"
+#include "ui/ui_context_menu.h"
+#include "ui/ui_system_internal.h"
 #include <ui/ui_theme.h>
 
 #include <math.h>
@@ -47,56 +48,9 @@
 #define UI_MAX_VERTEX_BUFFER (512 * 1024)
 #define UI_MAX_ELEMENT_BUFFER (128 * 1024)
 #define UI_MIN_CANVAS_WIDTH 320.0f
-#define UI_THEME_ID_CAPACITY 64
 #define UI_THEME_SETTINGS_PATH "gldraw.settings.json"
 #define UI_THEME_DIRECTORY_PATH "themes"
-#define UI_THEME_DESCRIPTOR_CACHE_MAX 64
 #define UI_THEME_WATCH_INTERVAL_SECONDS 0.35
-#define UI_CONTEXT_MENU_WIDTH 220.0f
-#define UI_CONTEXT_MENU_HEIGHT 240.0f
-#define UI_CONTEXT_MENU_ANCHOR_SIZE 1.0f
-
-typedef enum UiContextMenuMode {
-  UI_CONTEXT_MENU_MODE_TOOLS = 0,
-  UI_CONTEXT_MENU_MODE_SELECTION
-} UiContextMenuMode;
-
-typedef struct UiContextMenuState {
-  int open;
-  int close_requested;
-  UiContextMenuMode mode;
-  Vec2 anchor_screen;
-  RectF canvas_bounds;
-  RectF popup_bounds;
-} UiContextMenuState;
-
-struct UiSystem {
-  struct nk_glfw glfw;
-  struct nk_context *ctx;
-  GLFWwindow *window_handle;
-  UiMenuBar *menu_bar;
-  UiThemeTokens theme;
-  char active_theme_id[UI_THEME_ID_CAPACITY];
-  char theme_settings_path[260];
-  UiThemeDescriptor theme_descriptors_cache[UI_THEME_DESCRIPTOR_CACHE_MAX];
-  unsigned long long theme_directory_signature;
-  double theme_watch_last_check_seconds;
-  RectF appbar_bounds;
-  RectF rail_bounds;
-  RectF panel_bounds;
-  RectF status_bounds;
-  RectF content_bounds;
-  WorkspaceLayout layout_snapshot;
-  float inspector_anim_t;
-  int inspector_target_visible;
-  int inspector_anim_initialized;
-  int inspector_edit_active;
-  DocumentSnapshot inspector_edit_before_snapshot;
-  SelectionSet inspector_edit_before_selection;
-  int modal_active;
-  UiContextMenuState context_menu;
-  double last_frame_seconds;
-};
 
 typedef enum UiThemeReloadReason {
   UI_THEME_RELOAD_REASON_STARTUP = 0,
@@ -105,10 +59,6 @@ typedef enum UiThemeReloadReason {
 } UiThemeReloadReason;
 
 static ToolContext ui_tool_context(Workspace *workspace);
-static void ui_context_menu_reset(UiSystem *ui);
-static RectF ui_context_menu_popup_bounds(const UiContextMenuState *menu);
-static void ui_context_menu_open(UiSystem *ui, Workspace *workspace,
-                                 Vec2 screen_pos);
 static int ui_hover_overlays_allowed(const UiSystem *ui);
 
 /**
@@ -379,262 +329,6 @@ static RectF ui_clamp_rect_to_window(RectF rect, RectF window_bounds) {
   return rect;
 }
 
-static void ui_context_menu_reset(UiSystem *ui) {
-  if (!ui) {
-    return;
-  }
-
-  ui->context_menu.open = 0;
-  ui->context_menu.close_requested = 0;
-  ui->context_menu.mode = UI_CONTEXT_MENU_MODE_TOOLS;
-  ui->context_menu.anchor_screen = vec2_make(0.0f, 0.0f);
-  ui->context_menu.canvas_bounds = (RectF){0.0f, 0.0f, 0.0f, 0.0f};
-  ui->context_menu.popup_bounds = (RectF){0.0f, 0.0f, 0.0f, 0.0f};
-}
-
-static RectF ui_context_menu_popup_bounds(const UiContextMenuState *menu) {
-  RectF bounds = {0.0f, 0.0f, UI_CONTEXT_MENU_WIDTH, UI_CONTEXT_MENU_HEIGHT};
-
-  if (!menu) {
-    return bounds;
-  }
-
-  bounds.x = ui_clampf(menu->anchor_screen.x, menu->canvas_bounds.x,
-                       menu->canvas_bounds.x + menu->canvas_bounds.w -
-                           UI_CONTEXT_MENU_WIDTH);
-  bounds.y = ui_clampf(menu->anchor_screen.y, menu->canvas_bounds.y,
-                       menu->canvas_bounds.y + menu->canvas_bounds.h -
-                           UI_CONTEXT_MENU_HEIGHT);
-  return bounds;
-}
-
-static void ui_context_menu_open(UiSystem *ui, Workspace *workspace,
-                                 Vec2 screen_pos) {
-  RectF canvas_bounds;
-
-  if (!ui || !workspace) {
-    return;
-  }
-
-  canvas_bounds = ui->layout_snapshot.canvas_content_bounds;
-  if (canvas_bounds.w <= 1.0f || canvas_bounds.h <= 1.0f) {
-    canvas_bounds = ui->content_bounds;
-  }
-
-  if (canvas_bounds.w <= 0.0f || canvas_bounds.h <= 0.0f ||
-      !rectf_contains_point(&canvas_bounds, screen_pos)) {
-    return;
-  }
-
-  ui->context_menu.open = 1;
-  ui->context_menu.close_requested = 0;
-  ui->context_menu.mode = workspace->session.selection.count > 0
-                              ? UI_CONTEXT_MENU_MODE_SELECTION
-                              : UI_CONTEXT_MENU_MODE_TOOLS;
-  ui->context_menu.anchor_screen = screen_pos;
-  ui->context_menu.canvas_bounds = canvas_bounds;
-  ui->context_menu.popup_bounds = ui_context_menu_popup_bounds(&ui->context_menu);
-}
-
-static void ui_format_command_label(const Workspace *workspace,
-                                    const char *label,
-                                    const char *command_id, KeyScope scope,
-                                    char *buffer, size_t buffer_size) {
-  char shortcut[64];
-
-  if (!buffer || buffer_size == 0u) {
-    return;
-  }
-
-  buffer[0] = '\0';
-  if (!label) {
-    return;
-  }
-
-  shortcut[0] = '\0';
-  if (workspace && command_id && command_id[0] != '\0') {
-    keymap_format_command_shortcut(&workspace->session.keymap, command_id, scope,
-                                   shortcut, sizeof(shortcut));
-  }
-
-  if (shortcut[0] != '\0') {
-    snprintf(buffer, buffer_size, "%-18s %s", label, shortcut);
-  } else {
-    snprintf(buffer, buffer_size, "%s", label);
-  }
-}
-
-static int ui_context_menu_item(UiSystem *ui, const char *label,
-                                const char *command_id, EditorCommand command,
-                                Workspace *workspace) {
-  char item_label[96];
-  ToolContext context;
-
-  if (!ui || !ui->ctx || !label || !workspace) {
-    return 0;
-  }
-
-  ui_format_command_label(workspace, label, command_id, KEY_SCOPE_GLOBAL,
-                          item_label, sizeof(item_label));
-  if (!nk_button_label(ui->ctx, item_label)) {
-    return 0;
-  }
-
-  context = ui_tool_context(workspace);
-  command_registry_execute(workspace, &context, command);
-  return 1;
-}
-
-static void ui_context_menu_separator(UiSystem *ui) {
-  if (!ui || !ui->ctx) {
-    return;
-  }
-
-  nk_layout_row_dynamic(ui->ctx, 8.0f, 1);
-  nk_spacing(ui->ctx, 1);
-}
-
-static int ui_context_menu_build_tools(UiSystem *ui, Workspace *workspace) {
-  const ToolKind active_tool = workspace->core.tools.active_kind;
-
-  nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
-  if (active_tool == TOOL_KIND_SELECT) {
-    nk_label(ui->ctx, "Select Tool (V)", NK_TEXT_LEFT);
-  } else if (ui_context_menu_item(ui, "Select Tool", "tool.select",
-                                  EDITOR_COMMAND_TOOL_SELECT, workspace)) {
-    return 1;
-  }
-
-  if (active_tool == TOOL_KIND_PAN) {
-    nk_label(ui->ctx, "Pan Tool (H)", NK_TEXT_LEFT);
-  } else if (ui_context_menu_item(ui, "Pan Tool", "tool.pan",
-                                  EDITOR_COMMAND_TOOL_PAN, workspace)) {
-    return 1;
-  }
-
-  if (active_tool == TOOL_KIND_LINE) {
-    nk_label(ui->ctx, "Line Tool (L)", NK_TEXT_LEFT);
-  } else if (ui_context_menu_item(ui, "Line Tool", "tool.line",
-                                  EDITOR_COMMAND_TOOL_LINE, workspace)) {
-    return 1;
-  }
-
-  if (active_tool == TOOL_KIND_RECT) {
-    nk_label(ui->ctx, "Rectangle Tool (R)", NK_TEXT_LEFT);
-  } else if (ui_context_menu_item(ui, "Rectangle Tool", "tool.rect",
-                                  EDITOR_COMMAND_TOOL_RECT, workspace)) {
-    return 1;
-  }
-
-  if (active_tool == TOOL_KIND_ELLIPSE) {
-    nk_label(ui->ctx, "Ellipse Tool (E)", NK_TEXT_LEFT);
-  } else if (ui_context_menu_item(ui, "Ellipse Tool", "tool.ellipse",
-                                  EDITOR_COMMAND_TOOL_ELLIPSE, workspace)) {
-    return 1;
-  }
-
-  ui_context_menu_separator(ui);
-  nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
-  if (ui_context_menu_item(ui, "Zoom to Fit", "view.zoom_fit",
-                           EDITOR_COMMAND_VIEW_ZOOM_FIT, workspace)) {
-    return 1;
-  }
-
-  ui_context_menu_separator(ui);
-  nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
-  if (workspace->core.canvas.show_grid) {
-    if (ui_context_menu_item(ui, "Hide Grid", "view.toggle_grid",
-                             EDITOR_COMMAND_VIEW_TOGGLE_GRID, workspace)) {
-      return 1;
-    }
-  } else if (ui_context_menu_item(ui, "Show Grid", "view.toggle_grid",
-                                  EDITOR_COMMAND_VIEW_TOGGLE_GRID,
-                                  workspace)) {
-    return 1;
-  }
-
-  return 0;
-}
-
-static int ui_context_menu_build_selection(UiSystem *ui, Workspace *workspace) {
-  nk_layout_row_dynamic(ui->ctx, ui->theme.row_height, 1);
-  if (ui_context_menu_item(ui, "Copy", "edit.copy", EDITOR_COMMAND_EDIT_COPY,
-                           workspace)) {
-    return 1;
-  }
-  if (ui_context_menu_item(ui, "Paste", "edit.paste", EDITOR_COMMAND_EDIT_PASTE,
-                           workspace)) {
-    return 1;
-  }
-  if (ui_context_menu_item(ui, "Delete", "edit.delete",
-                           EDITOR_COMMAND_EDIT_DELETE, workspace)) {
-    return 1;
-  }
-
-  return 0;
-}
-
-static void ui_canvas_context_menu(UiSystem *ui, Workspace *workspace) {
-  RectF canvas_bounds;
-  RectF host_bounds;
-  RectF popup_bounds;
-  struct nk_rect nk_host_bounds;
-  struct nk_rect nk_popup_bounds;
-  int is_open = 0;
-  int menu_action_triggered = 0;
-
-  if (!ui || !ui->ctx || !workspace || !ui->context_menu.open) {
-    return;
-  }
-
-  canvas_bounds = ui->context_menu.canvas_bounds;
-  if (canvas_bounds.w <= 0.0f || canvas_bounds.h <= 0.0f) {
-    ui_context_menu_reset(ui);
-    return;
-  }
-
-  popup_bounds = ui_context_menu_popup_bounds(&ui->context_menu);
-  ui->context_menu.popup_bounds = popup_bounds;
-
-  host_bounds.x = popup_bounds.x;
-  host_bounds.y = popup_bounds.y;
-  host_bounds.w = UI_CONTEXT_MENU_ANCHOR_SIZE;
-  host_bounds.h = UI_CONTEXT_MENU_ANCHOR_SIZE;
-
-  /* Popup APIs need an active Nuklear window/panel. Keep the host window to a
-   * single pixel so the menu does not visually cover the canvas. */
-  nk_host_bounds =
-      nk_rect(host_bounds.x, host_bounds.y, host_bounds.w, host_bounds.h);
-  nk_popup_bounds =
-      nk_rect(0.0f, 0.0f, popup_bounds.w, popup_bounds.h);
-
-  if (nk_begin(ui->ctx, "Canvas Context Host", nk_host_bounds,
-               NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND |
-                   NK_WINDOW_NO_INPUT)) {
-    is_open = nk_popup_begin(ui->ctx, NK_POPUP_DYNAMIC, "Canvas Context Menu",
-                             NK_WINDOW_NO_SCROLLBAR, nk_popup_bounds);
-    if (is_open) {
-      if (ui->context_menu.close_requested) {
-        nk_popup_close(ui->ctx);
-      } else if (ui->context_menu.mode == UI_CONTEXT_MENU_MODE_SELECTION) {
-        menu_action_triggered = ui_context_menu_build_selection(ui, workspace);
-      } else {
-        menu_action_triggered = ui_context_menu_build_tools(ui, workspace);
-      }
-
-      if (ui->context_menu.close_requested || menu_action_triggered) {
-        nk_popup_close(ui->ctx);
-      }
-      nk_popup_end(ui->ctx);
-    }
-  }
-  nk_end(ui->ctx);
-
-  if (!is_open || ui->context_menu.close_requested || menu_action_triggered) {
-    ui_context_menu_reset(ui);
-  }
-}
-
 static void ui_publish_layout(UiSystem *ui, Workspace *workspace, int width,
                               int height) {
   WorkspaceLayout next_layout;
@@ -831,7 +525,7 @@ static int ui_hover_overlays_allowed(const UiSystem *ui) {
     return 0;
   }
 
-  return !ui->modal_active && !ui->context_menu.open &&
+  return !ui->modal_active && !ui_context_menu_is_open(ui) &&
          !ui_menubar_menu_open(ui->menu_bar);
 }
 
@@ -1358,7 +1052,7 @@ void ui_system_build(UiSystem *ui, Workspace *workspace) {
   }
 
   if (!ui->modal_active) {
-    ui_canvas_context_menu(ui, workspace);
+    ui_context_menu_build(ui, workspace);
   }
 
   ui_publish_layout(ui, workspace, width, height);
@@ -1369,41 +1063,13 @@ void ui_system_build(UiSystem *ui, Workspace *workspace) {
 }
 
 int ui_system_handle_key(UiSystem *ui, int key, int action) {
-  if (!ui || action != GLFW_PRESS) {
-    return 0;
-  }
-
-  if (key == GLFW_KEY_ESCAPE && ui->context_menu.open) {
-    ui->context_menu.close_requested = 1;
-    return 1;
-  }
-
-  return 0;
+  return ui_context_menu_handle_key(ui, key, action);
 }
 
 int ui_system_handle_mouse_button(UiSystem *ui, Workspace *workspace,
                                   Vec2 screen_pos, int button, int action) {
-  if (!ui || !workspace || action != GLFW_PRESS || ui->modal_active) {
-    return 0;
-  }
-
-  if (ui->context_menu.open && button == GLFW_MOUSE_BUTTON_LEFT) {
-    /* Match common desktop behavior: clicking blank canvas dismisses the
-     * context menu immediately instead of waiting for popup internals. */
-    if (!rectf_contains_point(&ui->context_menu.popup_bounds, screen_pos)) {
-      ui_context_menu_reset(ui);
-      return 1;
-    }
-  }
-
-  if (button == GLFW_MOUSE_BUTTON_RIGHT) {
-    /* Open the canvas menu from the input path so tools never see the same
-     * right-click as a drawing gesture. */
-    ui_context_menu_open(ui, workspace, screen_pos);
-    return ui->context_menu.open;
-  }
-
-  return 0;
+  return ui_context_menu_handle_mouse_button(ui, workspace, screen_pos, button,
+                                             action);
 }
 
 void ui_system_render(UiSystem *ui) {
@@ -1419,7 +1085,7 @@ int ui_system_has_active_interaction(const UiSystem *ui) {
     return 0;
   }
 
-  return ui->context_menu.open || ui_menubar_menu_open(ui->menu_bar) ||
+  return ui_context_menu_is_open(ui) || ui_menubar_menu_open(ui->menu_bar) ||
          nk_item_is_any_active(ui->ctx);
 }
 

--- a/src/ui/ui_system_internal.h
+++ b/src/ui/ui_system_internal.h
@@ -1,0 +1,89 @@
+/**
+ * @file ui_system_internal.h
+ * @brief Private UI system state shared by UI implementation modules.
+ */
+#ifndef GLDRAW_UI_UI_SYSTEM_INTERNAL_H
+#define GLDRAW_UI_UI_SYSTEM_INTERNAL_H
+
+#ifndef NK_NUKLEAR_H_
+#ifndef NK_INCLUDE_FIXED_TYPES
+#define NK_INCLUDE_FIXED_TYPES
+#endif
+#ifndef NK_INCLUDE_STANDARD_IO
+#define NK_INCLUDE_STANDARD_IO
+#endif
+#ifndef NK_INCLUDE_STANDARD_VARARGS
+#define NK_INCLUDE_STANDARD_VARARGS
+#endif
+#ifndef NK_INCLUDE_DEFAULT_ALLOCATOR
+#define NK_INCLUDE_DEFAULT_ALLOCATOR
+#endif
+#ifndef NK_INCLUDE_VERTEX_BUFFER_OUTPUT
+#define NK_INCLUDE_VERTEX_BUFFER_OUTPUT
+#endif
+#ifndef NK_INCLUDE_FONT_BAKING
+#define NK_INCLUDE_FONT_BAKING
+#endif
+#ifndef NK_INCLUDE_DEFAULT_FONT
+#define NK_INCLUDE_DEFAULT_FONT
+#endif
+#include "nuklear/nuklear.h"
+#endif
+
+#ifndef NK_GLFW_GL3_H_
+#include "nuklear/nuklear_glfw_gl3.h"
+#endif
+
+#include <app/workspace.h>
+#include <base/types.h>
+#include <ui/ui_menubar.h>
+#include <ui/ui_theme.h>
+
+#define UI_THEME_ID_CAPACITY 64
+#define UI_THEME_DESCRIPTOR_CACHE_MAX 64
+
+typedef enum UiContextMenuMode {
+  UI_CONTEXT_MENU_MODE_TOOLS = 0,
+  UI_CONTEXT_MENU_MODE_SELECTION
+} UiContextMenuMode;
+
+typedef struct UiContextMenuState {
+  int open;
+  int close_requested;
+  UiContextMenuMode mode;
+  Vec2 anchor_screen;
+  RectF canvas_bounds;
+  RectF popup_bounds;
+} UiContextMenuState;
+
+typedef struct UiSystem UiSystem;
+
+struct UiSystem {
+  struct nk_glfw glfw;
+  struct nk_context *ctx;
+  GLFWwindow *window_handle;
+  UiMenuBar *menu_bar;
+  UiThemeTokens theme;
+  char active_theme_id[UI_THEME_ID_CAPACITY];
+  char theme_settings_path[260];
+  UiThemeDescriptor theme_descriptors_cache[UI_THEME_DESCRIPTOR_CACHE_MAX];
+  unsigned long long theme_directory_signature;
+  double theme_watch_last_check_seconds;
+  RectF appbar_bounds;
+  RectF rail_bounds;
+  RectF panel_bounds;
+  RectF status_bounds;
+  RectF content_bounds;
+  WorkspaceLayout layout_snapshot;
+  float inspector_anim_t;
+  int inspector_target_visible;
+  int inspector_anim_initialized;
+  int inspector_edit_active;
+  DocumentSnapshot inspector_edit_before_snapshot;
+  SelectionSet inspector_edit_before_selection;
+  int modal_active;
+  UiContextMenuState context_menu;
+  double last_frame_seconds;
+};
+
+#endif /* GLDRAW_UI_UI_SYSTEM_INTERNAL_H */

--- a/src/ui/ui_theme.c
+++ b/src/ui/ui_theme.c
@@ -16,6 +16,7 @@
 #include <base/path_utils.h>
 #include <ui/ui_theme.h>
 
+#include <ctype.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -726,7 +727,7 @@ static int ui_theme_id_is_safe_for_json(const char* theme_id)
     }
 
     while (*cursor != '\0') {
-        if (!(isalnum(*cursor) || *cursor == '-' || *cursor == '_' || *cursor == '.')) {
+        if (!(isalnum((unsigned char)*cursor) || *cursor == '-' || *cursor == '_' || *cursor == '.')) {
             return 0;
         }
         cursor++;


### PR DESCRIPTION
## Summary
- move canvas context menu behavior out of ui_system into ui_context_menu
- add a private ui_system_internal boundary for UI implementation modules
- keep the public ui_system API unchanged while reducing ui_system.c responsibilities

## Validation
- cmake --build build --config Release
- ctest --test-dir build --output-on-failure
- git diff --check