### PR TITLE
refactor: harden editor boundaries and evolve render architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Cache GLFW source
+      uses: actions/cache@v4
+      with:
+        path: build/_deps
+        key: ${{ runner.os }}-glfw-3.3.9-${{ hashFiles('CMakeLists.txt') }}
+
     - name: Install dependencies (Linux)
       if: runner.os == 'Linux'
       run: |
@@ -61,6 +67,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+
+    - name: Cache GLFW source
+      uses: actions/cache@v4
+      with:
+        path: build/_deps
+        key: ${{ runner.os }}-glfw-3.3.9-${{ hashFiles('CMakeLists.txt') }}
 
     - name: Install dependencies (Linux)
       if: runner.os == 'Linux'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,13 +97,16 @@ set(RENDER_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_device.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/canvas_drawlist.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/canvas_renderer.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_arena.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_system.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/image/png_writer.c
 )
 
 set(RENDER_GLFW_GL_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/render/buffer_pool.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_device_factory.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_device_gl.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/render/shader_manager.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/glad.c
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ function(gldraw_apply_sanitizers target_name)
     endif()
 endfunction()
 
-set(GLDRAW_MODEL_SOURCES
+set(EDITOR_MODEL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/base/file_utils.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/base/path_utils.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/model/selection.c
@@ -92,37 +92,31 @@ set(GLDRAW_MODEL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/document/persistence.c
 )
 
-set(GLDRAW_RENDER_GL_SOURCES
+set(RENDER_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/canvas/canvas_view.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_device.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_device_factory.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_device_gl.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/canvas_drawlist.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/canvas_renderer.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_system.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/image/png_writer.c
+)
+
+set(RENDER_GLFW_GL_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_device_factory.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_device_gl.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/glad.c
 )
 
-set(GLDRAW_COMMAND_SOURCES
+set(EDITOR_COMMANDS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/commands/command.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/commands/command_executor.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/commands/command_layer_ops.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/commands/command_object_ops.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/commands/command_transaction.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/editor_action.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/command_registry.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/command_dispatcher.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/editor_viewmodel.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/registration_manifest.c
+)
+
+set(EDITOR_TOOLS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/tool_manifest.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_actions.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_dialogs.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_service.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/input/key_chord.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/input/keymap.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/input/input_router.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/tool_registry.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/tool_runtime.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/tool_input_dispatch.c
@@ -131,15 +125,34 @@ set(GLDRAW_COMMAND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/tool_shape.c
 )
 
+set(EDITOR_RUNTIME_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/editor_action.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/command_registry.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/command_dispatcher.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/editor_viewmodel.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/registration_manifest.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_actions.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_dialogs.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_service.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/input/key_chord.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/input/keymap.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/input/input_router.c
+)
+
 if(GLDRAW_ENABLE_SCRIPTING)
     find_package(Lua REQUIRED)
-    list(APPEND GLDRAW_COMMAND_SOURCES
+    list(APPEND EDITOR_TOOLS_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/script/script_runtime_lua.c
         ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/script_tool_lua.c
     )
 endif()
 
-set(GLDRAW_UI_NUKLEAR_SOURCES
+set(PLATFORM_GLFW_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/window.c
+)
+
+set(UI_NUKLEAR_GLFW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_chrome.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_context_menu.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_inspector_panel.c
@@ -154,13 +167,12 @@ set(GLDRAW_UI_NUKLEAR_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme.c
 )
 
-set(GLDRAW_APP_SOURCES
+set(EDITOR_APP_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/application.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/application_dialog_actions.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/application_file_actions.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/application_runtime.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/file_dialog.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/window.c
 )
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
@@ -175,130 +187,120 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     )
 endif()
 
-add_library(gldraw_model STATIC ${GLDRAW_MODEL_SOURCES})
+function(gldraw_target_defaults target_name)
+    target_include_directories(${target_name}
+        PUBLIC
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    gldraw_apply_compile_options(${target_name})
+    gldraw_apply_sanitizers(${target_name})
+endfunction()
 
-target_include_directories(gldraw_model
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
-)
+function(gldraw_target_glfw_defaults target_name)
+    gldraw_target_defaults(${target_name})
+    target_include_directories(${target_name}
+        PRIVATE
+            "${glfw_SOURCE_DIR}/include"
+    )
+endfunction()
 
-gldraw_apply_compile_options(gldraw_model)
-gldraw_apply_sanitizers(gldraw_model)
-
+add_library(editor_model STATIC ${EDITOR_MODEL_SOURCES})
+gldraw_target_defaults(editor_model)
 if(UNIX AND NOT APPLE)
-    target_link_libraries(gldraw_model PUBLIC m)
+    target_link_libraries(editor_model PUBLIC m)
 endif()
 
-add_library(gldraw_render_gl STATIC ${GLDRAW_RENDER_GL_SOURCES})
+add_library(render_core STATIC ${RENDER_CORE_SOURCES})
+gldraw_target_defaults(render_core)
+target_link_libraries(render_core PUBLIC editor_model)
 
-target_include_directories(gldraw_render_gl
+add_library(platform_glfw STATIC ${PLATFORM_GLFW_SOURCES})
+gldraw_target_glfw_defaults(platform_glfw)
+target_link_libraries(platform_glfw
     PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
-        "${glfw_SOURCE_DIR}/include"
-)
-
-target_link_libraries(gldraw_render_gl
-    PUBLIC
-        gldraw_model
+        editor_model
     PRIVATE
         glfw
         OpenGL::GL
 )
 
-gldraw_apply_compile_options(gldraw_render_gl)
-gldraw_apply_sanitizers(gldraw_render_gl)
-
-add_library(gldraw_commands STATIC ${GLDRAW_COMMAND_SOURCES})
-
-target_include_directories(gldraw_commands
+add_library(render_glfw_gl STATIC ${RENDER_GLFW_GL_SOURCES})
+gldraw_target_glfw_defaults(render_glfw_gl)
+target_link_libraries(render_glfw_gl
     PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        render_core
     PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
-        "${glfw_SOURCE_DIR}/include"
+        glfw
+        OpenGL::GL
 )
 
-target_link_libraries(gldraw_commands
+add_library(editor_commands STATIC ${EDITOR_COMMANDS_SOURCES})
+gldraw_target_defaults(editor_commands)
+target_link_libraries(editor_commands PUBLIC editor_model)
+
+add_library(editor_tools STATIC ${EDITOR_TOOLS_SOURCES})
+gldraw_target_glfw_defaults(editor_tools)
+target_link_libraries(editor_tools
     PUBLIC
-        gldraw_model
-        gldraw_render_gl
+        editor_commands
+        render_core
     PRIVATE
         glfw
 )
-
 if(GLDRAW_ENABLE_SCRIPTING)
-    target_include_directories(gldraw_commands PRIVATE ${LUA_INCLUDE_DIR})
-    target_link_libraries(gldraw_commands PRIVATE ${LUA_LIBRARIES})
-    target_compile_definitions(gldraw_commands PRIVATE GLDRAW_ENABLE_SCRIPTING=1)
+    target_include_directories(editor_tools PRIVATE ${LUA_INCLUDE_DIR})
+    target_link_libraries(editor_tools PRIVATE ${LUA_LIBRARIES})
+    target_compile_definitions(editor_tools PRIVATE GLDRAW_ENABLE_SCRIPTING=1)
 endif()
 
-gldraw_apply_compile_options(gldraw_commands)
-gldraw_apply_sanitizers(gldraw_commands)
-
-add_library(gldraw_ui_nuklear STATIC ${GLDRAW_UI_NUKLEAR_SOURCES})
-
-target_include_directories(gldraw_ui_nuklear
+add_library(editor_runtime STATIC ${EDITOR_RUNTIME_SOURCES})
+gldraw_target_glfw_defaults(editor_runtime)
+target_link_libraries(editor_runtime
     PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        editor_commands
+        editor_tools
     PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
-        "${glfw_SOURCE_DIR}/include"
-)
-
-target_link_libraries(gldraw_ui_nuklear
-    PUBLIC
-        gldraw_model
-        gldraw_render_gl
-        gldraw_commands
-    PRIVATE
+        render_core
         glfw
-        OpenGL::GL
 )
 
-gldraw_apply_compile_options(gldraw_ui_nuklear)
-gldraw_apply_sanitizers(gldraw_ui_nuklear)
-
-add_library(gldraw_app STATIC ${GLDRAW_APP_SOURCES})
-
-target_include_directories(gldraw_app
+add_library(ui_nuklear_glfw STATIC ${UI_NUKLEAR_GLFW_SOURCES})
+gldraw_target_glfw_defaults(ui_nuklear_glfw)
+target_link_libraries(ui_nuklear_glfw
     PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
-        "${glfw_SOURCE_DIR}/include"
+        editor_runtime
+        platform_glfw
 )
 
-target_link_libraries(gldraw_app
+add_library(editor_app STATIC ${EDITOR_APP_SOURCES})
+gldraw_target_glfw_defaults(editor_app)
+target_link_libraries(editor_app
     PUBLIC
-        gldraw_model
-        gldraw_render_gl
-        gldraw_commands
-        gldraw_ui_nuklear
-    PRIVATE
-        glfw
-        OpenGL::GL
+        editor_runtime
+        ui_nuklear_glfw
+        render_glfw_gl
+        platform_glfw
 )
-
-gldraw_apply_compile_options(gldraw_app)
-gldraw_apply_sanitizers(gldraw_app)
-
 if(WIN32)
-    target_link_libraries(gldraw_app PUBLIC gdi32 comdlg32)
+    target_link_libraries(editor_app PUBLIC gdi32 comdlg32)
+endif()
+if(UNIX AND NOT APPLE)
+    target_link_libraries(editor_app PUBLIC pthread dl)
 endif()
 
-if(UNIX AND NOT APPLE)
-    target_link_libraries(gldraw_app PUBLIC pthread dl)
-endif()
+add_library(gldraw_model ALIAS editor_model)
+add_library(gldraw_render_gl ALIAS render_glfw_gl)
+add_library(gldraw_commands ALIAS editor_runtime)
+add_library(gldraw_ui_nuklear ALIAS ui_nuklear_glfw)
+add_library(gldraw_app ALIAS editor_app)
 
 add_executable(${PROJECT_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c
 )
 
-target_link_libraries(${PROJECT_NAME} PRIVATE gldraw_app)
+target_link_libraries(${PROJECT_NAME} PRIVATE editor_app)
 
 gldraw_apply_compile_options(${PROJECT_NAME})
 gldraw_apply_sanitizers(${PROJECT_NAME})
@@ -338,7 +340,7 @@ target_include_directories(gldraw_document_core_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(gldraw_document_core_tests PRIVATE gldraw_model gldraw_commands)
+target_link_libraries(gldraw_document_core_tests PRIVATE editor_runtime)
 
 gldraw_apply_compile_options(gldraw_document_core_tests)
 gldraw_apply_sanitizers(gldraw_document_core_tests)
@@ -358,7 +360,7 @@ target_include_directories(gldraw_png_writer_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(gldraw_png_writer_tests PRIVATE gldraw_render_gl)
+target_link_libraries(gldraw_png_writer_tests PRIVATE render_core)
 
 gldraw_apply_compile_options(gldraw_png_writer_tests)
 gldraw_apply_sanitizers(gldraw_png_writer_tests)
@@ -378,7 +380,7 @@ target_include_directories(gldraw_selection_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(gldraw_selection_tests PRIVATE gldraw_model)
+target_link_libraries(gldraw_selection_tests PRIVATE editor_model)
 
 gldraw_apply_compile_options(gldraw_selection_tests)
 gldraw_apply_sanitizers(gldraw_selection_tests)
@@ -398,7 +400,7 @@ target_include_directories(gldraw_document_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(gldraw_document_tests PRIVATE gldraw_model)
+target_link_libraries(gldraw_document_tests PRIVATE editor_model)
 
 gldraw_apply_compile_options(gldraw_document_tests)
 gldraw_apply_sanitizers(gldraw_document_tests)
@@ -418,7 +420,7 @@ target_include_directories(gldraw_command_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(gldraw_command_tests PRIVATE gldraw_commands)
+target_link_libraries(gldraw_command_tests PRIVATE editor_runtime)
 
 gldraw_apply_compile_options(gldraw_command_tests)
 gldraw_apply_sanitizers(gldraw_command_tests)
@@ -438,7 +440,7 @@ target_include_directories(gldraw_registry_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(gldraw_registry_tests PRIVATE gldraw_ui_nuklear)
+target_link_libraries(gldraw_registry_tests PRIVATE ui_nuklear_glfw)
 
 gldraw_apply_compile_options(gldraw_registry_tests)
 gldraw_apply_sanitizers(gldraw_registry_tests)
@@ -459,7 +461,7 @@ if(GLDRAW_ENABLE_SCRIPTING)
             ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
 
-    target_link_libraries(gldraw_script_runtime_tests PRIVATE gldraw_commands gldraw_model)
+    target_link_libraries(gldraw_script_runtime_tests PRIVATE editor_tools)
 
     gldraw_apply_compile_options(gldraw_script_runtime_tests)
     gldraw_apply_sanitizers(gldraw_script_runtime_tests)
@@ -480,7 +482,7 @@ target_include_directories(gldraw_fake_star_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(gldraw_fake_star_tests PRIVATE gldraw_render_gl)
+target_link_libraries(gldraw_fake_star_tests PRIVATE render_core)
 
 gldraw_apply_compile_options(gldraw_fake_star_tests)
 gldraw_apply_sanitizers(gldraw_fake_star_tests)
@@ -500,7 +502,7 @@ target_include_directories(gldraw_no_builtin_knowledge_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(gldraw_no_builtin_knowledge_tests PRIVATE gldraw_model)
+target_link_libraries(gldraw_no_builtin_knowledge_tests PRIVATE editor_model)
 
 gldraw_apply_compile_options(gldraw_no_builtin_knowledge_tests)
 gldraw_apply_sanitizers(gldraw_no_builtin_knowledge_tests)
@@ -520,7 +522,7 @@ target_include_directories(gldraw_ui_logic_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(gldraw_ui_logic_tests PRIVATE gldraw_commands)
+target_link_libraries(gldraw_ui_logic_tests PRIVATE editor_runtime)
 
 gldraw_apply_compile_options(gldraw_ui_logic_tests)
 gldraw_apply_sanitizers(gldraw_ui_logic_tests)
@@ -540,7 +542,7 @@ target_include_directories(gldraw_renderer_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(gldraw_renderer_tests PRIVATE gldraw_render_gl)
+target_link_libraries(gldraw_renderer_tests PRIVATE render_core)
 
 gldraw_apply_compile_options(gldraw_renderer_tests)
 gldraw_apply_sanitizers(gldraw_renderer_tests)
@@ -560,7 +562,7 @@ target_include_directories(gldraw_workspace_service_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(gldraw_workspace_service_tests PRIVATE gldraw_commands)
+target_link_libraries(gldraw_workspace_service_tests PRIVATE editor_runtime)
 
 gldraw_apply_compile_options(gldraw_workspace_service_tests)
 gldraw_apply_sanitizers(gldraw_workspace_service_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,12 @@ if(EXISTS "${GLDRAW_LOCAL_GLFW_DIR}/CMakeLists.txt")
     set(glfw_SOURCE_DIR "${GLDRAW_LOCAL_GLFW_DIR}")
 else()
     include(FetchContent)
+    set(FETCHCONTENT_BASE_DIR "${CMAKE_SOURCE_DIR}/build/_deps")
+    set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
     FetchContent_Declare(
         glfw
-        GIT_REPOSITORY https://github.com/glfw/glfw.git
-        GIT_TAG 3.3.9
+        URL https://github.com/glfw/glfw/archive/refs/tags/3.3.9.tar.gz
+        DOWNLOAD_EXTRACT_TIMESTAMP FALSE
     )
     FetchContent_MakeAvailable(glfw)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ set(GLDRAW_COMMAND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/editor_viewmodel.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/registration_manifest.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/tool_manifest.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_actions.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_dialogs.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/app/workspace_service.c
@@ -447,6 +448,28 @@ set_target_properties(gldraw_registry_tests PROPERTIES
 )
 
 add_test(NAME gldraw_registry_tests COMMAND $<TARGET_FILE:gldraw_registry_tests>)
+
+if(GLDRAW_ENABLE_SCRIPTING)
+    add_executable(gldraw_script_runtime_tests
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_script_runtime.c
+    )
+
+    target_include_directories(gldraw_script_runtime_tests
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
+    target_link_libraries(gldraw_script_runtime_tests PRIVATE gldraw_commands gldraw_model)
+
+    gldraw_apply_compile_options(gldraw_script_runtime_tests)
+    gldraw_apply_sanitizers(gldraw_script_runtime_tests)
+
+    set_target_properties(gldraw_script_runtime_tests PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    add_test(NAME gldraw_script_runtime_tests COMMAND $<TARGET_FILE:gldraw_script_runtime_tests>)
+endif()
 
 add_executable(gldraw_fake_star_tests
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_fake_star.c

--- a/REFACTOR_LOG.md
+++ b/REFACTOR_LOG.md
@@ -119,3 +119,66 @@
 - Validation:
   `cmake --build build --parallel` passed.
   `ctest --test-dir build --output-on-failure` passed.
+
+## 2026-05-12 23:09:14 CST - P2: Introduce Render Resource Management Layer
+
+- Modified files:
+  `include/render/buffer_pool.h`,
+  `include/render/shader_manager.h`,
+  `src/render/buffer_pool.c`,
+  `src/render/render_device_gl.c`,
+  `src/render/shader_manager.c`,
+  `CMakeLists.txt`
+- Key changes:
+  Added a `ShaderManager` module that centralizes shader source loading, shader compilation, program linking, uniform lookup, and program destruction instead of keeping that lifecycle embedded in `render_device_gl.c`.
+  Added a `BufferPool` module that owns GL vertex stream creation, attribute layout setup, buffer growth, and VAO/VBO teardown so transient backend resources are managed through one resource layer.
+  Updated `render_device_gl.c` to consume the new shader and buffer managers, reducing the backend file to frame state, transform logic, clip handling, and draw submission orchestration.
+- Validation:
+  `cmake --build build --parallel` passed.
+  `ctest --test-dir build --output-on-failure` passed.
+
+## 2026-05-12 23:27:42 CST - P2: Replace Draw-List Hot-Path Heap Churn With Reusable Arena Storage
+
+- Modified files:
+  `include/render/render_arena.h`,
+  `src/render/render_arena.c`,
+  `include/render/canvas_drawlist.h`,
+  `src/render/canvas_drawlist.c`,
+  `tests/test_renderer.c`,
+  `CMakeLists.txt`
+- Key changes:
+  Added a reusable `RenderArena` allocator module with explicit init/reset/shutdown/reserve/alloc operations so temporary render-build storage lives behind a dedicated abstraction instead of ad hoc per-call heap usage.
+  Updated `CanvasDrawList` to own a build-scoped scratch arena and reset it once per build, making temporary object path buffers, grid geometry buffers, and visible-index arrays reuse retained memory across frames.
+  Removed the hot-path `malloc/free` pairs from `canvas_drawlist_build()` and its helper paths, while keeping the externally visible draw-list output arrays and submission flow unchanged.
+  Added a renderer regression test that verifies the draw-list scratch arena remains allocated and reusable across repeated builds.
+- Validation:
+  `cmake --build build --parallel` passed.
+  `ctest --test-dir build --output-on-failure` passed.
+
+## 2026-05-12 23:46:18 CST - P2: Raise Render Abstraction Around Pass, Material, and Geometry
+
+- Modified files:
+  `include/render/render_device.h`,
+  `src/render/render_device.c`,
+  `include/render/canvas_drawlist.h`,
+  `src/render/canvas_drawlist.c`,
+  `src/render/render_device_gl.c`,
+  `src/render/canvas_renderer.c`,
+  `tests/test_renderer.c`
+- Key changes:
+  Replaced the old immediate-mode render-device surface (`set_color`, `draw_path`, `draw_rect`, `draw_line`, mutable transform/clip state) with explicit `RenderPass`, `RenderMaterial`, and `RenderGeometry` value types.
+  Updated `canvas_renderer_submit()` to build a pass object once per frame submission and then submit each stroke as a geometry/material pair, making the renderer intent explicit and reducing hidden backend state transitions.
+  Simplified the GL backend so pass setup owns clip and transform state, while draw submission consumes geometry and material payloads directly instead of relying on prior setter calls.
+  Updated renderer tests to validate the new frame/pass/draw submission sequence and geometry metadata capture.
+- Validation:
+  `cmake --build build --parallel` passed.
+  `ctest --test-dir build --output-on-failure` passed.
+
+## 2026-05-12 23:54:03 CST - P3: Future Architecture Evolution Suggestions
+
+- Render graph direction:
+  If GLDraw grows beyond a single canvas line-render pass, evolve the current frame/pass model into a render graph so offscreen composition, post-processing, and dependency ordering are explicit instead of being encoded inside backend control flow.
+- Backend portability direction:
+  Split backend-facing rendering into a `RenderBackend` layer plus a separate context/provider abstraction so OpenGL-specific context creation assumptions stop leaking into the rendering lifecycle and alternate backends can be introduced incrementally.
+- Editor ecosystem direction:
+  Keep the current static manifest model unless there is a real plugin-distribution goal; if that goal appears later, introduce a narrow plugin ABI centered on registration APIs rather than exposing workspace or renderer internals directly.

--- a/REFACTOR_LOG.md
+++ b/REFACTOR_LOG.md
@@ -67,3 +67,55 @@
 - Validation:
   `cmake --build build --parallel` passed.
   `ctest --test-dir build --output-on-failure -R 'workspace|ui_logic|registry|selection|renderer'` passed.
+
+## 2026-05-12 22:09:20 CST - P1: Replace ToolContext Workspace Access With Ports
+
+- Modified files:
+  `include/tools/tool.h`,
+  `include/script/script_runtime.h`,
+  `src/app/workspace.c`,
+  `src/tools/tool_select.c`,
+  `src/tools/tool_shape.c`,
+  `src/tools/script_tool_lua.c`,
+  `src/script/script_runtime_lua.c`,
+  `tests/test_ui_logic.c`,
+  `tests/test_script_runtime.c`
+- Key changes:
+  Added `ToolPorts` to `ToolContext` and introduced helper wrappers for command execution, undo/redo, selection preview updates, and dirty-flag sync so tools no longer require direct `Workspace*` access for runtime mutations.
+  Wired `workspace_tool_context()` to publish concrete port implementations backed by the workspace command executor and session preview/dirty state.
+  Updated built-in select and shape tools plus the optional Lua-backed script tool/runtime to use the new port callbacks instead of reaching into `Workspace` internals or `CommandExecutor` directly.
+  Updated tests to build contexts through `workspace_tool_context()` and to provide explicit test ports for script runtime execution.
+- Validation:
+  `cmake --build build --parallel` passed.
+  `ctest --test-dir build --output-on-failure -R 'ui_logic|workspace|registry|selection|renderer|command'` passed.
+  The scripting-enabled build still could not be compiled locally because this machine does not have the required Lua development package discoverable by CMake.
+
+## 2026-05-12 22:32:08 CST - P1: Seal Platform Window Leakage Behind Callbacks and Adapters
+
+- Modified files:
+  `include/platform/window.h`,
+  `src/platform/window.c`,
+  `src/platform/window_internal.h`,
+  `src/app/application.c`,
+  `src/ui/ui_runtime.c`,
+  `src/ui/ui_system_internal.h`
+- Key changes:
+  Added platform-owned window event callback registration APIs plus wrappers for window sizing, close requests, timed waits, and shared time queries so application runtime code no longer calls GLFW window functions directly.
+  Moved GLFW callback dispatch into the platform layer and backed it with an internal native-window registry, removing the need for application/user-pointer ownership on `GLFWwindow`.
+  Added a small platform-owned Nuklear/GLFW adapter surface so `ui_runtime.c` can initialize, frame, render, and shut down Nuklear without including `window_internal.h` or touching raw `GLFWwindow*`.
+  Updated application startup and loop code to register platform callbacks and use platform wrappers for framebuffer polling and close control.
+- Validation:
+  `cmake --build build --parallel` passed.
+  `ctest --test-dir build --output-on-failure -R 'ui_logic|workspace|registry|selection|renderer|command'` passed.
+
+## 2026-05-12 22:42:37 CST - P1: Reorganize CMake Targets Around Runtime Boundaries
+
+- Modified files:
+  `CMakeLists.txt`
+- Key changes:
+  Replaced the old coarse library split (`gldraw_model`, `gldraw_render_gl`, `gldraw_commands`, `gldraw_ui_nuklear`, `gldraw_app`) with a layered target graph centered on `editor_model`, `editor_commands`, `editor_tools`, `editor_runtime`, `render_core`, `render_glfw_gl`, `platform_glfw`, `ui_nuklear_glfw`, and `editor_app`.
+  Moved command core, tool runtime, render core, GL backend, platform window implementation, UI runtime, and application shell sources into separate targets so their responsibilities match the architecture more closely and command/tool/runtime cycles are broken explicitly in the link graph.
+  Updated executable and test link dependencies to target the new layer boundaries, while keeping compatibility aliases for the previous `gldraw_*` library names.
+- Validation:
+  `cmake --build build --parallel` passed.
+  `ctest --test-dir build --output-on-failure` passed.

--- a/REFACTOR_LOG.md
+++ b/REFACTOR_LOG.md
@@ -1,0 +1,69 @@
+# Refactor Log
+
+## 2026-05-12 21:25:51 CST - Baseline Check
+
+- Build system: CMake (`CMakeLists.txt` at repository root).
+- Source layout: `src/`, `include/`, `doc/`, and existing `build/` directory match the proposed plan.
+- Baseline validation: `cmake --build build --parallel` completed successfully before refactor work started.
+
+## 2026-05-12 21:29:13 CST - P0: Fix RenderSystem Selection Cache Key
+
+- Modified files:
+  `include/model/selection.h`,
+  `src/model/selection.c`,
+  `src/render/render_system.c`,
+  `tests/test_selection.c`,
+  `tests/test_renderer.c`
+- Key changes:
+  Added `SelectionSet.revision` and incremented it only when the selected ID set actually changes.
+  Extended `RenderSystem` cache invalidation to depend on both `selection_count` and `selection_revision`.
+  Added regression coverage for stable revisions on no-op updates and for render invalidation when the selection content changes without changing selection count.
+- Validation:
+  `cmake --build build --parallel` passed.
+  `ctest --test-dir build --output-on-failure -R 'selection|renderer'` passed.
+
+## 2026-05-12 21:39:06 CST - P0: Harden Lua Script Runtime Boundary
+
+- Modified files:
+  `src/script/script_runtime_lua.c`,
+  `scripts/star_wreath.lua`,
+  `tests/test_script_runtime.c`,
+  `CMakeLists.txt`
+- Key changes:
+  Replaced per-event `luaL_dofile()` execution with a one-time script load path that caches the compiled script per runtime instance.
+  Moved script access onto a whitelist-style `gldraw` table (`document_add_object`, `undo`, `redo`, `selection_get_ids`) inside a dedicated environment instead of exposing command text execution and unrestricted globals.
+  Limited the available standard libraries to base helpers plus `math`, `string`, and `table`, and added a scripting-only regression test target that checks safe-library exposure and one-time loading behavior.
+- Validation:
+  `cmake --build build --parallel` passed for the default configuration (`GLDRAW_ENABLE_SCRIPTING=OFF`).
+  `ctest --test-dir build --output-on-failure -R 'selection|renderer'` passed after the P0 changes.
+  `cmake -S . -B build-scripting -DGLDRAW_ENABLE_SCRIPTING=ON -DCMAKE_BUILD_TYPE=Release` could not complete on this machine because CMake could not find `LUA_LIBRARIES` / `LUA_INCLUDE_DIR`, so the scripting-enabled branch could not be compiled locally.
+
+## 2026-05-12 21:54:08 CST - P1: Split Public Workspace API From Internal State
+
+- Modified files:
+  `include/app/workspace.h`,
+  `include/app/workspace_internal.h`,
+  `src/app/workspace.c`,
+  `src/app/application_internal.h`,
+  `src/app/application_file_actions.c`,
+  `src/app/editor_viewmodel.c`,
+  `src/app/workspace_service.c`,
+  `src/app/workspace_actions.c`,
+  `src/app/workspace_dialogs.c`,
+  `src/app/command_dispatcher.c`,
+  `src/app/command_registry.c`,
+  `src/input/input_router.c`,
+  `src/tools/script_tool_lua.c`,
+  `src/tools/tool_select.c`,
+  `src/tools/tool_shape.c`,
+  `tests/test_registry.c`,
+  `tests/test_ui_logic.c`,
+  `tests/test_workspace_service.c`,
+  `CMakeLists.txt`
+- Key changes:
+  Moved the concrete `Workspace`/`EditorCore`/`EditorSession`/`EditorServices` layout into `workspace_internal.h` and reduced the public `workspace.h` surface to public enums, dialog/layout types, and opaque-pointer API declarations.
+  Replaced the old public inline implementations with compiled functions in `src/app/workspace.c`, including the existing status/layout/dirty/clipboard helpers plus new accessor entry points for core editor services.
+  Updated internal runtime modules and tests that need concrete workspace storage or direct field access to include the internal header explicitly, removing accidental dependence on the public header layout.
+- Validation:
+  `cmake --build build --parallel` passed.
+  `ctest --test-dir build --output-on-failure -R 'workspace|ui_logic|registry|selection|renderer'` passed.

--- a/include/app/workspace.h
+++ b/include/app/workspace.h
@@ -1,37 +1,22 @@
 /**
  * @file workspace.h
- * @brief Editor runtime shared workspace definition.
+ * @brief Public workspace types and opaque workspace API.
  */
 #ifndef GLDRAW_APP_WORKSPACE_H
 #define GLDRAW_APP_WORKSPACE_H
 
-#include <app/editor_session.h>
-#include <base/path_utils.h>
+#include <base/types.h>
 #include <canvas/canvas_view.h>
 #include <commands/command.h>
 #include <input/keymap.h>
+#include <model/selection.h>
+#include <tools/tool.h>
 #include <tools/tool_controller.h>
 
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+typedef struct Workspace Workspace;
 
-struct Workspace;
+typedef int (*WorkspaceCommandFn)(Workspace* workspace, void* user_data);
 
-/**
- * @typedef WorkspaceCommandFn
- * @brief Workspace command callback signature (e.g., save/load).
- * @param workspace Target workspace.
- * @param user_data Caller-supplied context passed through.
- * @return Non-zero on success, zero on failure.
- */
-typedef int (*WorkspaceCommandFn)(struct Workspace* workspace, void* user_data);
-
-/**
- * @enum WorkspaceActionType
- * @brief Destructive workspace actions that may require deferred confirmation.
- */
 typedef enum WorkspaceActionType {
     WORKSPACE_ACTION_NONE = 0,
     WORKSPACE_ACTION_NEW_DOCUMENT,
@@ -39,19 +24,11 @@ typedef enum WorkspaceActionType {
     WORKSPACE_ACTION_EXIT_APPLICATION
 } WorkspaceActionType;
 
-/**
- * @enum UiRequestType
- * @brief Top-level UI request kinds owned by the workspace.
- */
 typedef enum UiRequestType {
     UI_REQUEST_NONE = 0,
     UI_REQUEST_DIALOG
 } UiRequestType;
 
-/**
- * @enum UiDialogKind
- * @brief Stable dialog kinds used to resolve reusable dialog flows.
- */
 typedef enum UiDialogKind {
     UI_DIALOG_NONE = 0,
     UI_DIALOG_CONFIRM_UNSAVED,
@@ -60,10 +37,6 @@ typedef enum UiDialogKind {
     UI_DIALOG_SAVE_AS
 } UiDialogKind;
 
-/**
- * @enum UiDialogResult
- * @brief Standard dialog outcomes returned by reusable UI components.
- */
 typedef enum UiDialogResult {
     UI_DIALOG_RESULT_NONE = 0,
     UI_DIALOG_RESULT_PRIMARY,
@@ -71,46 +44,17 @@ typedef enum UiDialogResult {
     UI_DIALOG_RESULT_CANCEL
 } UiDialogResult;
 
-/**
- * @struct UiDialogPayload
- * @brief Small reusable payload block reserved for future dialog-specific data.
- *
- * @member int_values Integer payload slots.
- * @member text Text payload buffer.
- */
 typedef struct UiDialogPayload {
     int int_values[4];
     char text[1024];
 } UiDialogPayload;
 
-/**
- * @struct UiDialogButtonSpec
- * @brief Static button description used by generic dialog rendering.
- *
- * @member label Button label text.
- * @member result Result emitted when the button is selected.
- * @member is_default Non-zero when this button is the default action.
- */
 typedef struct UiDialogButtonSpec {
     char label[24];
     UiDialogResult result;
     int is_default;
 } UiDialogButtonSpec;
 
-/**
- * @struct UiDialogState
- * @brief Complete dialog state model owned by the workspace and rendered by UI components.
- *
- * @member kind Stable dialog kind used by business logic.
- * @member title Dialog title.
- * @member message Dialog body text.
- * @member payload Reserved dialog payload.
- * @member buttons Button specifications.
- * @member button_count Number of active buttons in `buttons`.
- * @member width Preferred dialog width.
- * @member height Preferred dialog height.
- * @member modal Non-zero when the dialog blocks background interaction.
- */
 typedef struct UiDialogState {
     UiDialogKind kind;
     char title[64];
@@ -123,30 +67,10 @@ typedef struct UiDialogState {
     int modal;
 } UiDialogState;
 
-/**
- * @typedef WorkspaceActionExecutorFn
- * @brief Application-owned executor for deferred workspace actions.
- * @param workspace Target workspace.
- * @param action Requested action.
- * @param user_data Caller-supplied context passed through.
- * @return Non-zero on success, zero on failure.
- */
-typedef int (*WorkspaceActionExecutorFn)(struct Workspace* workspace,
+typedef int (*WorkspaceActionExecutorFn)(Workspace* workspace,
                                          WorkspaceActionType action,
                                          void* user_data);
 
-/**
- * @struct WorkspaceLayout
- * @brief Layout snapshot computed by the UI.
- *
- * @member window_bounds Window boundary.
- * @member canvas_content_bounds Available canvas content area.
- * @member appbar_bounds Top toolbar area.
- * @member rail_bounds Left tool rail area.
- * @member panel_bounds Right panel area.
- * @member status_bounds Bottom status bar area.
- * @member layout_revision Layout version number (used for cross-system sync).
- */
 typedef struct WorkspaceLayout {
     RectF window_bounds;
     RectF canvas_content_bounds;
@@ -157,230 +81,29 @@ typedef struct WorkspaceLayout {
     unsigned int layout_revision;
 } WorkspaceLayout;
 
-/**
- * @struct EditorCore
- * @brief Backend-agnostic editing state.
- *
- * @member document Persisted document model.
- * @member canvas Canvas view state.
- * @member tools Tool controller.
- */
-typedef struct EditorCore {
-    Document document;
-    CommandExecutor commands;
-    CanvasView canvas;
-    ToolController tools;
-} EditorCore;
+ToolContext workspace_tool_context(Workspace* workspace);
+Document* workspace_get_document(Workspace* workspace);
+CommandExecutor* workspace_get_command_executor(Workspace* workspace);
+CanvasView* workspace_get_canvas(Workspace* workspace);
+ToolController* workspace_get_tool_controller(Workspace* workspace);
+EditorKeymap* workspace_get_keymap(Workspace* workspace);
+SelectionSet* workspace_get_selection(Workspace* workspace);
+const char* workspace_get_status_message(const Workspace* workspace);
+WorkspaceLayout workspace_get_layout(const Workspace* workspace);
+UiRequestType workspace_get_active_request_type(const Workspace* workspace);
+UiDialogState* workspace_get_active_dialog(Workspace* workspace);
+const UiDialogState* workspace_get_active_dialog_const(const Workspace* workspace);
+int workspace_document_dirty(const Workspace* workspace);
+unsigned int workspace_saved_revision(const Workspace* workspace);
+const char* workspace_get_current_document_path(const Workspace* workspace);
 
-/**
- * @struct EditorSession
- * @brief Session-only editor state.
- *
- * @member keymap Effective keyboard mapping state.
- * @member layout UI layout information.
- * @member selection Active object selection.
- * @member clipboard_objects Internal clipboard object clones.
- * @member clipboard_count Number of objects currently stored in the internal clipboard.
- * @member clipboard_capacity Allocated clipboard object capacity.
- * @member clipboard_paste_serial Repeated paste counter used to offset pasted content.
- * @member selection_preview_delta Temporary drag preview offset for the current selection.
- * @member selection_preview_active Non-zero when drag preview is active.
- * @member current_document_path Current document path (empty string means unnamed).
- * @member status_message Status bar message.
- * @member saved_revision Document revision corresponding to the last save.
- * @member document_dirty Whether the document is dirty (non-zero means unsaved changes).
- * @member active_request_type Active top-level UI request type.
- * @member active_dialog Active reusable dialog state.
- */
-typedef struct EditorSession {
-    EditorKeymap keymap;
-    WorkspaceLayout layout;
-    SelectionSet selection;
-    GraphicObject** clipboard_objects;
-    int clipboard_count;
-    int clipboard_capacity;
-    unsigned int clipboard_paste_serial;
-    Vec2 selection_preview_delta;
-    int selection_preview_active;
-    char current_document_path[GLDRAW_PATH_MAX];
-    char status_message[256];
-    unsigned int saved_revision;
-    int document_dirty;
-    UiRequestType active_request_type;
-    UiDialogState active_dialog;
-} EditorSession;
-
-/**
- * @struct EditorServices
- * @brief Integration callbacks supplied by the application shell.
- */
-typedef struct EditorServices {
-    WorkspaceCommandFn save_document;
-    WorkspaceCommandFn save_as_document;
-    WorkspaceCommandFn export_png;
-    WorkspaceCommandFn load_document;
-    WorkspaceActionExecutorFn execute_action;
-    void* command_user_data;
-} EditorServices;
-
-/**
- * @struct Workspace
- * @brief Runtime editor container split into core/session/services layers.
- */
-typedef struct Workspace {
-    EditorCore core;
-    EditorSession session;
-    EditorServices services;
-} Workspace;
-
-/**
- * @brief Build a tool context view over the workspace-owned editor state.
- * @param workspace Source workspace; members become `NULL` when workspace is `NULL`.
- * @return Tool context value.
- */
-static inline ToolContext workspace_tool_context(Workspace* workspace)
-{
-    ToolContext context;
-
-    context.workspace = workspace;
-    context.document = workspace ? &workspace->core.document : NULL;
-    context.canvas = workspace ? &workspace->core.canvas : NULL;
-    context.selection = workspace ? &workspace->session.selection : NULL;
-    return context;
-}
-
-/**
- * @brief Overwrite the workspace status message with plain text.
- * @param workspace Target workspace; no-op if `NULL`.
- * @param message Source text; `NULL` clears the status.
- * @return No return value.
- */
-static inline void workspace_set_status_message(Workspace* workspace, const char* message)
-{
-    if (!workspace) {
-        return;
-    }
-
-    snprintf(workspace->session.status_message,
-             sizeof(workspace->session.status_message),
-             "%s",
-             message ? message : "");
-}
-
-/**
- * @brief Write formatted text into the workspace status buffer.
- * @param workspace Target workspace; no-op if `NULL`.
- * @param fmt `printf`-style format string; `NULL` clears the status.
- * @return No return value.
- */
-static inline void workspace_set_statusf(Workspace* workspace, const char* fmt, ...)
-{
-    va_list args;
-
-    if (!workspace) {
-        return;
-    }
-    if (!fmt) {
-        workspace_set_status_message(workspace, "");
-        return;
-    }
-
-    va_start(args, fmt);
-    vsnprintf(workspace->session.status_message,
-              sizeof(workspace->session.status_message),
-              fmt,
-              args);
-    va_end(args);
-}
-
-/**
- * @brief Store the latest layout snapshot computed by the UI.
- * @param workspace Target workspace; no-op if `NULL`.
- * @param layout Layout snapshot to copy.
- * @return No return value.
- */
-static inline void workspace_set_layout(Workspace* workspace, WorkspaceLayout layout)
-{
-    if (!workspace) {
-        return;
-    }
-
-    workspace->session.layout = layout;
-}
-
-/**
- * @brief Return whether selection drag preview rendering is active.
- * @param workspace Source workspace.
- * @return Non-zero when active; zero otherwise.
- */
-static inline int workspace_selection_preview_active(const Workspace* workspace)
-{
-    return workspace ? workspace->session.selection_preview_active : 0;
-}
-
-/**
- * @brief Return the current selection drag preview offset.
- * @param workspace Source workspace.
- * @return Preview delta, or zero vector when unavailable.
- */
-static inline Vec2 workspace_selection_preview_delta(const Workspace* workspace)
-{
-    return workspace ? workspace->session.selection_preview_delta
-                     : (Vec2){0.0f, 0.0f};
-}
-
-/**
- * @brief Mark the current document revision as saved.
- * @param workspace Target workspace; no-op if `NULL`.
- * @return No return value.
- */
-static inline void workspace_mark_saved(Workspace* workspace)
-{
-    if (!workspace) {
-        return;
-    }
-
-    workspace->session.saved_revision = workspace->core.document.revision;
-    workspace->session.document_dirty = 0;
-}
-
-/**
- * @brief Sync the dirty flag based on `saved_revision` and the current revision.
- * @param workspace Target workspace; no-op if `NULL`.
- * @return No return value.
- */
-static inline void workspace_sync_document_dirty(Workspace* workspace)
-{
-    if (!workspace) {
-        return;
-    }
-
-    workspace->session.document_dirty =
-        (workspace->session.saved_revision != workspace->core.document.revision);
-}
-
-/**
- * @brief Clear all objects stored in the internal clipboard.
- * @param workspace Target workspace; no-op if `NULL`.
- * @return No return value.
- */
-static inline void workspace_clear_clipboard(Workspace* workspace)
-{
-    int i = 0;
-
-    if (!workspace) {
-        return;
-    }
-
-    for (i = 0; i < workspace->session.clipboard_count; ++i) {
-        object_destroy(workspace->session.clipboard_objects[i]);
-    }
-
-    free(workspace->session.clipboard_objects);
-    workspace->session.clipboard_objects = NULL;
-    workspace->session.clipboard_count = 0;
-    workspace->session.clipboard_capacity = 0;
-    workspace->session.clipboard_paste_serial = 0;
-}
+void workspace_set_status_message(Workspace* workspace, const char* message);
+void workspace_set_statusf(Workspace* workspace, const char* fmt, ...);
+void workspace_set_layout(Workspace* workspace, WorkspaceLayout layout);
+int workspace_selection_preview_active(const Workspace* workspace);
+Vec2 workspace_selection_preview_delta(const Workspace* workspace);
+void workspace_mark_saved(Workspace* workspace);
+void workspace_sync_document_dirty(Workspace* workspace);
+void workspace_clear_clipboard(Workspace* workspace);
 
 #endif /* GLDRAW_APP_WORKSPACE_H */

--- a/include/app/workspace_internal.h
+++ b/include/app/workspace_internal.h
@@ -1,0 +1,52 @@
+/**
+ * @file workspace_internal.h
+ * @brief Internal workspace state layout for runtime modules and tests.
+ */
+#ifndef GLDRAW_APP_WORKSPACE_INTERNAL_H
+#define GLDRAW_APP_WORKSPACE_INTERNAL_H
+
+#include <app/editor_session.h>
+#include <app/workspace.h>
+#include <base/path_utils.h>
+
+typedef struct EditorCore {
+    Document document;
+    CommandExecutor commands;
+    CanvasView canvas;
+    ToolController tools;
+} EditorCore;
+
+typedef struct EditorSession {
+    EditorKeymap keymap;
+    WorkspaceLayout layout;
+    SelectionSet selection;
+    GraphicObject** clipboard_objects;
+    int clipboard_count;
+    int clipboard_capacity;
+    unsigned int clipboard_paste_serial;
+    Vec2 selection_preview_delta;
+    int selection_preview_active;
+    char current_document_path[GLDRAW_PATH_MAX];
+    char status_message[256];
+    unsigned int saved_revision;
+    int document_dirty;
+    UiRequestType active_request_type;
+    UiDialogState active_dialog;
+} EditorSession;
+
+typedef struct EditorServices {
+    WorkspaceCommandFn save_document;
+    WorkspaceCommandFn save_as_document;
+    WorkspaceCommandFn export_png;
+    WorkspaceCommandFn load_document;
+    WorkspaceActionExecutorFn execute_action;
+    void* command_user_data;
+} EditorServices;
+
+struct Workspace {
+    EditorCore core;
+    EditorSession session;
+    EditorServices services;
+};
+
+#endif /* GLDRAW_APP_WORKSPACE_INTERNAL_H */

--- a/include/model/selection.h
+++ b/include/model/selection.h
@@ -5,6 +5,8 @@
 #ifndef GLDRAW_MODEL_SELECTION_H
 #define GLDRAW_MODEL_SELECTION_H
 
+#include <stdint.h>
+
 #include <base/types.h>
 
 /**
@@ -15,6 +17,7 @@ typedef struct {
     ObjectId* ids;
     int count;
     int capacity;
+    uint64_t revision;
 } SelectionSet;
 
 void selection_set_init(SelectionSet* selection);

--- a/include/platform/window.h
+++ b/include/platform/window.h
@@ -5,6 +5,10 @@
 #ifndef GLDRAW_PLATFORM_WINDOW_H
 #define GLDRAW_PLATFORM_WINDOW_H
 
+struct nk_context;
+struct nk_font_atlas;
+struct nk_glfw;
+
 typedef struct GldWindow GldWindow;
 
 /**
@@ -26,6 +30,31 @@ typedef struct {
     int framebuffer_height;
     const char* title;
 } PlatformWindow;
+
+typedef void (*PlatformFramebufferSizeCallback)(PlatformWindow* window,
+                                                int width,
+                                                int height,
+                                                void* user_data);
+typedef void (*PlatformCursorPosCallback)(PlatformWindow* window,
+                                          double xpos,
+                                          double ypos,
+                                          void* user_data);
+typedef void (*PlatformMouseButtonCallback)(PlatformWindow* window,
+                                            int button,
+                                            int action,
+                                            int mods,
+                                            void* user_data);
+typedef void (*PlatformKeyCallback)(PlatformWindow* window,
+                                    int key,
+                                    int scancode,
+                                    int action,
+                                    int mods,
+                                    void* user_data);
+typedef void (*PlatformScrollCallback)(PlatformWindow* window,
+                                       double xoffset,
+                                       double yoffset,
+                                       void* user_data);
+typedef void (*PlatformCloseCallback)(PlatformWindow* window, void* user_data);
 
 /**
  * @brief Initialize platform windowing and create the window.
@@ -49,6 +78,7 @@ void platform_window_shutdown(PlatformWindow* window);
  * @return No return value.
  */
 void platform_window_poll_events(void);
+void platform_window_wait_events_timeout(double timeout_seconds);
 
 /**
  * @brief Swap the window front and back buffers.
@@ -63,5 +93,40 @@ void platform_window_swap_buffers(PlatformWindow* window);
  * @return Non-zero if the window should close, zero otherwise.
  */
 int platform_window_should_close(const PlatformWindow* window);
+void platform_window_set_should_close(PlatformWindow* window, int should_close);
+void platform_window_get_size(PlatformWindow* window, int* width, int* height);
+void platform_window_get_framebuffer_size(PlatformWindow* window, int* width, int* height);
+double platform_time_seconds(void);
+
+void platform_window_on_framebuffer_size(PlatformWindow* window,
+                                         PlatformFramebufferSizeCallback callback,
+                                         void* user_data);
+void platform_window_on_cursor_pos(PlatformWindow* window,
+                                   PlatformCursorPosCallback callback,
+                                   void* user_data);
+void platform_window_on_mouse_button(PlatformWindow* window,
+                                     PlatformMouseButtonCallback callback,
+                                     void* user_data);
+void platform_window_on_key(PlatformWindow* window,
+                            PlatformKeyCallback callback,
+                            void* user_data);
+void platform_window_on_scroll(PlatformWindow* window,
+                               PlatformScrollCallback callback,
+                               void* user_data);
+void platform_window_on_close(PlatformWindow* window,
+                              PlatformCloseCallback callback,
+                              void* user_data);
+
+struct nk_context* platform_window_nuklear_init(struct nk_glfw* glfw,
+                                                PlatformWindow* window);
+void platform_window_nuklear_shutdown(struct nk_glfw* glfw);
+void platform_window_nuklear_font_stash_begin(struct nk_glfw* glfw,
+                                              struct nk_font_atlas** atlas);
+void platform_window_nuklear_font_stash_end(struct nk_glfw* glfw);
+void platform_window_nuklear_new_frame(struct nk_glfw* glfw);
+void platform_window_nuklear_render(struct nk_glfw* glfw,
+                                    int anti_aliasing,
+                                    int max_vertex_buffer,
+                                    int max_element_buffer);
 
 #endif /* GLDRAW_PLATFORM_WINDOW_H */

--- a/include/render/buffer_pool.h
+++ b/include/render/buffer_pool.h
@@ -1,0 +1,40 @@
+#ifndef GLDRAW_RENDER_BUFFER_POOL_H
+#define GLDRAW_RENDER_BUFFER_POOL_H
+
+#include <stddef.h>
+
+typedef struct RenderVertexAttribute {
+    unsigned int index;
+    int component_count;
+    size_t offset_bytes;
+} RenderVertexAttribute;
+
+typedef struct RenderVertexStreamDesc {
+    size_t stride_bytes;
+    const RenderVertexAttribute* attributes;
+    size_t attribute_count;
+    size_t initial_capacity_bytes;
+} RenderVertexStreamDesc;
+
+typedef struct RenderVertexStream {
+    unsigned int vertex_array;
+    unsigned int vertex_buffer;
+    size_t stride_bytes;
+    size_t capacity_bytes;
+} RenderVertexStream;
+
+typedef struct BufferPool {
+    RenderVertexStream* streams;
+    size_t stream_count;
+    size_t stream_capacity;
+} BufferPool;
+
+void buffer_pool_init(BufferPool* pool);
+void buffer_pool_shutdown(BufferPool* pool);
+int buffer_pool_create_vertex_stream(BufferPool* pool,
+                                     const RenderVertexStreamDesc* desc,
+                                     RenderVertexStream* out_stream);
+int buffer_pool_reserve(BufferPool* pool, RenderVertexStream* stream, size_t capacity_bytes);
+void buffer_pool_bind_vertex_stream(const RenderVertexStream* stream);
+
+#endif /* GLDRAW_RENDER_BUFFER_POOL_H */

--- a/include/render/canvas_drawlist.h
+++ b/include/render/canvas_drawlist.h
@@ -4,6 +4,7 @@
 #include <canvas/canvas_view.h>
 #include <document/document.h>
 #include <model/selection.h>
+#include <render/render_arena.h>
 #include <render/render_device.h>
 
 #include <stddef.h>
@@ -11,7 +12,7 @@
 typedef struct CanvasStrokeCommand {
     Color color;
     float line_width;
-    RenderPathMode mode;
+    RenderPrimitiveType primitive;
     size_t point_offset;
     int point_count;
 } CanvasStrokeCommand;
@@ -23,6 +24,7 @@ typedef struct CanvasDrawList {
     CanvasStrokeCommand* strokes;
     size_t stroke_count;
     size_t stroke_capacity;
+    RenderArena scratch_arena;
     RectF clip_rect;
     Color clear_color;
 } CanvasDrawList;

--- a/include/render/render_arena.h
+++ b/include/render/render_arena.h
@@ -1,0 +1,18 @@
+#ifndef GLDRAW_RENDER_RENDER_ARENA_H
+#define GLDRAW_RENDER_RENDER_ARENA_H
+
+#include <stddef.h>
+
+typedef struct RenderArena {
+    unsigned char* memory;
+    size_t capacity_bytes;
+    size_t offset_bytes;
+} RenderArena;
+
+void render_arena_init(RenderArena* arena);
+void render_arena_reset(RenderArena* arena);
+void render_arena_shutdown(RenderArena* arena);
+int render_arena_reserve(RenderArena* arena, size_t capacity_bytes);
+void* render_arena_alloc(RenderArena* arena, size_t size_bytes, size_t alignment_bytes);
+
+#endif /* GLDRAW_RENDER_RENDER_ARENA_H */

--- a/include/render/render_device.h
+++ b/include/render/render_device.h
@@ -3,10 +3,10 @@
 
 #include <base/types.h>
 
-typedef enum RenderPathMode {
-    RENDER_PATH_LINES = 0,
-    RENDER_PATH_LINE_STRIP
-} RenderPathMode;
+typedef enum RenderPrimitiveType {
+    RENDER_PRIMITIVE_LINES = 0,
+    RENDER_PRIMITIVE_LINE_STRIP
+} RenderPrimitiveType;
 
 typedef struct RenderFrameDesc {
     int logical_width;
@@ -21,6 +21,22 @@ typedef struct RenderTransform {
     float scale_y;
 } RenderTransform;
 
+typedef struct RenderMaterial {
+    Color color;
+    float line_width;
+} RenderMaterial;
+
+typedef struct RenderGeometry {
+    const Vec2* points;
+    int point_count;
+    RenderPrimitiveType primitive;
+} RenderGeometry;
+
+typedef struct RenderPass {
+    RectF clip_rect;
+    RenderTransform transform;
+} RenderPass;
+
 typedef struct RenderDevice RenderDevice;
 
 typedef struct RenderDeviceVTable {
@@ -30,16 +46,10 @@ typedef struct RenderDeviceVTable {
                   int framebuffer_width,
                   int framebuffer_height);
     int (*begin_frame)(RenderDevice* device, const RenderFrameDesc* frame_desc);
-    void (*set_transform)(RenderDevice* device, const RenderTransform* transform);
-    void (*set_clip_rect)(RenderDevice* device, RectF clip_rect);
-    void (*set_color)(RenderDevice* device, Color color);
-    void (*draw_line)(RenderDevice* device, Vec2 from, Vec2 to, float line_width);
-    void (*draw_rect)(RenderDevice* device, RectF rect, float line_width);
-    void (*draw_path)(RenderDevice* device,
-                      const Vec2* points,
-                      int point_count,
-                      RenderPathMode mode,
-                      float line_width);
+    int (*begin_pass)(RenderDevice* device, const RenderPass* pass);
+    int (*draw_geometry)(RenderDevice* device,
+                         const RenderGeometry* geometry,
+                         const RenderMaterial* material);
     int (*read_pixels)(RenderDevice* device,
                        RectF rect,
                        unsigned char* out_rgba,
@@ -58,16 +68,10 @@ int render_device_resize(RenderDevice* device,
                          int framebuffer_width,
                          int framebuffer_height);
 int render_device_begin_frame(RenderDevice* device, const RenderFrameDesc* frame_desc);
-void render_device_set_transform(RenderDevice* device, const RenderTransform* transform);
-void render_device_set_clip_rect(RenderDevice* device, RectF clip_rect);
-void render_device_set_color(RenderDevice* device, Color color);
-void render_device_draw_line(RenderDevice* device, Vec2 from, Vec2 to, float line_width);
-void render_device_draw_rect(RenderDevice* device, RectF rect, float line_width);
-void render_device_draw_path(RenderDevice* device,
-                             const Vec2* points,
-                             int point_count,
-                             RenderPathMode mode,
-                             float line_width);
+int render_device_begin_pass(RenderDevice* device, const RenderPass* pass);
+int render_device_draw_geometry(RenderDevice* device,
+                                const RenderGeometry* geometry,
+                                const RenderMaterial* material);
 int render_device_read_pixels(RenderDevice* device,
                               RectF rect,
                               unsigned char* out_rgba,

--- a/include/render/shader_manager.h
+++ b/include/render/shader_manager.h
@@ -1,0 +1,30 @@
+#ifndef GLDRAW_RENDER_SHADER_MANAGER_H
+#define GLDRAW_RENDER_SHADER_MANAGER_H
+
+#include <stddef.h>
+
+typedef struct RenderShaderProgram {
+    unsigned int handle;
+} RenderShaderProgram;
+
+typedef struct RenderShaderProgramDesc {
+    const char* vertex_path;
+    const char* fragment_path;
+    const char* debug_label;
+} RenderShaderProgramDesc;
+
+typedef struct ShaderManager {
+    unsigned int* program_handles;
+    size_t program_count;
+    size_t program_capacity;
+} ShaderManager;
+
+void shader_manager_init(ShaderManager* manager);
+void shader_manager_shutdown(ShaderManager* manager);
+int shader_manager_load_program(ShaderManager* manager,
+                                const RenderShaderProgramDesc* desc,
+                                RenderShaderProgram* out_program);
+unsigned int shader_program_handle(const RenderShaderProgram* program);
+int shader_program_uniform_location(const RenderShaderProgram* program, const char* uniform_name);
+
+#endif /* GLDRAW_RENDER_SHADER_MANAGER_H */

--- a/include/script/script_runtime.h
+++ b/include/script/script_runtime.h
@@ -13,7 +13,7 @@ void script_runtime_shutdown(ScriptRuntime* runtime);
 void script_runtime_set_context(ScriptRuntime* runtime,
                                 Document* document,
                                 SelectionSet* selection,
-                                CommandExecutor* executor);
+                                const ToolPorts* ports);
 int script_runtime_execute_file_event(ScriptRuntime* runtime,
                                       const char* script_path,
                                       const char* event_name,

--- a/include/tools/tool.h
+++ b/include/tools/tool.h
@@ -6,10 +6,10 @@
 #define GLDRAW_TOOLS_TOOL_H
 
 #include <base/types.h>
+#include <commands/command.h>
 #include <document/document.h>
 #include <document/object.h>
 
-struct Workspace;
 struct Document;
 struct CanvasView;
 
@@ -46,11 +46,57 @@ typedef struct {
 } ToolEvent;
 
 typedef struct {
-    struct Workspace* workspace;
+    int (*execute_command)(void* user, Command* command, Document* document);
+    int (*undo)(void* user, Document* document);
+    int (*redo)(void* user, Document* document);
+    void (*set_selection_preview)(void* user, int active, Vec2 delta);
+    void (*sync_document_dirty)(void* user);
+    void* user;
+} ToolPorts;
+
+typedef struct {
     struct Document* document;
     struct CanvasView* canvas;
     SelectionSet* selection;
+    ToolPorts ports;
 } ToolContext;
+
+static inline int tool_context_execute_command(ToolContext* context, Command* command)
+{
+    return (context && context->document && context->ports.execute_command) ?
+               context->ports.execute_command(context->ports.user, command, context->document) :
+               0;
+}
+
+static inline int tool_context_undo(ToolContext* context)
+{
+    return (context && context->document && context->ports.undo) ?
+               context->ports.undo(context->ports.user, context->document) :
+               0;
+}
+
+static inline int tool_context_redo(ToolContext* context)
+{
+    return (context && context->document && context->ports.redo) ?
+               context->ports.redo(context->ports.user, context->document) :
+               0;
+}
+
+static inline void tool_context_set_selection_preview(ToolContext* context,
+                                                      int active,
+                                                      Vec2 delta)
+{
+    if (context && context->ports.set_selection_preview) {
+        context->ports.set_selection_preview(context->ports.user, active, delta);
+    }
+}
+
+static inline void tool_context_sync_document_dirty(ToolContext* context)
+{
+    if (context && context->ports.sync_document_dirty) {
+        context->ports.sync_document_dirty(context->ports.user);
+    }
+}
 
 typedef struct Tool Tool;
 typedef struct ToolDescriptor ToolDescriptor;

--- a/scripts/star_wreath.lua
+++ b/scripts/star_wreath.lua
@@ -1,5 +1,5 @@
 local function add_star(cx, cy, radius)
-    gldraw_document_add_object("fake_star", {
+    gldraw.document_add_object("fake_star", {
         x = cx - radius,
         y = cy - radius,
         width = radius * 2.0,

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -29,7 +29,6 @@
 #include <stdlib.h>
 
 #include "application_internal.h"
-#include "platform/window_internal.h"
 
 #define APP_KEYMAP_SETTINGS_PATH "gldraw.keymap.json"
 
@@ -43,13 +42,11 @@ static int app_workspace_execute_action(Workspace *workspace,
                                         void *user_data);
 
 static int app_exit_application(Application *app) {
-  GLFWwindow *handle = app ? platform_window_glfw_handle(&app->window) : NULL;
-
-  if (!app || !handle) {
+  if (!app) {
     return 0;
   }
 
-  glfwSetWindowShouldClose(handle, GLFW_TRUE);
+  platform_window_set_should_close(&app->window, 1);
   workspace_set_status_message(&app->workspace, "Closing application");
   return 1;
 }
@@ -112,21 +109,17 @@ static int app_workspace_execute_action(Workspace *workspace,
  * @param height New framebuffer height.
  * @return No return value.
  */
-static void framebuffer_size_callback(GLFWwindow *handle, int width,
-                                      int height) {
-  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+static void framebuffer_size_callback(PlatformWindow *window, int width,
+                                      int height, void *user_data) {
+  Application *app = (Application *)user_data;
   int window_width = 0;
   int window_height = 0;
 
-  if (!app) {
+  if (!app || !window) {
     return;
   }
 
-  glfwGetWindowSize(handle, &window_width, &window_height);
-  app->window.width = window_width;
-  app->window.height = window_height;
-  app->window.framebuffer_width = width;
-  app->window.framebuffer_height = height;
+  platform_window_get_size(window, &window_width, &window_height);
   application_runtime_update_canvas_viewport(app);
   render_system_resize(app->renderer, window_width, window_height, width, height);
 }
@@ -138,10 +131,14 @@ static void framebuffer_size_callback(GLFWwindow *handle, int width,
  * @param ypos Cursor y position in screen coordinates.
  * @return No return value.
  */
-static void cursor_pos_callback(GLFWwindow *handle, double xpos, double ypos) {
-  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+static void cursor_pos_callback(PlatformWindow *window,
+                                double xpos,
+                                double ypos,
+                                void *user_data) {
+  Application *app = (Application *)user_data;
   ToolContext context;
   ToolEvent event;
+  (void)window;
 
   if (!app) {
     return;
@@ -169,11 +166,15 @@ static void cursor_pos_callback(GLFWwindow *handle, double xpos, double ypos) {
  * @param mods Modifier key flags.
  * @return No return value.
  */
-static void mouse_button_callback(GLFWwindow *handle, int button, int action,
-                                  int mods) {
-  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+static void mouse_button_callback(PlatformWindow *window,
+                                  int button,
+                                  int action,
+                                  int mods,
+                                  void *user_data) {
+  Application *app = (Application *)user_data;
   ToolContext context;
   ToolEvent event;
+  (void)window;
 
   if (!app) {
     return;
@@ -220,12 +221,17 @@ static void mouse_button_callback(GLFWwindow *handle, int button, int action,
  * - Global document/view commands must win over tool-specific key handlers
  *   for predictable editor behavior.
  */
-static void key_callback(GLFWwindow *handle, int key, int scancode, int action,
-                         int mods) {
-  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+static void key_callback(PlatformWindow *window,
+                         int key,
+                         int scancode,
+                         int action,
+                         int mods,
+                         void *user_data) {
+  Application *app = (Application *)user_data;
   ToolContext context;
   InputRouterContext router_context;
   KeyEvent event;
+  (void)window;
   (void)scancode;
 
   if (!app) {
@@ -255,10 +261,13 @@ static void key_callback(GLFWwindow *handle, int key, int scancode, int action,
  * @param yoffset Vertical scroll delta.
  * @return No return value.
  */
-static void scroll_callback(GLFWwindow *handle, double xoffset,
-                            double yoffset) {
-  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+static void scroll_callback(PlatformWindow *window,
+                            double xoffset,
+                            double yoffset,
+                            void *user_data) {
+  Application *app = (Application *)user_data;
   ToolContext context;
+  (void)window;
   (void)xoffset;
 
   if (!app) {
@@ -275,14 +284,14 @@ static void scroll_callback(GLFWwindow *handle, double xoffset,
                          (float)yoffset);
 }
 
-static void window_close_callback(GLFWwindow *handle) {
-  Application *app = (Application *)glfwGetWindowUserPointer(handle);
+static void window_close_callback(PlatformWindow *window, void *user_data) {
+  Application *app = (Application *)user_data;
 
-  if (!app) {
+  if (!app || !window) {
     return;
   }
 
-  glfwSetWindowShouldClose(handle, GLFW_FALSE);
+  platform_window_set_should_close(window, 0);
   workspace_request_action(&app->workspace, WORKSPACE_ACTION_EXIT_APPLICATION);
 }
 
@@ -296,7 +305,6 @@ static void window_close_callback(GLFWwindow *handle) {
  */
 static int app_init(Application *app) {
   RectF viewport = {0.0f, 0.0f, 1440.0f, 900.0f};
-  GLFWwindow *native_window = NULL;
 
   if (platform_window_init(&app->window, 1440, 900, "GLDraw Canvas") != 0) {
     LOG_ERROR("%s", "Failed to create window");
@@ -343,14 +351,12 @@ static int app_init(Application *app) {
     ui_system_set_action_sink(app->ui, &sink);
   }
 
-  native_window = platform_window_glfw_handle(&app->window);
-  glfwSetWindowUserPointer(native_window, app);
-  glfwSetFramebufferSizeCallback(native_window, framebuffer_size_callback);
-  glfwSetCursorPosCallback(native_window, cursor_pos_callback);
-  glfwSetMouseButtonCallback(native_window, mouse_button_callback);
-  glfwSetKeyCallback(native_window, key_callback);
-  glfwSetScrollCallback(native_window, scroll_callback);
-  glfwSetWindowCloseCallback(native_window, window_close_callback);
+  platform_window_on_framebuffer_size(&app->window, framebuffer_size_callback, app);
+  platform_window_on_cursor_pos(&app->window, cursor_pos_callback, app);
+  platform_window_on_mouse_button(&app->window, mouse_button_callback, app);
+  platform_window_on_key(&app->window, key_callback, app);
+  platform_window_on_scroll(&app->window, scroll_callback, app);
+  platform_window_on_close(&app->window, window_close_callback, app);
 
   render_system_resize(app->renderer,
                        app->window.width,
@@ -410,15 +416,14 @@ int app_run(void) {
   while (!platform_window_should_close(&app->window)) {
     int framebuffer_w = 0;
     int framebuffer_h = 0;
-    GLFWwindow *native_window = platform_window_glfw_handle(&app->window);
     ToolContext tool_context;
 
     platform_window_poll_events();
-    glfwGetFramebufferSize(native_window, &framebuffer_w, &framebuffer_h);
+    platform_window_get_framebuffer_size(&app->window, &framebuffer_w, &framebuffer_h);
     if (framebuffer_w <= 0 || framebuffer_h <= 0) {
       /* During monitor/fullscreen transitions some platforms briefly report
          zero-sized framebuffers. Avoid busy rendering loops in that state. */
-      glfwWaitEventsTimeout(0.02);
+      platform_window_wait_events_timeout(0.02);
       continue;
     }
     ui_system_begin_frame(app->ui);

--- a/src/app/application_file_actions.c
+++ b/src/app/application_file_actions.c
@@ -1,5 +1,6 @@
 #include <app/application_file_actions.h>
 
+#include <app/workspace_internal.h>
 #include <app/application_dialog_actions.h>
 #include <app/workspace_dialogs.h>
 #include <app/workspace_service.h>

--- a/src/app/application_internal.h
+++ b/src/app/application_internal.h
@@ -2,7 +2,7 @@
 #define GLDRAW_APP_APPLICATION_INTERNAL_H
 
 #include <app/command_dispatcher.h>
-#include <app/workspace.h>
+#include <app/workspace_internal.h>
 #include <platform/window.h>
 #include <render/render_system.h>
 #include <ui/editor_viewmodel.h>

--- a/src/app/command_dispatcher.c
+++ b/src/app/command_dispatcher.c
@@ -1,5 +1,6 @@
 #include <app/command_dispatcher.h>
 
+#include <app/workspace_internal.h>
 #include <app/command_registry.h>
 #include <app/workspace_actions.h>
 #include <commands/command.h>

--- a/src/app/command_registry.c
+++ b/src/app/command_registry.c
@@ -4,7 +4,7 @@
  */
 #include <app/command_registry.h>
 
-#include <app/workspace.h>
+#include <app/workspace_internal.h>
 #include <app/workspace_actions.h>
 #include <app/workspace_dialogs.h>
 #include <base/math2d.h>

--- a/src/app/editor_viewmodel.c
+++ b/src/app/editor_viewmodel.c
@@ -1,9 +1,10 @@
 #include <ui/editor_viewmodel.h>
 
-#include <app/workspace.h>
+#include <app/workspace_internal.h>
 #include <canvas/canvas_view.h>
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 typedef struct EditorCommandMapEntry {

--- a/src/app/workspace.c
+++ b/src/app/workspace.c
@@ -4,14 +4,69 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+static int workspace_tool_execute_command(void* user, Command* command, Document* document)
+{
+    Workspace* workspace = (Workspace*)user;
+
+    if (!workspace || !command || !document) {
+        return 0;
+    }
+
+    return command_executor_execute(&workspace->core.commands, command, document);
+}
+
+static int workspace_tool_undo(void* user, Document* document)
+{
+    Workspace* workspace = (Workspace*)user;
+
+    if (!workspace || !document) {
+        return 0;
+    }
+
+    return command_executor_undo(&workspace->core.commands, document);
+}
+
+static int workspace_tool_redo(void* user, Document* document)
+{
+    Workspace* workspace = (Workspace*)user;
+
+    if (!workspace || !document) {
+        return 0;
+    }
+
+    return command_executor_redo(&workspace->core.commands, document);
+}
+
+static void workspace_tool_set_selection_preview(void* user, int active, Vec2 delta)
+{
+    Workspace* workspace = (Workspace*)user;
+
+    if (!workspace) {
+        return;
+    }
+
+    workspace->session.selection_preview_active = active;
+    workspace->session.selection_preview_delta = active ? delta : (Vec2){0.0f, 0.0f};
+}
+
+static void workspace_tool_sync_document_dirty(void* user)
+{
+    workspace_sync_document_dirty((Workspace*)user);
+}
+
 ToolContext workspace_tool_context(Workspace* workspace)
 {
     ToolContext context;
 
-    context.workspace = workspace;
     context.document = workspace ? &workspace->core.document : NULL;
     context.canvas = workspace ? &workspace->core.canvas : NULL;
     context.selection = workspace ? &workspace->session.selection : NULL;
+    context.ports.execute_command = workspace ? workspace_tool_execute_command : NULL;
+    context.ports.undo = workspace ? workspace_tool_undo : NULL;
+    context.ports.redo = workspace ? workspace_tool_redo : NULL;
+    context.ports.set_selection_preview = workspace ? workspace_tool_set_selection_preview : NULL;
+    context.ports.sync_document_dirty = workspace ? workspace_tool_sync_document_dirty : NULL;
+    context.ports.user = workspace;
     return context;
 }
 

--- a/src/app/workspace.c
+++ b/src/app/workspace.c
@@ -1,0 +1,175 @@
+#include <app/workspace_internal.h>
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+ToolContext workspace_tool_context(Workspace* workspace)
+{
+    ToolContext context;
+
+    context.workspace = workspace;
+    context.document = workspace ? &workspace->core.document : NULL;
+    context.canvas = workspace ? &workspace->core.canvas : NULL;
+    context.selection = workspace ? &workspace->session.selection : NULL;
+    return context;
+}
+
+Document* workspace_get_document(Workspace* workspace)
+{
+    return workspace ? &workspace->core.document : NULL;
+}
+
+CommandExecutor* workspace_get_command_executor(Workspace* workspace)
+{
+    return workspace ? &workspace->core.commands : NULL;
+}
+
+CanvasView* workspace_get_canvas(Workspace* workspace)
+{
+    return workspace ? &workspace->core.canvas : NULL;
+}
+
+ToolController* workspace_get_tool_controller(Workspace* workspace)
+{
+    return workspace ? &workspace->core.tools : NULL;
+}
+
+EditorKeymap* workspace_get_keymap(Workspace* workspace)
+{
+    return workspace ? &workspace->session.keymap : NULL;
+}
+
+SelectionSet* workspace_get_selection(Workspace* workspace)
+{
+    return workspace ? &workspace->session.selection : NULL;
+}
+
+const char* workspace_get_status_message(const Workspace* workspace)
+{
+    return workspace ? workspace->session.status_message : "";
+}
+
+WorkspaceLayout workspace_get_layout(const Workspace* workspace)
+{
+    return workspace ? workspace->session.layout : (WorkspaceLayout){0};
+}
+
+UiRequestType workspace_get_active_request_type(const Workspace* workspace)
+{
+    return workspace ? workspace->session.active_request_type : UI_REQUEST_NONE;
+}
+
+UiDialogState* workspace_get_active_dialog(Workspace* workspace)
+{
+    return workspace ? &workspace->session.active_dialog : NULL;
+}
+
+const UiDialogState* workspace_get_active_dialog_const(const Workspace* workspace)
+{
+    return workspace ? &workspace->session.active_dialog : NULL;
+}
+
+int workspace_document_dirty(const Workspace* workspace)
+{
+    return workspace ? workspace->session.document_dirty : 0;
+}
+
+unsigned int workspace_saved_revision(const Workspace* workspace)
+{
+    return workspace ? workspace->session.saved_revision : 0u;
+}
+
+const char* workspace_get_current_document_path(const Workspace* workspace)
+{
+    return workspace ? workspace->session.current_document_path : "";
+}
+
+void workspace_set_status_message(Workspace* workspace, const char* message)
+{
+    if (!workspace) {
+        return;
+    }
+
+    snprintf(workspace->session.status_message,
+             sizeof(workspace->session.status_message),
+             "%s",
+             message ? message : "");
+}
+
+void workspace_set_statusf(Workspace* workspace, const char* fmt, ...)
+{
+    va_list args;
+
+    if (!workspace) {
+        return;
+    }
+    if (!fmt) {
+        workspace_set_status_message(workspace, "");
+        return;
+    }
+
+    va_start(args, fmt);
+    vsnprintf(workspace->session.status_message,
+              sizeof(workspace->session.status_message),
+              fmt,
+              args);
+    va_end(args);
+}
+
+void workspace_set_layout(Workspace* workspace, WorkspaceLayout layout)
+{
+    if (workspace) {
+        workspace->session.layout = layout;
+    }
+}
+
+int workspace_selection_preview_active(const Workspace* workspace)
+{
+    return workspace ? workspace->session.selection_preview_active : 0;
+}
+
+Vec2 workspace_selection_preview_delta(const Workspace* workspace)
+{
+    return workspace ? workspace->session.selection_preview_delta
+                     : (Vec2){0.0f, 0.0f};
+}
+
+void workspace_mark_saved(Workspace* workspace)
+{
+    if (!workspace) {
+        return;
+    }
+
+    workspace->session.saved_revision = workspace->core.document.revision;
+    workspace->session.document_dirty = 0;
+}
+
+void workspace_sync_document_dirty(Workspace* workspace)
+{
+    if (!workspace) {
+        return;
+    }
+
+    workspace->session.document_dirty =
+        (workspace->session.saved_revision != workspace->core.document.revision);
+}
+
+void workspace_clear_clipboard(Workspace* workspace)
+{
+    int i = 0;
+
+    if (!workspace) {
+        return;
+    }
+
+    for (i = 0; i < workspace->session.clipboard_count; ++i) {
+        object_destroy(workspace->session.clipboard_objects[i]);
+    }
+
+    free(workspace->session.clipboard_objects);
+    workspace->session.clipboard_objects = NULL;
+    workspace->session.clipboard_count = 0;
+    workspace->session.clipboard_capacity = 0;
+    workspace->session.clipboard_paste_serial = 0;
+}

--- a/src/app/workspace_actions.c
+++ b/src/app/workspace_actions.c
@@ -10,6 +10,7 @@
  * - Sits between UI/application entry points and application-owned executors.
  * - Uses workspace callbacks for save operations before deferred execution.
  */
+#include <app/workspace_internal.h>
 #include <app/workspace_actions.h>
 
 /** Return non-zero when the requested action can discard the current document state. */

--- a/src/app/workspace_dialogs.c
+++ b/src/app/workspace_dialogs.c
@@ -2,6 +2,7 @@
  * @file workspace_dialogs.c
  * @brief Reusable workspace-owned dialog builders and lifecycle helpers.
  */
+#include <app/workspace_internal.h>
 #include <app/workspace_dialogs.h>
 
 #include <stdio.h>

--- a/src/app/workspace_service.c
+++ b/src/app/workspace_service.c
@@ -5,6 +5,7 @@
  * Extracted from application.c to separate document manipulation
  * from the application shell and reduce the "god object" pattern.
  */
+#include <app/workspace_internal.h>
 #include <app/workspace_service.h>
 
 #include <app/registration_manifest.h>

--- a/src/input/input_router.c
+++ b/src/input/input_router.c
@@ -5,7 +5,7 @@
 #include <input/input_router.h>
 
 #include <app/command_registry.h>
-#include <app/workspace.h>
+#include <app/workspace_internal.h>
 #include <app/workspace_actions.h>
 #include <tools/tool.h>
 #include <tools/tool_controller.h>

--- a/src/model/selection.c
+++ b/src/model/selection.c
@@ -3,6 +3,13 @@
 #include <stdlib.h>
 #include <string.h>
 
+static void selection_set_touch(SelectionSet* selection)
+{
+    if (selection) {
+        selection->revision++;
+    }
+}
+
 void selection_set_init(SelectionSet* selection)
 {
     if (!selection) {
@@ -24,8 +31,9 @@ void selection_set_shutdown(SelectionSet* selection)
 
 void selection_set_clear(SelectionSet* selection)
 {
-    if (selection) {
+    if (selection && selection->count > 0) {
         selection->count = 0;
+        selection_set_touch(selection);
     }
 }
 
@@ -58,8 +66,13 @@ int selection_set_reserve(SelectionSet* selection, int needed)
 
 int selection_set_copy(SelectionSet* dst, const SelectionSet* src)
 {
+    size_t size = 0u;
+
     if (!dst || !src) {
         return 0;
+    }
+    if (dst == src) {
+        return 1;
     }
     if (src->count <= 0) {
         selection_set_clear(dst);
@@ -69,8 +82,14 @@ int selection_set_copy(SelectionSet* dst, const SelectionSet* src)
         return 0;
     }
 
-    memcpy(dst->ids, src->ids, (size_t)src->count * sizeof(src->ids[0]));
+    size = (size_t)src->count * sizeof(src->ids[0]);
+    if (dst->count == src->count && memcmp(dst->ids, src->ids, size) == 0) {
+        return 1;
+    }
+
+    memcpy(dst->ids, src->ids, size);
     dst->count = src->count;
+    selection_set_touch(dst);
     return 1;
 }
 
@@ -104,6 +123,7 @@ int selection_set_add(SelectionSet* selection, ObjectId id)
     }
 
     selection->ids[selection->count++] = id;
+    selection_set_touch(selection);
     return 1;
 }
 
@@ -121,6 +141,7 @@ void selection_set_remove(SelectionSet* selection, ObjectId id)
                     &selection->ids[i + 1],
                     (size_t)(selection->count - i - 1) * sizeof(selection->ids[0]));
             selection->count--;
+            selection_set_touch(selection);
             return;
         }
     }

--- a/src/platform/window.c
+++ b/src/platform/window.c
@@ -12,9 +12,124 @@
  */
 #include "platform/window_internal.h"
 
+#include <glad/glad.h>
+
+#define NK_INCLUDE_FIXED_TYPES
+#define NK_INCLUDE_STANDARD_IO
+#define NK_INCLUDE_STANDARD_VARARGS
+#define NK_INCLUDE_DEFAULT_ALLOCATOR
+#define NK_INCLUDE_VERTEX_BUFFER_OUTPUT
+#define NK_INCLUDE_FONT_BAKING
+#define NK_INCLUDE_DEFAULT_FONT
+#include "nuklear/nuklear.h"
+#include "nuklear/nuklear_glfw_gl3.h"
+
 #include <stdlib.h>
 
 static int g_glfw_initialized = 0;
+static GldWindow* g_window_list = NULL;
+
+static GldWindow* platform_window_find_native(GLFWwindow* glfw)
+{
+    GldWindow* current = g_window_list;
+
+    while (current) {
+        if (current->glfw == glfw) {
+            return current;
+        }
+        current = current->next;
+    }
+
+    return NULL;
+}
+
+static void platform_framebuffer_size_dispatch(GLFWwindow* glfw, int width, int height)
+{
+    GldWindow* native_window = platform_window_find_native(glfw);
+    int logical_width = 0;
+    int logical_height = 0;
+
+    if (!native_window || !native_window->owner) {
+        return;
+    }
+
+    glfwGetWindowSize(glfw, &logical_width, &logical_height);
+    native_window->owner->width = logical_width;
+    native_window->owner->height = logical_height;
+    native_window->owner->framebuffer_width = width;
+    native_window->owner->framebuffer_height = height;
+    if (native_window->framebuffer_size_callback) {
+        native_window->framebuffer_size_callback(native_window->owner,
+                                                 width,
+                                                 height,
+                                                 native_window->framebuffer_size_user_data);
+    }
+}
+
+static void platform_cursor_pos_dispatch(GLFWwindow* glfw, double xpos, double ypos)
+{
+    GldWindow* native_window = platform_window_find_native(glfw);
+
+    if (native_window && native_window->cursor_pos_callback) {
+        native_window->cursor_pos_callback(native_window->owner,
+                                           xpos,
+                                           ypos,
+                                           native_window->cursor_pos_user_data);
+    }
+}
+
+static void platform_mouse_button_dispatch(GLFWwindow* glfw, int button, int action, int mods)
+{
+    GldWindow* native_window = platform_window_find_native(glfw);
+
+    if (native_window && native_window->mouse_button_callback) {
+        native_window->mouse_button_callback(native_window->owner,
+                                             button,
+                                             action,
+                                             mods,
+                                             native_window->mouse_button_user_data);
+    }
+}
+
+static void platform_key_dispatch(GLFWwindow* glfw,
+                                  int key,
+                                  int scancode,
+                                  int action,
+                                  int mods)
+{
+    GldWindow* native_window = platform_window_find_native(glfw);
+
+    if (native_window && native_window->key_callback) {
+        native_window->key_callback(native_window->owner,
+                                    key,
+                                    scancode,
+                                    action,
+                                    mods,
+                                    native_window->key_user_data);
+    }
+}
+
+static void platform_scroll_dispatch(GLFWwindow* glfw, double xoffset, double yoffset)
+{
+    GldWindow* native_window = platform_window_find_native(glfw);
+
+    if (native_window && native_window->scroll_callback) {
+        native_window->scroll_callback(native_window->owner,
+                                       xoffset,
+                                       yoffset,
+                                       native_window->scroll_user_data);
+    }
+}
+
+static void platform_close_dispatch(GLFWwindow* glfw)
+{
+    GldWindow* native_window = platform_window_find_native(glfw);
+
+    if (native_window && native_window->close_callback) {
+        native_window->close_callback(native_window->owner,
+                                      native_window->close_user_data);
+    }
+}
 
 /**
  * @brief Initialize GLFW and create an OpenGL 3.3 Core Profile window and context.
@@ -75,7 +190,16 @@ int platform_window_init(PlatformWindow* window, int width, int height, const ch
     }
 
     window->handle = native_window;
+    native_window->owner = window;
+    native_window->next = g_window_list;
+    g_window_list = native_window;
     glfwSetWindowSizeLimits(native_window->glfw, 800, 600, GLFW_DONT_CARE, GLFW_DONT_CARE);
+    glfwSetFramebufferSizeCallback(native_window->glfw, platform_framebuffer_size_dispatch);
+    glfwSetCursorPosCallback(native_window->glfw, platform_cursor_pos_dispatch);
+    glfwSetMouseButtonCallback(native_window->glfw, platform_mouse_button_dispatch);
+    glfwSetKeyCallback(native_window->glfw, platform_key_dispatch);
+    glfwSetScrollCallback(native_window->glfw, platform_scroll_dispatch);
+    glfwSetWindowCloseCallback(native_window->glfw, platform_close_dispatch);
 
     window->width = width;
     window->height = height;
@@ -100,8 +224,19 @@ int platform_window_init(PlatformWindow* window, int width, int height, const ch
  */
 void platform_window_shutdown(PlatformWindow* window)
 {
+    GldWindow** current = NULL;
+
     if (!window) {
         return;
+    }
+
+    current = &g_window_list;
+    while (*current) {
+        if (*current == window->handle) {
+            *current = window->handle->next;
+            break;
+        }
+        current = &(*current)->next;
     }
 
     if (window->handle && window->handle->glfw) {
@@ -125,6 +260,11 @@ void platform_window_shutdown(PlatformWindow* window)
 void platform_window_poll_events(void)
 {
     glfwPollEvents();
+}
+
+void platform_window_wait_events_timeout(double timeout_seconds)
+{
+    glfwWaitEventsTimeout(timeout_seconds);
 }
 
 /**
@@ -154,4 +294,179 @@ int platform_window_should_close(const PlatformWindow* window)
         return 1;
     }
     return glfwWindowShouldClose(handle);
+}
+
+void platform_window_set_should_close(PlatformWindow* window, int should_close)
+{
+    GLFWwindow* handle = platform_window_glfw_handle(window);
+
+    if (handle) {
+        glfwSetWindowShouldClose(handle, should_close ? GLFW_TRUE : GLFW_FALSE);
+    }
+}
+
+void platform_window_get_size(PlatformWindow* window, int* width, int* height)
+{
+    GLFWwindow* handle = platform_window_glfw_handle(window);
+
+    if (!window) {
+        return;
+    }
+
+    if (handle) {
+        glfwGetWindowSize(handle, &window->width, &window->height);
+    }
+    if (width) {
+        *width = window->width;
+    }
+    if (height) {
+        *height = window->height;
+    }
+}
+
+void platform_window_get_framebuffer_size(PlatformWindow* window, int* width, int* height)
+{
+    GLFWwindow* handle = platform_window_glfw_handle(window);
+
+    if (!window) {
+        return;
+    }
+
+    if (handle) {
+        glfwGetFramebufferSize(handle,
+                               &window->framebuffer_width,
+                               &window->framebuffer_height);
+    }
+    if (width) {
+        *width = window->framebuffer_width;
+    }
+    if (height) {
+        *height = window->framebuffer_height;
+    }
+}
+
+double platform_time_seconds(void)
+{
+    return glfwGetTime();
+}
+
+void platform_window_on_framebuffer_size(PlatformWindow* window,
+                                         PlatformFramebufferSizeCallback callback,
+                                         void* user_data)
+{
+    if (!window || !window->handle) {
+        return;
+    }
+
+    window->handle->framebuffer_size_callback = callback;
+    window->handle->framebuffer_size_user_data = user_data;
+}
+
+void platform_window_on_cursor_pos(PlatformWindow* window,
+                                   PlatformCursorPosCallback callback,
+                                   void* user_data)
+{
+    if (!window || !window->handle) {
+        return;
+    }
+
+    window->handle->cursor_pos_callback = callback;
+    window->handle->cursor_pos_user_data = user_data;
+}
+
+void platform_window_on_mouse_button(PlatformWindow* window,
+                                     PlatformMouseButtonCallback callback,
+                                     void* user_data)
+{
+    if (!window || !window->handle) {
+        return;
+    }
+
+    window->handle->mouse_button_callback = callback;
+    window->handle->mouse_button_user_data = user_data;
+}
+
+void platform_window_on_key(PlatformWindow* window,
+                            PlatformKeyCallback callback,
+                            void* user_data)
+{
+    if (!window || !window->handle) {
+        return;
+    }
+
+    window->handle->key_callback = callback;
+    window->handle->key_user_data = user_data;
+}
+
+void platform_window_on_scroll(PlatformWindow* window,
+                               PlatformScrollCallback callback,
+                               void* user_data)
+{
+    if (!window || !window->handle) {
+        return;
+    }
+
+    window->handle->scroll_callback = callback;
+    window->handle->scroll_user_data = user_data;
+}
+
+void platform_window_on_close(PlatformWindow* window,
+                              PlatformCloseCallback callback,
+                              void* user_data)
+{
+    if (!window || !window->handle) {
+        return;
+    }
+
+    window->handle->close_callback = callback;
+    window->handle->close_user_data = user_data;
+}
+
+struct nk_context* platform_window_nuklear_init(struct nk_glfw* glfw, PlatformWindow* window)
+{
+    return (glfw && window) ?
+               nk_glfw3_init(glfw, platform_window_glfw_handle(window), NK_GLFW3_DEFAULT) :
+               NULL;
+}
+
+void platform_window_nuklear_shutdown(struct nk_glfw* glfw)
+{
+    if (glfw) {
+        nk_glfw3_shutdown(glfw);
+    }
+}
+
+void platform_window_nuklear_font_stash_begin(struct nk_glfw* glfw,
+                                              struct nk_font_atlas** atlas)
+{
+    if (glfw) {
+        nk_glfw3_font_stash_begin(glfw, atlas);
+    }
+}
+
+void platform_window_nuklear_font_stash_end(struct nk_glfw* glfw)
+{
+    if (glfw) {
+        nk_glfw3_font_stash_end(glfw);
+    }
+}
+
+void platform_window_nuklear_new_frame(struct nk_glfw* glfw)
+{
+    if (glfw) {
+        nk_glfw3_new_frame(glfw);
+    }
+}
+
+void platform_window_nuklear_render(struct nk_glfw* glfw,
+                                    int anti_aliasing,
+                                    int max_vertex_buffer,
+                                    int max_element_buffer)
+{
+    if (glfw) {
+        nk_glfw3_render(glfw,
+                        (enum nk_anti_aliasing)anti_aliasing,
+                        max_vertex_buffer,
+                        max_element_buffer);
+    }
 }

--- a/src/platform/window_internal.h
+++ b/src/platform/window_internal.h
@@ -12,6 +12,20 @@
 
 struct GldWindow {
     GLFWwindow* glfw;
+    PlatformWindow* owner;
+    PlatformFramebufferSizeCallback framebuffer_size_callback;
+    void* framebuffer_size_user_data;
+    PlatformCursorPosCallback cursor_pos_callback;
+    void* cursor_pos_user_data;
+    PlatformMouseButtonCallback mouse_button_callback;
+    void* mouse_button_user_data;
+    PlatformKeyCallback key_callback;
+    void* key_user_data;
+    PlatformScrollCallback scroll_callback;
+    void* scroll_user_data;
+    PlatformCloseCallback close_callback;
+    void* close_user_data;
+    struct GldWindow* next;
 };
 
 static inline GLFWwindow* platform_window_glfw_handle(const PlatformWindow* window)

--- a/src/render/buffer_pool.c
+++ b/src/render/buffer_pool.c
@@ -1,0 +1,158 @@
+#include <render/buffer_pool.h>
+
+#include <glad/glad.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+
+static int buffer_pool_track_stream(BufferPool* pool, const RenderVertexStream* stream)
+{
+    RenderVertexStream* streams = NULL;
+    size_t capacity = 0u;
+
+    if (!pool || !stream || !stream->vertex_array || !stream->vertex_buffer) {
+        return 0;
+    }
+    if (pool->stream_count >= pool->stream_capacity) {
+        capacity = pool->stream_capacity > 0u ? pool->stream_capacity * 2u : 4u;
+        streams = (RenderVertexStream*)realloc(pool->streams, capacity * sizeof(streams[0]));
+        if (!streams) {
+            return 0;
+        }
+
+        pool->streams = streams;
+        pool->stream_capacity = capacity;
+    }
+
+    pool->streams[pool->stream_count++] = *stream;
+    return 1;
+}
+
+static void buffer_pool_sync_stream(BufferPool* pool, const RenderVertexStream* stream)
+{
+    size_t i = 0u;
+
+    if (!pool || !stream) {
+        return;
+    }
+
+    for (i = 0u; i < pool->stream_count; ++i) {
+        if (pool->streams[i].vertex_array == stream->vertex_array &&
+            pool->streams[i].vertex_buffer == stream->vertex_buffer) {
+            pool->streams[i] = *stream;
+            return;
+        }
+    }
+}
+
+void buffer_pool_init(BufferPool* pool)
+{
+    if (!pool) {
+        return;
+    }
+
+    pool->streams = NULL;
+    pool->stream_count = 0u;
+    pool->stream_capacity = 0u;
+}
+
+void buffer_pool_shutdown(BufferPool* pool)
+{
+    size_t i = 0u;
+
+    if (!pool) {
+        return;
+    }
+
+    for (i = 0u; i < pool->stream_count; ++i) {
+        if (pool->streams[i].vertex_buffer != 0u) {
+            glDeleteBuffers(1, &pool->streams[i].vertex_buffer);
+        }
+        if (pool->streams[i].vertex_array != 0u) {
+            glDeleteVertexArrays(1, &pool->streams[i].vertex_array);
+        }
+    }
+
+    free(pool->streams);
+    buffer_pool_init(pool);
+}
+
+int buffer_pool_create_vertex_stream(BufferPool* pool,
+                                     const RenderVertexStreamDesc* desc,
+                                     RenderVertexStream* out_stream)
+{
+    RenderVertexStream stream = {0u, 0u, 0u, 0u};
+    size_t i = 0u;
+
+    if (!pool || !desc || !out_stream || !desc->attributes || desc->attribute_count == 0u ||
+        desc->stride_bytes == 0u) {
+        return 0;
+    }
+
+    glGenVertexArrays(1, &stream.vertex_array);
+    glGenBuffers(1, &stream.vertex_buffer);
+    if (!stream.vertex_array || !stream.vertex_buffer) {
+        if (stream.vertex_buffer) {
+            glDeleteBuffers(1, &stream.vertex_buffer);
+        }
+        if (stream.vertex_array) {
+            glDeleteVertexArrays(1, &stream.vertex_array);
+        }
+        return 0;
+    }
+
+    stream.stride_bytes = desc->stride_bytes;
+    stream.capacity_bytes = desc->initial_capacity_bytes;
+
+    glBindVertexArray(stream.vertex_array);
+    glBindBuffer(GL_ARRAY_BUFFER, stream.vertex_buffer);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)stream.capacity_bytes, NULL, GL_DYNAMIC_DRAW);
+    for (i = 0u; i < desc->attribute_count; ++i) {
+        const RenderVertexAttribute* attribute = &desc->attributes[i];
+
+        glVertexAttribPointer(attribute->index,
+                              attribute->component_count,
+                              GL_FLOAT,
+                              GL_FALSE,
+                              (GLsizei)stream.stride_bytes,
+                              (void*)(uintptr_t)attribute->offset_bytes);
+        glEnableVertexAttribArray(attribute->index);
+    }
+    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    if (!buffer_pool_track_stream(pool, &stream)) {
+        glDeleteBuffers(1, &stream.vertex_buffer);
+        glDeleteVertexArrays(1, &stream.vertex_array);
+        return 0;
+    }
+
+    *out_stream = stream;
+    return 1;
+}
+
+int buffer_pool_reserve(BufferPool* pool, RenderVertexStream* stream, size_t capacity_bytes)
+{
+    if (!pool || !stream) {
+        return 0;
+    }
+    if (capacity_bytes <= stream->capacity_bytes) {
+        return 1;
+    }
+
+    glBindBuffer(GL_ARRAY_BUFFER, stream->vertex_buffer);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)capacity_bytes, NULL, GL_DYNAMIC_DRAW);
+    stream->capacity_bytes = capacity_bytes;
+    buffer_pool_sync_stream(pool, stream);
+    return 1;
+}
+
+void buffer_pool_bind_vertex_stream(const RenderVertexStream* stream)
+{
+    if (!stream) {
+        return;
+    }
+
+    glBindVertexArray(stream->vertex_array);
+    glBindBuffer(GL_ARRAY_BUFFER, stream->vertex_buffer);
+}

--- a/src/render/canvas_drawlist.c
+++ b/src/render/canvas_drawlist.c
@@ -66,7 +66,7 @@ static int canvas_drawlist_append_stroke(CanvasDrawList* draw_list,
                                          int point_count,
                                          Color color,
                                          float line_width,
-                                         RenderPathMode mode)
+                                         RenderPrimitiveType primitive)
 {
     CanvasStrokeCommand* stroke = NULL;
 
@@ -86,7 +86,7 @@ static int canvas_drawlist_append_stroke(CanvasDrawList* draw_list,
     stroke = &draw_list->strokes[draw_list->stroke_count++];
     stroke->color = color;
     stroke->line_width = line_width;
-    stroke->mode = mode;
+    stroke->primitive = primitive;
     stroke->point_offset = draw_list->point_count;
     stroke->point_count = point_count;
     draw_list->point_count += (size_t)point_count;
@@ -129,7 +129,9 @@ static int canvas_drawlist_append_grid(CanvasDrawList* draw_list, const CanvasVi
     int index = 0;
 
     if (point_count > 0) {
-        points = (Vec2*)malloc((size_t)point_count * sizeof(points[0]));
+        points = (Vec2*)render_arena_alloc(&draw_list->scratch_arena,
+                                           (size_t)point_count * sizeof(points[0]),
+                                           sizeof(points[0]));
         if (!points) {
             return 0;
         }
@@ -150,11 +152,9 @@ static int canvas_drawlist_append_grid(CanvasDrawList* draw_list, const CanvasVi
                                            point_count,
                                            grid_color,
                                            1.0f,
-                                           RENDER_PATH_LINES)) {
-            free(points);
+                                           RENDER_PRIMITIVE_LINES)) {
             return 0;
         }
-        free(points);
     }
 
     axis_points[0] = canvas_view_world_to_screen(canvas, vec2_make(visible.x, 0.0f));
@@ -169,7 +169,7 @@ static int canvas_drawlist_append_grid(CanvasDrawList* draw_list, const CanvasVi
                                          4,
                                          axis_color,
                                          1.5f,
-                                         RENDER_PATH_LINES);
+                                         RENDER_PRIMITIVE_LINES);
 }
 
 static int canvas_drawlist_append_object(CanvasDrawList* draw_list,
@@ -192,7 +192,9 @@ static int canvas_drawlist_append_object(CanvasDrawList* draw_list,
         return 1;
     }
 
-    points = (Vec2*)malloc((size_t)point_count * sizeof(points[0]));
+    points = (Vec2*)render_arena_alloc(&draw_list->scratch_arena,
+                                       (size_t)point_count * sizeof(points[0]),
+                                       sizeof(points[0]));
     if (!points) {
         return 0;
     }
@@ -209,8 +211,7 @@ static int canvas_drawlist_append_object(CanvasDrawList* draw_list,
                                        point_count,
                                        highlight,
                                        object->style.stroke_width + 3.0f,
-                                       RENDER_PATH_LINE_STRIP)) {
-        free(points);
+                                       RENDER_PRIMITIVE_LINE_STRIP)) {
         return 0;
     }
 
@@ -219,12 +220,10 @@ static int canvas_drawlist_append_object(CanvasDrawList* draw_list,
                                        point_count,
                                        object->style.stroke_color,
                                        object->style.stroke_width,
-                                       RENDER_PATH_LINE_STRIP)) {
-        free(points);
+                                       RENDER_PRIMITIVE_LINE_STRIP)) {
         return 0;
     }
 
-    free(points);
     return 1;
 }
 
@@ -235,6 +234,7 @@ void canvas_drawlist_init(CanvasDrawList* draw_list)
     }
 
     memset(draw_list, 0, sizeof(*draw_list));
+    render_arena_init(&draw_list->scratch_arena);
 }
 
 void canvas_drawlist_reset(CanvasDrawList* draw_list)
@@ -245,6 +245,7 @@ void canvas_drawlist_reset(CanvasDrawList* draw_list)
 
     draw_list->point_count = 0u;
     draw_list->stroke_count = 0u;
+    render_arena_reset(&draw_list->scratch_arena);
     draw_list->clip_rect = (RectF){0.0f, 0.0f, 0.0f, 0.0f};
     draw_list->clear_color = (Color){0.0f, 0.0f, 0.0f, 1.0f};
 }
@@ -257,6 +258,7 @@ void canvas_drawlist_shutdown(CanvasDrawList* draw_list)
 
     free(draw_list->points);
     free(draw_list->strokes);
+    render_arena_shutdown(&draw_list->scratch_arena);
     canvas_drawlist_init(draw_list);
 }
 
@@ -286,7 +288,10 @@ int canvas_drawlist_build(CanvasDrawList* draw_list,
     }
 
     if (document->count > 0) {
-        visible_indices = (int*)malloc((size_t)document->count * sizeof(visible_indices[0]));
+        visible_indices = (int*)render_arena_alloc(&draw_list->scratch_arena,
+                                                   (size_t)document->count *
+                                                       sizeof(visible_indices[0]),
+                                                   sizeof(visible_indices[0]));
         if (!visible_indices) {
             return 0;
         }
@@ -329,7 +334,6 @@ int canvas_drawlist_build(CanvasDrawList* draw_list,
                                                object,
                                                selected,
                                                preview_delta)) {
-                free(visible_indices);
                 return 0;
             }
         }
@@ -341,10 +345,8 @@ int canvas_drawlist_build(CanvasDrawList* draw_list,
                                        overlay_object,
                                        0,
                                        vec2_make(0.0f, 0.0f))) {
-        free(visible_indices);
         return 0;
     }
 
-    free(visible_indices);
     return 1;
 }

--- a/src/render/canvas_drawlist.c
+++ b/src/render/canvas_drawlist.c
@@ -274,6 +274,7 @@ int canvas_drawlist_build(CanvasDrawList* draw_list,
     int* visible_indices = NULL;
     int visible_count = 0;
     int layer_index = 0;
+    int success = 0;
 
     if (!draw_list || !document || !canvas) {
         return 0;
@@ -284,16 +285,13 @@ int canvas_drawlist_build(CanvasDrawList* draw_list,
     draw_list->clear_color = canvas->background;
 
     if (canvas->show_grid && !canvas_drawlist_append_grid(draw_list, canvas)) {
-        return 0;
+        goto cleanup;
     }
 
     if (document->count > 0) {
-        visible_indices = (int*)render_arena_alloc(&draw_list->scratch_arena,
-                                                   (size_t)document->count *
-                                                       sizeof(visible_indices[0]),
-                                                   sizeof(visible_indices[0]));
+        visible_indices = (int*)malloc((size_t)document->count * sizeof(visible_indices[0]));
         if (!visible_indices) {
-            return 0;
+            goto cleanup;
         }
     }
 
@@ -334,7 +332,7 @@ int canvas_drawlist_build(CanvasDrawList* draw_list,
                                                object,
                                                selected,
                                                preview_delta)) {
-                return 0;
+                goto cleanup;
             }
         }
     }
@@ -345,8 +343,12 @@ int canvas_drawlist_build(CanvasDrawList* draw_list,
                                        overlay_object,
                                        0,
                                        vec2_make(0.0f, 0.0f))) {
-        return 0;
+        goto cleanup;
     }
 
-    return 1;
+    success = 1;
+
+cleanup:
+    free(visible_indices);
+    return success;
 }

--- a/src/render/canvas_renderer.c
+++ b/src/render/canvas_renderer.c
@@ -5,6 +5,7 @@ int canvas_renderer_submit(RenderDevice* device,
                            const RenderTransform* transform,
                            const CanvasDrawList* draw_list)
 {
+    RenderPass pass;
     size_t i = 0u;
 
     if (!device || !frame_desc || !transform || !draw_list) {
@@ -15,17 +16,27 @@ int canvas_renderer_submit(RenderDevice* device,
         return 0;
     }
 
-    render_device_set_transform(device, transform);
-    render_device_set_clip_rect(device, draw_list->clip_rect);
+    pass.clip_rect = draw_list->clip_rect;
+    pass.transform = *transform;
+    if (!render_device_begin_pass(device, &pass)) {
+        render_device_end_frame(device);
+        return 0;
+    }
+
     for (i = 0u; i < draw_list->stroke_count; ++i) {
         const CanvasStrokeCommand* stroke = &draw_list->strokes[i];
+        RenderGeometry geometry;
+        RenderMaterial material;
 
-        render_device_set_color(device, stroke->color);
-        render_device_draw_path(device,
-                                draw_list->points + stroke->point_offset,
-                                stroke->point_count,
-                                stroke->mode,
-                                stroke->line_width);
+        geometry.points = draw_list->points + stroke->point_offset;
+        geometry.point_count = stroke->point_count;
+        geometry.primitive = stroke->primitive;
+        material.color = stroke->color;
+        material.line_width = stroke->line_width;
+        if (!render_device_draw_geometry(device, &geometry, &material)) {
+            render_device_end_frame(device);
+            return 0;
+        }
     }
     render_device_end_frame(device);
     return 1;

--- a/src/render/render_arena.c
+++ b/src/render/render_arena.c
@@ -1,0 +1,91 @@
+#include <render/render_arena.h>
+
+#include <stdlib.h>
+
+static size_t render_arena_align_up(size_t value, size_t alignment)
+{
+    size_t remainder = 0u;
+
+    if (alignment <= 1u) {
+        return value;
+    }
+
+    remainder = value % alignment;
+    return remainder == 0u ? value : value + (alignment - remainder);
+}
+
+void render_arena_init(RenderArena* arena)
+{
+    if (!arena) {
+        return;
+    }
+
+    arena->memory = NULL;
+    arena->capacity_bytes = 0u;
+    arena->offset_bytes = 0u;
+}
+
+void render_arena_reset(RenderArena* arena)
+{
+    if (!arena) {
+        return;
+    }
+
+    arena->offset_bytes = 0u;
+}
+
+void render_arena_shutdown(RenderArena* arena)
+{
+    if (!arena) {
+        return;
+    }
+
+    free(arena->memory);
+    render_arena_init(arena);
+}
+
+int render_arena_reserve(RenderArena* arena, size_t capacity_bytes)
+{
+    unsigned char* memory = NULL;
+    size_t capacity = 0u;
+
+    if (!arena) {
+        return 0;
+    }
+    if (capacity_bytes <= arena->capacity_bytes) {
+        return 1;
+    }
+
+    capacity = arena->capacity_bytes > 0u ? arena->capacity_bytes : 256u;
+    while (capacity < capacity_bytes) {
+        capacity *= 2u;
+    }
+
+    memory = (unsigned char*)realloc(arena->memory, capacity);
+    if (!memory) {
+        return 0;
+    }
+
+    arena->memory = memory;
+    arena->capacity_bytes = capacity;
+    return 1;
+}
+
+void* render_arena_alloc(RenderArena* arena, size_t size_bytes, size_t alignment_bytes)
+{
+    size_t offset = 0u;
+    size_t required = 0u;
+
+    if (!arena || size_bytes == 0u) {
+        return NULL;
+    }
+
+    offset = render_arena_align_up(arena->offset_bytes, alignment_bytes);
+    required = offset + size_bytes;
+    if (!render_arena_reserve(arena, required)) {
+        return NULL;
+    }
+
+    arena->offset_bytes = required;
+    return arena->memory + offset;
+}

--- a/src/render/render_device.c
+++ b/src/render/render_device.c
@@ -26,50 +26,24 @@ int render_device_begin_frame(RenderDevice* device, const RenderFrameDesc* frame
     return device->vtable->begin_frame(device, frame_desc);
 }
 
-void render_device_set_transform(RenderDevice* device, const RenderTransform* transform)
+int render_device_begin_pass(RenderDevice* device, const RenderPass* pass)
 {
-    if (device && device->vtable && device->vtable->set_transform) {
-        device->vtable->set_transform(device, transform);
+    if (!device || !device->vtable || !device->vtable->begin_pass) {
+        return 0;
     }
+
+    return device->vtable->begin_pass(device, pass);
 }
 
-void render_device_set_clip_rect(RenderDevice* device, RectF clip_rect)
+int render_device_draw_geometry(RenderDevice* device,
+                                const RenderGeometry* geometry,
+                                const RenderMaterial* material)
 {
-    if (device && device->vtable && device->vtable->set_clip_rect) {
-        device->vtable->set_clip_rect(device, clip_rect);
+    if (!device || !device->vtable || !device->vtable->draw_geometry) {
+        return 0;
     }
-}
 
-void render_device_set_color(RenderDevice* device, Color color)
-{
-    if (device && device->vtable && device->vtable->set_color) {
-        device->vtable->set_color(device, color);
-    }
-}
-
-void render_device_draw_line(RenderDevice* device, Vec2 from, Vec2 to, float line_width)
-{
-    if (device && device->vtable && device->vtable->draw_line) {
-        device->vtable->draw_line(device, from, to, line_width);
-    }
-}
-
-void render_device_draw_rect(RenderDevice* device, RectF rect, float line_width)
-{
-    if (device && device->vtable && device->vtable->draw_rect) {
-        device->vtable->draw_rect(device, rect, line_width);
-    }
-}
-
-void render_device_draw_path(RenderDevice* device,
-                             const Vec2* points,
-                             int point_count,
-                             RenderPathMode mode,
-                             float line_width)
-{
-    if (device && device->vtable && device->vtable->draw_path) {
-        device->vtable->draw_path(device, points, point_count, mode, line_width);
-    }
+    return device->vtable->draw_geometry(device, geometry, material);
 }
 
 int render_device_read_pixels(RenderDevice* device,

--- a/src/render/render_device_gl.c
+++ b/src/render/render_device_gl.c
@@ -1,12 +1,14 @@
 #include "render_device_gl.h"
 
-#include <base/file_utils.h>
 #include <base/log.h>
 #include <base/math2d.h>
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 #include <glad/glad.h>
+
+#include <render/buffer_pool.h>
+#include <render/shader_manager.h>
 
 #include <math.h>
 #include <stdlib.h>
@@ -16,9 +18,10 @@
 
 typedef struct GLRenderDevice {
     RenderDevice base;
-    GLuint program;
-    GLuint vao;
-    GLuint vbo;
+    ShaderManager shader_manager;
+    BufferPool buffer_pool;
+    RenderShaderProgram basic_program;
+    RenderVertexStream stroke_stream;
     GLint screen_size_loc;
     int logical_width;
     int logical_height;
@@ -28,82 +31,10 @@ typedef struct GLRenderDevice {
     float scale_y;
     float* vertex_buffer;
     size_t vertex_capacity;
-    Color current_color;
-    RenderTransform transform;
     Color clear_color;
+    RenderPass active_pass;
     GLint clip_box[4];
 } GLRenderDevice;
-
-static GLuint gl_render_compile_shader(GLenum type, const char* source, const char* label)
-{
-    GLuint shader = glCreateShader(type);
-    GLint success = 0;
-
-    glShaderSource(shader, 1, &source, NULL);
-    glCompileShader(shader);
-    glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
-    if (!success) {
-        char info[1024];
-        glGetShaderInfoLog(shader, (GLsizei)sizeof(info), NULL, info);
-        LOG_ERROR("Shader compilation failed for %s: %s",
-                  label ? label : "unknown stage",
-                  info);
-        glDeleteShader(shader);
-        return 0;
-    }
-
-    return shader;
-}
-
-static GLuint gl_render_load_program(const char* vertex_path, const char* fragment_path)
-{
-    char* vertex_source = file_utils_read_text_file(vertex_path);
-    char* fragment_source = file_utils_read_text_file(fragment_path);
-    GLuint vertex_shader = 0;
-    GLuint fragment_shader = 0;
-    GLuint program = 0;
-    GLint success = 0;
-
-    if (!vertex_source || !fragment_source) {
-        free(vertex_source);
-        free(fragment_source);
-        return 0;
-    }
-
-    vertex_shader = gl_render_compile_shader(GL_VERTEX_SHADER, vertex_source, vertex_path);
-    fragment_shader = gl_render_compile_shader(GL_FRAGMENT_SHADER, fragment_source, fragment_path);
-    free(vertex_source);
-    free(fragment_source);
-
-    if (!vertex_shader || !fragment_shader) {
-        if (vertex_shader) {
-            glDeleteShader(vertex_shader);
-        }
-        if (fragment_shader) {
-            glDeleteShader(fragment_shader);
-        }
-        return 0;
-    }
-
-    program = glCreateProgram();
-    glAttachShader(program, vertex_shader);
-    glAttachShader(program, fragment_shader);
-    glLinkProgram(program);
-    glGetProgramiv(program, GL_LINK_STATUS, &success);
-
-    glDeleteShader(vertex_shader);
-    glDeleteShader(fragment_shader);
-
-    if (!success) {
-        char info[1024];
-        glGetProgramInfoLog(program, (GLsizei)sizeof(info), NULL, info);
-        LOG_ERROR("Program link failed: %s", info);
-        glDeleteProgram(program);
-        return 0;
-    }
-
-    return program;
-}
 
 static int gl_render_reserve_vertices(GLRenderDevice* device, size_t vertex_count)
 {
@@ -124,12 +55,9 @@ static int gl_render_reserve_vertices(GLRenderDevice* device, size_t vertex_coun
 
     device->vertex_buffer = buffer;
     device->vertex_capacity = required;
-    glBindBuffer(GL_ARRAY_BUFFER, device->vbo);
-    glBufferData(GL_ARRAY_BUFFER,
-                 (GLsizeiptr)(required * sizeof(device->vertex_buffer[0])),
-                 NULL,
-                 GL_DYNAMIC_DRAW);
-    return 1;
+    return buffer_pool_reserve(&device->buffer_pool,
+                               &device->stroke_stream,
+                               required * sizeof(device->vertex_buffer[0]));
 }
 
 static Vec2 gl_render_transform_point(const GLRenderDevice* device, Vec2 point)
@@ -140,8 +68,8 @@ static Vec2 gl_render_transform_point(const GLRenderDevice* device, Vec2 point)
         return out;
     }
 
-    out.x *= device->transform.scale_x;
-    out.y *= device->transform.scale_y;
+    out.x *= device->active_pass.transform.scale_x;
+    out.y *= device->active_pass.transform.scale_y;
     return out;
 }
 
@@ -156,26 +84,24 @@ static void gl_render_write_vertex(float** cursor, Vec2 point, Color color)
 }
 
 static int gl_render_upload_and_draw(GLRenderDevice* device,
-                                     const Vec2* points,
-                                     int point_count,
-                                     RenderPathMode mode,
-                                     float line_width)
+                                     const RenderGeometry* geometry,
+                                     const RenderMaterial* material)
 {
     int vertex_count = 0;
     GLenum primitive = GL_LINES;
     float* cursor = NULL;
     int i = 0;
 
-    if (!device || !points || point_count <= 1) {
+    if (!device || !geometry || !geometry->points || geometry->point_count <= 1 || !material) {
         return 0;
     }
 
-    if (mode == RENDER_PATH_LINE_STRIP) {
+    if (geometry->primitive == RENDER_PRIMITIVE_LINE_STRIP) {
         primitive = GL_LINES;
-        vertex_count = (point_count - 1) * 2;
+        vertex_count = (geometry->point_count - 1) * 2;
     } else {
         primitive = GL_LINES;
-        vertex_count = point_count;
+        vertex_count = geometry->point_count;
     }
 
     if (!gl_render_reserve_vertices(device, (size_t)vertex_count)) {
@@ -183,32 +109,31 @@ static int gl_render_upload_and_draw(GLRenderDevice* device,
     }
 
     cursor = device->vertex_buffer;
-    if (mode == RENDER_PATH_LINE_STRIP) {
-        for (i = 0; i < point_count - 1; ++i) {
+    if (geometry->primitive == RENDER_PRIMITIVE_LINE_STRIP) {
+        for (i = 0; i < geometry->point_count - 1; ++i) {
             gl_render_write_vertex(&cursor,
-                                   gl_render_transform_point(device, points[i]),
-                                   device->current_color);
+                                   gl_render_transform_point(device, geometry->points[i]),
+                                   material->color);
             gl_render_write_vertex(&cursor,
-                                   gl_render_transform_point(device, points[i + 1]),
-                                   device->current_color);
+                                   gl_render_transform_point(device, geometry->points[i + 1]),
+                                   material->color);
         }
     } else {
-        for (i = 0; i < point_count; ++i) {
+        for (i = 0; i < geometry->point_count; ++i) {
             gl_render_write_vertex(&cursor,
-                                   gl_render_transform_point(device, points[i]),
-                                   device->current_color);
+                                   gl_render_transform_point(device, geometry->points[i]),
+                                   material->color);
         }
     }
 
-    glUseProgram(device->program);
-    glBindVertexArray(device->vao);
-    glBindBuffer(GL_ARRAY_BUFFER, device->vbo);
+    glUseProgram(shader_program_handle(&device->basic_program));
+    buffer_pool_bind_vertex_stream(&device->stroke_stream);
     glBufferSubData(GL_ARRAY_BUFFER,
                     0,
                     (GLsizeiptr)(vertex_count * GL_RENDER_VERTEX_STRIDE_FLOATS *
                                  sizeof(device->vertex_buffer[0])),
                     device->vertex_buffer);
-    glLineWidth((line_width > 0.5f) ? line_width : 1.0f);
+    glLineWidth((material->line_width > 0.5f) ? material->line_width : 1.0f);
     glDrawArrays(primitive, 0, vertex_count);
     return 1;
 }
@@ -235,7 +160,7 @@ static int gl_render_resize(RenderDevice* render_device,
                                            : 1.0f;
 
     glViewport(0, 0, framebuffer_width, framebuffer_height);
-    glUseProgram(device->program);
+    glUseProgram(shader_program_handle(&device->basic_program));
     if (device->screen_size_loc >= 0) {
         glUniform2f(device->screen_size_loc,
                     (float)framebuffer_width,
@@ -259,30 +184,21 @@ static int gl_render_begin_frame(RenderDevice* render_device, const RenderFrameD
                      frame_desc->framebuffer_width,
                      frame_desc->framebuffer_height);
     device->clear_color = frame_desc->clear_color;
-    device->current_color = (Color){1.0f, 1.0f, 1.0f, 1.0f};
-    device->transform.scale_x = device->scale_x;
-    device->transform.scale_y = device->scale_y;
+    device->active_pass.transform.scale_x = device->scale_x;
+    device->active_pass.transform.scale_y = device->scale_y;
+    device->active_pass.clip_rect = (RectF){0.0f,
+                                            0.0f,
+                                            (float)frame_desc->logical_width,
+                                            (float)frame_desc->logical_height};
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glUseProgram(device->program);
-    glBindVertexArray(device->vao);
-    glBindBuffer(GL_ARRAY_BUFFER, device->vbo);
+    glUseProgram(shader_program_handle(&device->basic_program));
+    buffer_pool_bind_vertex_stream(&device->stroke_stream);
     return 1;
 }
 
-static void gl_render_set_transform(RenderDevice* render_device, const RenderTransform* transform)
-{
-    GLRenderDevice* device = (GLRenderDevice*)render_device;
-
-    if (!device || !transform) {
-        return;
-    }
-
-    device->transform = *transform;
-}
-
-static void gl_render_set_clip_rect(RenderDevice* render_device, RectF clip_rect)
+static int gl_render_begin_pass(RenderDevice* render_device, const RenderPass* pass)
 {
     GLRenderDevice* device = (GLRenderDevice*)render_device;
     int x = 0;
@@ -291,14 +207,15 @@ static void gl_render_set_clip_rect(RenderDevice* render_device, RectF clip_rect
     int h = 0;
     int y = 0;
 
-    if (!device) {
-        return;
+    if (!device || !pass) {
+        return 0;
     }
 
-    x = (int)floorf(clip_rect.x * device->scale_x);
-    y_top = (int)floorf(clip_rect.y * device->scale_y);
-    w = (int)ceilf(clip_rect.w * device->scale_x);
-    h = (int)ceilf(clip_rect.h * device->scale_y);
+    device->active_pass = *pass;
+    x = (int)floorf(pass->clip_rect.x * device->scale_x);
+    y_top = (int)floorf(pass->clip_rect.y * device->scale_y);
+    w = (int)ceilf(pass->clip_rect.w * device->scale_x);
+    h = (int)ceilf(pass->clip_rect.h * device->scale_y);
     y = device->framebuffer_height - y_top - h;
 
     if (x < 0) {
@@ -316,7 +233,7 @@ static void gl_render_set_clip_rect(RenderDevice* render_device, RectF clip_rect
         h = device->framebuffer_height - y;
     }
     if (w <= 0 || h <= 0) {
-        return;
+        return 0;
     }
 
     device->clip_box[0] = x;
@@ -331,64 +248,14 @@ static void gl_render_set_clip_rect(RenderDevice* render_device, RectF clip_rect
                  device->clear_color.b,
                  device->clear_color.a);
     glClear(GL_COLOR_BUFFER_BIT);
+    return 1;
 }
 
-static void gl_render_set_color(RenderDevice* render_device, Color color)
+static int gl_render_draw_geometry(RenderDevice* render_device,
+                                   const RenderGeometry* geometry,
+                                   const RenderMaterial* material)
 {
-    GLRenderDevice* device = (GLRenderDevice*)render_device;
-
-    if (!device) {
-        return;
-    }
-
-    device->current_color = color;
-}
-
-static void gl_render_draw_line(RenderDevice* render_device,
-                                Vec2 from,
-                                Vec2 to,
-                                float line_width)
-{
-    Vec2 points[2];
-
-    points[0] = from;
-    points[1] = to;
-    gl_render_upload_and_draw((GLRenderDevice*)render_device,
-                              points,
-                              2,
-                              RENDER_PATH_LINES,
-                              line_width);
-}
-
-static void gl_render_draw_rect(RenderDevice* render_device,
-                                RectF rect,
-                                float line_width)
-{
-    Vec2 points[5];
-
-    points[0] = vec2_make(rect.x, rect.y);
-    points[1] = vec2_make(rect.x + rect.w, rect.y);
-    points[2] = vec2_make(rect.x + rect.w, rect.y + rect.h);
-    points[3] = vec2_make(rect.x, rect.y + rect.h);
-    points[4] = points[0];
-    gl_render_upload_and_draw((GLRenderDevice*)render_device,
-                              points,
-                              5,
-                              RENDER_PATH_LINE_STRIP,
-                              line_width);
-}
-
-static void gl_render_draw_path(RenderDevice* render_device,
-                                const Vec2* points,
-                                int point_count,
-                                RenderPathMode mode,
-                                float line_width)
-{
-    gl_render_upload_and_draw((GLRenderDevice*)render_device,
-                              points,
-                              point_count,
-                              mode,
-                              line_width);
+    return gl_render_upload_and_draw((GLRenderDevice*)render_device, geometry, material);
 }
 
 static int gl_render_read_pixels(RenderDevice* render_device,
@@ -446,22 +313,17 @@ static void gl_render_destroy(RenderDevice* render_device)
         return;
     }
 
-    glDeleteBuffers(1, &device->vbo);
-    glDeleteVertexArrays(1, &device->vao);
-    glDeleteProgram(device->program);
     free(device->vertex_buffer);
+    buffer_pool_shutdown(&device->buffer_pool);
+    shader_manager_shutdown(&device->shader_manager);
     free(device);
 }
 
 static const RenderDeviceVTable GL_RENDER_DEVICE_VTABLE = {
     gl_render_resize,
     gl_render_begin_frame,
-    gl_render_set_transform,
-    gl_render_set_clip_rect,
-    gl_render_set_color,
-    gl_render_draw_line,
-    gl_render_draw_rect,
-    gl_render_draw_path,
+    gl_render_begin_pass,
+    gl_render_draw_geometry,
     gl_render_read_pixels,
     gl_render_end_frame,
     gl_render_destroy
@@ -470,6 +332,21 @@ static const RenderDeviceVTable GL_RENDER_DEVICE_VTABLE = {
 RenderDevice* gl_render_device_create(PlatformWindow* window)
 {
     GLRenderDevice* device = NULL;
+    static const RenderShaderProgramDesc BASIC_PROGRAM_DESC = {
+        "shaders/basic.vert",
+        "shaders/basic.frag",
+        "basic"
+    };
+    static const RenderVertexAttribute STROKE_ATTRIBUTES[] = {
+        {0u, 2, 0u},
+        {1u, 4, 2u * sizeof(float)}
+    };
+    static const RenderVertexStreamDesc STROKE_STREAM_DESC = {
+        GL_RENDER_VERTEX_STRIDE_FLOATS * sizeof(float),
+        STROKE_ATTRIBUTES,
+        sizeof(STROKE_ATTRIBUTES) / sizeof(STROKE_ATTRIBUTES[0]),
+        0u
+    };
 
     if (!window) {
         return NULL;
@@ -484,23 +361,25 @@ RenderDevice* gl_render_device_create(PlatformWindow* window)
     }
 
     device->base.vtable = &GL_RENDER_DEVICE_VTABLE;
-    device->program = gl_render_load_program("shaders/basic.vert", "shaders/basic.frag");
-    if (!device->program) {
+    shader_manager_init(&device->shader_manager);
+    buffer_pool_init(&device->buffer_pool);
+
+    if (!shader_manager_load_program(&device->shader_manager,
+                                     &BASIC_PROGRAM_DESC,
+                                     &device->basic_program)) {
         gl_render_destroy(&device->base);
         return NULL;
     }
 
-    glGenVertexArrays(1, &device->vao);
-    glGenBuffers(1, &device->vbo);
-    glBindVertexArray(device->vao);
-    glBindBuffer(GL_ARRAY_BUFFER, device->vbo);
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)0);
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)(2 * sizeof(float)));
-    glEnableVertexAttribArray(1);
-    glBindVertexArray(0);
+    if (!buffer_pool_create_vertex_stream(&device->buffer_pool,
+                                          &STROKE_STREAM_DESC,
+                                          &device->stroke_stream)) {
+        gl_render_destroy(&device->base);
+        return NULL;
+    }
 
-    device->screen_size_loc = glGetUniformLocation(device->program, "uScreenSize");
+    device->screen_size_loc = shader_program_uniform_location(&device->basic_program,
+                                                              "uScreenSize");
     if (!gl_render_resize(&device->base,
                           window->width,
                           window->height,

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -16,6 +16,7 @@ struct RenderSystem {
     unsigned int cached_document_revision;
     unsigned int cached_overlay_revision;
     int cached_selection_count;
+    uint64_t cached_selection_revision;
     int cached_selection_preview_active;
     RectF cached_viewport;
     Vec2 cached_center;
@@ -116,6 +117,7 @@ void render_system_draw(RenderSystem* renderer,
         renderer->cached_document_revision != document->revision ||
         renderer->cached_overlay_revision != (overlay_object ? overlay_object->revision : 0u) ||
         renderer->cached_selection_count != (selection ? selection->count : 0) ||
+        renderer->cached_selection_revision != (selection ? selection->revision : 0u) ||
         renderer->cached_selection_preview_active != selection_preview_active ||
         renderer->cached_selection_preview_delta.x != selection_preview_delta.x ||
         renderer->cached_selection_preview_delta.y != selection_preview_delta.y ||
@@ -138,6 +140,7 @@ void render_system_draw(RenderSystem* renderer,
         renderer->cached_document_revision = document->revision;
         renderer->cached_overlay_revision = overlay_object ? overlay_object->revision : 0u;
         renderer->cached_selection_count = selection ? selection->count : 0;
+        renderer->cached_selection_revision = selection ? selection->revision : 0u;
         renderer->cached_selection_preview_active = selection_preview_active;
         renderer->cached_selection_preview_delta = selection_preview_delta;
         renderer->cached_viewport = canvas_view_viewport(canvas);

--- a/src/render/shader_manager.c
+++ b/src/render/shader_manager.c
@@ -1,0 +1,166 @@
+#include <render/shader_manager.h>
+
+#include <base/file_utils.h>
+#include <base/log.h>
+
+#include <glad/glad.h>
+
+#include <stdlib.h>
+
+static int shader_manager_track_program(ShaderManager* manager, unsigned int handle)
+{
+    unsigned int* handles = NULL;
+    size_t capacity = 0u;
+
+    if (!manager || !handle) {
+        return 0;
+    }
+    if (manager->program_count >= manager->program_capacity) {
+        capacity = manager->program_capacity > 0u ? manager->program_capacity * 2u : 4u;
+        handles =
+            (unsigned int*)realloc(manager->program_handles, capacity * sizeof(handles[0]));
+        if (!handles) {
+            return 0;
+        }
+
+        manager->program_handles = handles;
+        manager->program_capacity = capacity;
+    }
+
+    manager->program_handles[manager->program_count++] = handle;
+    return 1;
+}
+
+static GLuint shader_manager_compile_shader(GLenum type, const char* source, const char* label)
+{
+    GLuint shader = glCreateShader(type);
+    GLint success = 0;
+
+    glShaderSource(shader, 1, &source, NULL);
+    glCompileShader(shader);
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+    if (!success) {
+        char info[1024];
+        glGetShaderInfoLog(shader, (GLsizei)sizeof(info), NULL, info);
+        LOG_ERROR("Shader compilation failed for %s: %s",
+                  label ? label : "unknown stage",
+                  info);
+        glDeleteShader(shader);
+        return 0;
+    }
+
+    return shader;
+}
+
+void shader_manager_init(ShaderManager* manager)
+{
+    if (!manager) {
+        return;
+    }
+
+    manager->program_handles = NULL;
+    manager->program_count = 0u;
+    manager->program_capacity = 0u;
+}
+
+void shader_manager_shutdown(ShaderManager* manager)
+{
+    size_t i = 0u;
+
+    if (!manager) {
+        return;
+    }
+
+    for (i = 0u; i < manager->program_count; ++i) {
+        if (manager->program_handles[i] != 0u) {
+            glDeleteProgram(manager->program_handles[i]);
+        }
+    }
+
+    free(manager->program_handles);
+    shader_manager_init(manager);
+}
+
+int shader_manager_load_program(ShaderManager* manager,
+                                const RenderShaderProgramDesc* desc,
+                                RenderShaderProgram* out_program)
+{
+    char* vertex_source = NULL;
+    char* fragment_source = NULL;
+    GLuint vertex_shader = 0;
+    GLuint fragment_shader = 0;
+    GLuint program = 0;
+    GLint success = 0;
+
+    if (!manager || !desc || !desc->vertex_path || !desc->fragment_path || !out_program) {
+        return 0;
+    }
+
+    vertex_source = file_utils_read_text_file(desc->vertex_path);
+    fragment_source = file_utils_read_text_file(desc->fragment_path);
+    if (!vertex_source || !fragment_source) {
+        free(vertex_source);
+        free(fragment_source);
+        return 0;
+    }
+
+    vertex_shader =
+        shader_manager_compile_shader(GL_VERTEX_SHADER, vertex_source, desc->vertex_path);
+    fragment_shader =
+        shader_manager_compile_shader(GL_FRAGMENT_SHADER, fragment_source, desc->fragment_path);
+    free(vertex_source);
+    free(fragment_source);
+
+    if (!vertex_shader || !fragment_shader) {
+        if (vertex_shader) {
+            glDeleteShader(vertex_shader);
+        }
+        if (fragment_shader) {
+            glDeleteShader(fragment_shader);
+        }
+        return 0;
+    }
+
+    program = glCreateProgram();
+    glAttachShader(program, vertex_shader);
+    glAttachShader(program, fragment_shader);
+    glLinkProgram(program);
+    glGetProgramiv(program, GL_LINK_STATUS, &success);
+
+    glDeleteShader(vertex_shader);
+    glDeleteShader(fragment_shader);
+
+    if (!success) {
+        char info[1024];
+        glGetProgramInfoLog(program, (GLsizei)sizeof(info), NULL, info);
+        LOG_ERROR("Program link failed for %s: %s",
+                  desc->debug_label ? desc->debug_label : "unnamed program",
+                  info);
+        glDeleteProgram(program);
+        return 0;
+    }
+
+    if (!shader_manager_track_program(manager, program)) {
+        glDeleteProgram(program);
+        return 0;
+    }
+
+    out_program->handle = program;
+    return 1;
+}
+
+unsigned int shader_program_handle(const RenderShaderProgram* program)
+{
+    return program ? program->handle : 0u;
+}
+
+int shader_program_uniform_location(const RenderShaderProgram* program, const char* uniform_name)
+{
+    unsigned int handle = shader_program_handle(program);
+
+    if (!handle || !uniform_name) {
+        return -1;
+    }
+
+    return glGetUniformLocation(handle, uniform_name);
+}

--- a/src/script/script_runtime_lua.c
+++ b/src/script/script_runtime_lua.c
@@ -6,18 +6,31 @@
 #include <lauxlib.h>
 #include <lualib.h>
 
+#include <stdio.h>
 #include <string.h>
+
+#define GLDRAW_SCRIPT_MAX_PATH 260
 
 struct ScriptRuntime {
     lua_State* state;
     Document* document;
     SelectionSet* selection;
     CommandExecutor* executor;
+    int environment_ref;
+    int script_loaded;
+    char loaded_script_path[GLDRAW_SCRIPT_MAX_PATH];
 };
 
 static ScriptRuntime* script_runtime_from_lua(lua_State* state)
 {
     return (ScriptRuntime*)lua_touserdata(state, lua_upvalueindex(1));
+}
+
+static void script_runtime_env_copy_global(lua_State* state, int env_index, const char* name)
+{
+    env_index = lua_absindex(state, env_index);
+    lua_getglobal(state, name);
+    lua_setfield(state, env_index, name);
 }
 
 static int script_runtime_execute_command(ScriptRuntime* runtime,
@@ -144,41 +157,30 @@ static int script_api_document_add_object(lua_State* state)
     return 1;
 }
 
-static int script_api_command_execute(lua_State* state)
+static int script_api_command_undo(lua_State* state)
 {
     ScriptRuntime* runtime = script_runtime_from_lua(state);
-    const char* text = luaL_checkstring(state, 1);
 
-    if (!runtime || !runtime->document || !runtime->executor || !text) {
+    if (!runtime || !runtime->document || !runtime->executor) {
         lua_pushboolean(state, 0);
         return 1;
     }
 
-    if (strstr(text, "undo") != NULL) {
-        lua_pushboolean(state, command_executor_undo(runtime->executor, runtime->document));
-        return 1;
-    }
-    if (strstr(text, "redo") != NULL) {
-        lua_pushboolean(state, command_executor_redo(runtime->executor, runtime->document));
-        return 1;
-    }
-
-    lua_pushboolean(state, 0);
+    lua_pushboolean(state, command_executor_undo(runtime->executor, runtime->document));
     return 1;
 }
 
-static int script_runtime_execute_command_text(ScriptRuntime* runtime, const char* text)
+static int script_api_command_redo(lua_State* state)
 {
-    if (!runtime || !runtime->document || !runtime->executor || !text) {
-        return 0;
+    ScriptRuntime* runtime = script_runtime_from_lua(state);
+
+    if (!runtime || !runtime->document || !runtime->executor) {
+        lua_pushboolean(state, 0);
+        return 1;
     }
-    if (strstr(text, "undo") != NULL) {
-        return command_executor_undo(runtime->executor, runtime->document);
-    }
-    if (strstr(text, "redo") != NULL) {
-        return command_executor_redo(runtime->executor, runtime->document);
-    }
-    return 0;
+
+    lua_pushboolean(state, command_executor_redo(runtime->executor, runtime->document));
+    return 1;
 }
 
 static int script_api_selection_get_ids(lua_State* state)
@@ -202,22 +204,83 @@ static int script_api_selection_get_ids(lua_State* state)
 
 static int script_runtime_register_api(ScriptRuntime* runtime)
 {
+    lua_State* state = NULL;
+
     if (!runtime || !runtime->state) {
         return 0;
     }
 
-    lua_pushlightuserdata(runtime->state, runtime);
-    lua_pushcclosure(runtime->state, script_api_document_add_object, 1);
-    lua_setglobal(runtime->state, "gldraw_document_add_object");
+    state = runtime->state;
+    lua_newtable(state);
+    lua_pushvalue(state, -1);
+    lua_setfield(state, -2, "_G");
 
-    lua_pushlightuserdata(runtime->state, runtime);
-    lua_pushcclosure(runtime->state, script_api_command_execute, 1);
-    lua_setglobal(runtime->state, "gldraw_command_execute");
+    script_runtime_env_copy_global(state, -1, "assert");
+    script_runtime_env_copy_global(state, -1, "error");
+    script_runtime_env_copy_global(state, -1, "ipairs");
+    script_runtime_env_copy_global(state, -1, "next");
+    script_runtime_env_copy_global(state, -1, "pairs");
+    script_runtime_env_copy_global(state, -1, "pcall");
+    script_runtime_env_copy_global(state, -1, "select");
+    script_runtime_env_copy_global(state, -1, "tonumber");
+    script_runtime_env_copy_global(state, -1, "tostring");
+    script_runtime_env_copy_global(state, -1, "type");
+    script_runtime_env_copy_global(state, -1, "xpcall");
+    script_runtime_env_copy_global(state, -1, "math");
+    script_runtime_env_copy_global(state, -1, "string");
+    script_runtime_env_copy_global(state, -1, "table");
 
-    lua_pushlightuserdata(runtime->state, runtime);
-    lua_pushcclosure(runtime->state, script_api_selection_get_ids, 1);
-    lua_setglobal(runtime->state, "gldraw_selection_get_ids");
+    lua_newtable(state);
+
+    lua_pushlightuserdata(state, runtime);
+    lua_pushcclosure(state, script_api_document_add_object, 1);
+    lua_setfield(state, -2, "document_add_object");
+
+    lua_pushlightuserdata(state, runtime);
+    lua_pushcclosure(state, script_api_command_undo, 1);
+    lua_setfield(state, -2, "undo");
+
+    lua_pushlightuserdata(state, runtime);
+    lua_pushcclosure(state, script_api_command_redo, 1);
+    lua_setfield(state, -2, "redo");
+
+    lua_pushlightuserdata(state, runtime);
+    lua_pushcclosure(state, script_api_selection_get_ids, 1);
+    lua_setfield(state, -2, "selection_get_ids");
+
+    lua_setfield(state, -2, "gldraw");
+    runtime->environment_ref = luaL_ref(state, LUA_REGISTRYINDEX);
     return 1;
+}
+
+static int script_runtime_reset_state(ScriptRuntime* runtime)
+{
+    if (!runtime) {
+        return 0;
+    }
+
+    if (runtime->state) {
+        lua_close(runtime->state);
+        runtime->state = NULL;
+    }
+    runtime->environment_ref = LUA_NOREF;
+    runtime->script_loaded = 0;
+    runtime->loaded_script_path[0] = '\0';
+
+    runtime->state = luaL_newstate();
+    if (!runtime->state) {
+        return 0;
+    }
+    luaL_requiref(runtime->state, "_G", luaopen_base, 1);
+    lua_pop(runtime->state, 1);
+    luaL_requiref(runtime->state, LUA_MATHLIBNAME, luaopen_math, 1);
+    lua_pop(runtime->state, 1);
+    luaL_requiref(runtime->state, LUA_STRLIBNAME, luaopen_string, 1);
+    lua_pop(runtime->state, 1);
+    luaL_requiref(runtime->state, LUA_TABLIBNAME, luaopen_table, 1);
+    lua_pop(runtime->state, 1);
+
+    return script_runtime_register_api(runtime);
 }
 
 int script_runtime_init(ScriptRuntime* runtime)
@@ -227,12 +290,8 @@ int script_runtime_init(ScriptRuntime* runtime)
     }
 
     memset(runtime, 0, sizeof(*runtime));
-    runtime->state = luaL_newstate();
-    if (!runtime->state) {
-        return 0;
-    }
-    luaL_openlibs(runtime->state);
-    return script_runtime_register_api(runtime);
+    runtime->environment_ref = LUA_NOREF;
+    return script_runtime_reset_state(runtime);
 }
 
 void script_runtime_shutdown(ScriptRuntime* runtime)
@@ -261,27 +320,63 @@ void script_runtime_set_context(ScriptRuntime* runtime,
     runtime->executor = executor;
 }
 
+static int script_runtime_ensure_script_loaded(ScriptRuntime* runtime, const char* script_path)
+{
+    if (!runtime || !runtime->state || !script_path || script_path[0] == '\0') {
+        return 0;
+    }
+    if (runtime->script_loaded &&
+        strcmp(runtime->loaded_script_path, script_path) == 0) {
+        return 1;
+    }
+    if (!script_runtime_reset_state(runtime)) {
+        return 0;
+    }
+    if (luaL_loadfile(runtime->state, script_path) != LUA_OK) {
+        lua_pop(runtime->state, 1);
+        return 0;
+    }
+
+    lua_rawgeti(runtime->state, LUA_REGISTRYINDEX, runtime->environment_ref);
+    if (!lua_setupvalue(runtime->state, -2, 1)) {
+        lua_pop(runtime->state, 1);
+        return 0;
+    }
+    if (lua_pcall(runtime->state, 0, 0, 0) != LUA_OK) {
+        lua_pop(runtime->state, 1);
+        return 0;
+    }
+
+    snprintf(runtime->loaded_script_path,
+             sizeof(runtime->loaded_script_path),
+             "%s",
+             script_path);
+    runtime->script_loaded = 1;
+    return 1;
+}
+
 int script_runtime_execute_file_event(ScriptRuntime* runtime,
                                       const char* script_path,
                                       const char* event_name,
                                       const ToolEvent* event)
 {
     int call_result = 0;
+    int success = 1;
 
     if (!runtime || !runtime->state || !script_path || !event_name || !event) {
         return 0;
     }
-
-    if (luaL_dofile(runtime->state, script_path) != LUA_OK) {
-        lua_pop(runtime->state, 1);
+    if (!script_runtime_ensure_script_loaded(runtime, script_path)) {
         return 0;
     }
 
-    lua_getglobal(runtime->state, "on_event");
+    lua_rawgeti(runtime->state, LUA_REGISTRYINDEX, runtime->environment_ref);
+    lua_getfield(runtime->state, -1, "on_event");
     if (!lua_isfunction(runtime->state, -1)) {
-        lua_pop(runtime->state, 1);
+        lua_pop(runtime->state, 2);
         return 0;
     }
+    lua_remove(runtime->state, -2);
 
     lua_newtable(runtime->state);
     lua_pushstring(runtime->state, event_name);
@@ -307,14 +402,10 @@ int script_runtime_execute_file_event(ScriptRuntime* runtime,
         return 0;
     }
 
-    if (lua_isstring(runtime->state, -1)) {
-        const char* command_text = lua_tostring(runtime->state, -1);
-        if (command_text) {
-            lua_pop(runtime->state, 1);
-            return script_runtime_execute_command_text(runtime, command_text);
-        }
+    if (lua_isboolean(runtime->state, -1)) {
+        success = lua_toboolean(runtime->state, -1) != 0;
     }
 
     lua_pop(runtime->state, 1);
-    return 1;
+    return success;
 }

--- a/src/script/script_runtime_lua.c
+++ b/src/script/script_runtime_lua.c
@@ -15,7 +15,7 @@ struct ScriptRuntime {
     lua_State* state;
     Document* document;
     SelectionSet* selection;
-    CommandExecutor* executor;
+    ToolPorts ports;
     int environment_ref;
     int script_loaded;
     char loaded_script_path[GLDRAW_SCRIPT_MAX_PATH];
@@ -39,7 +39,7 @@ static int script_runtime_execute_command(ScriptRuntime* runtime,
 {
     CommandExecuteCheck check = COMMAND_EXECUTE_CHECK_INVALID_ARGUMENT;
 
-    if (!runtime || !runtime->document || !runtime->executor || !command) {
+    if (!runtime || !runtime->document || !runtime->ports.execute_command || !command) {
         if (out_error) {
             *out_error = command_execute_check_message(COMMAND_EXECUTE_CHECK_INVALID_ARGUMENT);
         }
@@ -57,7 +57,7 @@ static int script_runtime_execute_command(ScriptRuntime* runtime,
         return 0;
     }
 
-    if (!command_executor_execute(runtime->executor, command, runtime->document)) {
+    if (!runtime->ports.execute_command(runtime->ports.user, command, runtime->document)) {
         if (out_error) {
             *out_error = "Command execution failed.";
         }
@@ -120,7 +120,7 @@ static int script_api_document_add_object(lua_State* state)
     GraphicObject* object = NULL;
     Command* command = NULL;
 
-    if (!runtime || !runtime->document || !runtime->executor || !type_id) {
+    if (!runtime || !runtime->document || !runtime->ports.execute_command || !type_id) {
         lua_pushnil(state);
         return 1;
     }
@@ -161,12 +161,12 @@ static int script_api_command_undo(lua_State* state)
 {
     ScriptRuntime* runtime = script_runtime_from_lua(state);
 
-    if (!runtime || !runtime->document || !runtime->executor) {
+    if (!runtime || !runtime->document || !runtime->ports.undo) {
         lua_pushboolean(state, 0);
         return 1;
     }
 
-    lua_pushboolean(state, command_executor_undo(runtime->executor, runtime->document));
+    lua_pushboolean(state, runtime->ports.undo(runtime->ports.user, runtime->document));
     return 1;
 }
 
@@ -174,12 +174,12 @@ static int script_api_command_redo(lua_State* state)
 {
     ScriptRuntime* runtime = script_runtime_from_lua(state);
 
-    if (!runtime || !runtime->document || !runtime->executor) {
+    if (!runtime || !runtime->document || !runtime->ports.redo) {
         lua_pushboolean(state, 0);
         return 1;
     }
 
-    lua_pushboolean(state, command_executor_redo(runtime->executor, runtime->document));
+    lua_pushboolean(state, runtime->ports.redo(runtime->ports.user, runtime->document));
     return 1;
 }
 
@@ -309,7 +309,7 @@ void script_runtime_shutdown(ScriptRuntime* runtime)
 void script_runtime_set_context(ScriptRuntime* runtime,
                                 Document* document,
                                 SelectionSet* selection,
-                                CommandExecutor* executor)
+                                const ToolPorts* ports)
 {
     if (!runtime) {
         return;
@@ -317,7 +317,7 @@ void script_runtime_set_context(ScriptRuntime* runtime,
 
     runtime->document = document;
     runtime->selection = selection;
-    runtime->executor = executor;
+    runtime->ports = ports ? *ports : (ToolPorts){0};
 }
 
 static int script_runtime_ensure_script_loaded(ScriptRuntime* runtime, const char* script_path)

--- a/src/tools/script_tool_lua.c
+++ b/src/tools/script_tool_lua.c
@@ -1,4 +1,3 @@
-#include <app/workspace_internal.h>
 #include <tools/tool.h>
 
 #include <script/script_runtime.h>
@@ -57,14 +56,14 @@ static void script_tool_dispatch(Tool* tool,
 {
     ScriptToolState* state = tool ? (ScriptToolState*)tool->state : NULL;
 
-    if (!state || !context || !event || !context->workspace) {
+    if (!state || !context || !event) {
         return;
     }
 
     script_runtime_set_context(&state->runtime,
                                context->document,
                                context->selection,
-                               &context->workspace->core.commands);
+                               &context->ports);
     script_runtime_execute_file_event(&state->runtime,
                                       state->script_path,
                                       event_name,

--- a/src/tools/script_tool_lua.c
+++ b/src/tools/script_tool_lua.c
@@ -1,4 +1,4 @@
-#include <app/workspace.h>
+#include <app/workspace_internal.h>
 #include <tools/tool.h>
 
 #include <script/script_runtime.h>

--- a/src/tools/tool_select.c
+++ b/src/tools/tool_select.c
@@ -1,6 +1,5 @@
 #include "tool_internal.h"
 
-#include <app/workspace_internal.h>
 #include <base/math2d.h>
 #include <canvas/canvas_view.h>
 #include <commands/command.h>
@@ -45,10 +44,7 @@ static void select_tool_deactivate(Tool* tool, ToolContext* context)
         return;
     }
 
-    if (context && context->workspace) {
-        context->workspace->session.selection_preview_active = 0;
-        context->workspace->session.selection_preview_delta = vec2_make(0.0f, 0.0f);
-    }
+    tool_context_set_selection_preview(context, 0, vec2_make(0.0f, 0.0f));
     state->dragging = 0;
     state->moved = 0;
     state->drag_delta_total = vec2_make(0.0f, 0.0f);
@@ -98,10 +94,7 @@ static int select_tool_pointer_down(Tool* tool, ToolContext* context,
     state->moved = 0;
     state->drag_delta_total = vec2_make(0.0f, 0.0f);
     state->drag_object_count = 0;
-    if (context->workspace) {
-        context->workspace->session.selection_preview_active = 0;
-        context->workspace->session.selection_preview_delta = vec2_make(0.0f, 0.0f);
-    }
+    tool_context_set_selection_preview(context, 0, vec2_make(0.0f, 0.0f));
     hit = canvas_view_pick_object(context->canvas, event->screen_pos, 8.0f);
     if (!hit) {
         if ((event->mods & GLFW_MOD_SHIFT) == 0) {
@@ -156,10 +149,7 @@ static void select_tool_pointer_move(Tool* tool, ToolContext* context,
     state->last_world = event->world_pos;
     state->drag_delta_total = vec2_add(state->drag_delta_total, delta);
     state->moved = 1;
-    if (context->workspace) {
-        context->workspace->session.selection_preview_active = 1;
-        context->workspace->session.selection_preview_delta = state->drag_delta_total;
-    }
+    tool_context_set_selection_preview(context, 1, state->drag_delta_total);
 }
 
 static void select_tool_pointer_up(Tool* tool, ToolContext* context,
@@ -176,23 +166,17 @@ static void select_tool_pointer_up(Tool* tool, ToolContext* context,
         state->moved &&
         state->drag_object_count > 0 &&
         vec2_length_sq(state->drag_delta_total) > 1e-6f &&
-        context &&
-        context->workspace) {
+        context) {
         Command* command = command_create_move_objects(state->drag_object_ids,
                                                        state->drag_object_count,
                                                        state->drag_delta_total);
         if (command) {
-            command_executor_execute(&context->workspace->core.commands,
-                                     command,
-                                     context->document);
+            tool_context_execute_command(context, command);
         }
-        workspace_sync_document_dirty(context->workspace);
+        tool_context_sync_document_dirty(context);
     }
 
-    if (context && context->workspace) {
-        context->workspace->session.selection_preview_active = 0;
-        context->workspace->session.selection_preview_delta = vec2_make(0.0f, 0.0f);
-    }
+    tool_context_set_selection_preview(context, 0, vec2_make(0.0f, 0.0f));
     state->dragging = 0;
     state->moved = 0;
     state->drag_delta_total = vec2_make(0.0f, 0.0f);

--- a/src/tools/tool_select.c
+++ b/src/tools/tool_select.c
@@ -1,6 +1,6 @@
 #include "tool_internal.h"
 
-#include <app/workspace.h>
+#include <app/workspace_internal.h>
 #include <base/math2d.h>
 #include <canvas/canvas_view.h>
 #include <commands/command.h>

--- a/src/tools/tool_shape.c
+++ b/src/tools/tool_shape.c
@@ -1,6 +1,6 @@
 #include "tool_internal.h"
 
-#include <app/workspace.h>
+#include <app/workspace_internal.h>
 #include <commands/command.h>
 #include <document/document.h>
 

--- a/src/tools/tool_shape.c
+++ b/src/tools/tool_shape.c
@@ -1,6 +1,5 @@
 #include "tool_internal.h"
 
-#include <app/workspace_internal.h>
 #include <commands/command.h>
 #include <document/document.h>
 
@@ -157,7 +156,7 @@ static void shape_tool_pointer_up(Tool* tool, ToolContext* context,
     ObjectId created_id = 0u;
 
     (void)event;
-    if (!state || !config || !context || !context->workspace || !state->drawing) {
+    if (!state || !config || !context || !state->drawing) {
         return;
     }
 
@@ -173,17 +172,14 @@ static void shape_tool_pointer_up(Tool* tool, ToolContext* context,
     }
 
     command = command_create_create_object(object);
-    if (!command ||
-        !command_executor_execute(&context->workspace->core.commands,
-                                  command,
-                                  context->document)) {
+    if (!command || !tool_context_execute_command(context, command)) {
         return;
     }
 
     created_id = object->id;
     selection_set_clear(context->selection);
     selection_set_add(context->selection, created_id);
-    workspace_sync_document_dirty(context->workspace);
+    tool_context_sync_document_dirty(context);
 }
 
 static void shape_tool_key_down(Tool* tool, ToolContext* context, int key, int mods)

--- a/src/ui/ui_runtime.c
+++ b/src/ui/ui_runtime.c
@@ -6,7 +6,6 @@
 
 #include <base/math2d.h>
 #include <glad/glad.h>
-#include "platform/window_internal.h"
 
 #define NK_INCLUDE_FIXED_TYPES
 #define NK_INCLUDE_STANDARD_IO
@@ -66,20 +65,20 @@ UiSystem *ui_system_create(PlatformWindow *window) {
     return NULL;
   }
 
-  ui->ctx = nk_glfw3_init(&ui->glfw, platform_window_glfw_handle(window), 0);
+  ui->ctx = platform_window_nuklear_init(&ui->glfw, window);
   if (!ui->ctx) {
     free(ui);
     return NULL;
   }
 
-  nk_glfw3_font_stash_begin(&ui->glfw, &atlas);
-  nk_glfw3_font_stash_end(&ui->glfw);
+  platform_window_nuklear_font_stash_begin(&ui->glfw, &atlas);
+  platform_window_nuklear_font_stash_end(&ui->glfw);
 
   snprintf(ui->theme_settings_path, sizeof(ui->theme_settings_path), "%s",
            UI_THEME_SETTINGS_PATH);
 
   ui_system_reload_themes(ui, 0, UI_THEME_RELOAD_REASON_STARTUP);
-  ui->theme_watch_last_check_seconds = glfwGetTime();
+  ui->theme_watch_last_check_seconds = platform_time_seconds();
 
   ui->menu_bar = ui_menubar_create(ui->ctx);
   if (ui->menu_bar) {
@@ -90,8 +89,8 @@ UiSystem *ui_system_create(PlatformWindow *window) {
   ui->inspector_anim_t = 1.0f;
   ui->inspector_target_visible = 1;
   ui->inspector_anim_initialized = 0;
-  ui->last_frame_seconds = glfwGetTime();
-  ui->window_handle = platform_window_glfw_handle(window);
+  ui->last_frame_seconds = platform_time_seconds();
+  ui->window = window;
 
   return ui;
 }
@@ -104,13 +103,13 @@ void ui_system_destroy(UiSystem *ui) {
     ui_menubar_destroy(ui->menu_bar);
     ui->menu_bar = NULL;
   }
-  nk_glfw3_shutdown(&ui->glfw);
+  platform_window_nuklear_shutdown(&ui->glfw);
   free(ui);
 }
 
 void ui_system_begin_frame(UiSystem *ui) {
   if (ui) {
-    nk_glfw3_new_frame(&ui->glfw);
+    platform_window_nuklear_new_frame(&ui->glfw);
   }
 }
 
@@ -158,14 +157,8 @@ void ui_system_build(UiSystem *ui, const EditorViewModel *view_model) {
     ui->dialog_kind_snapshot = UI_DIALOG_NONE;
   }
 
-  if (ui->window_handle) {
-    glfwGetWindowSize(ui->window_handle, &width, &height);
-  }
-  if (width <= 0 || height <= 0) {
-    GLFWwindow *current_context = glfwGetCurrentContext();
-    if (current_context) {
-      glfwGetWindowSize(current_context, &width, &height);
-    }
+  if (ui->window) {
+    platform_window_get_size(ui->window, &width, &height);
   }
 
   if (width <= 0 || height <= 0) {
@@ -173,7 +166,7 @@ void ui_system_build(UiSystem *ui, const EditorViewModel *view_model) {
     return;
   }
 
-  now_seconds = glfwGetTime();
+  now_seconds = platform_time_seconds();
   dt_seconds = (float)(now_seconds - ui->last_frame_seconds);
   ui->last_frame_seconds = now_seconds;
   dt_seconds = ui_clampf(dt_seconds, 0.0f, 0.10f);
@@ -307,8 +300,10 @@ void ui_system_render(UiSystem *ui) {
   if (!ui) {
     return;
   }
-  nk_glfw3_render(&ui->glfw, NK_ANTI_ALIASING_ON, UI_MAX_VERTEX_BUFFER,
-                  UI_MAX_ELEMENT_BUFFER);
+  platform_window_nuklear_render(&ui->glfw,
+                                 NK_ANTI_ALIASING_ON,
+                                 UI_MAX_VERTEX_BUFFER,
+                                 UI_MAX_ELEMENT_BUFFER);
 }
 
 int ui_system_has_active_interaction(const UiSystem *ui) {

--- a/src/ui/ui_system_internal.h
+++ b/src/ui/ui_system_internal.h
@@ -37,6 +37,7 @@
 #include <app/workspace.h>
 #include <base/path_utils.h>
 #include <base/types.h>
+#include <platform/window.h>
 #include <ui/editor_action.h>
 #include <ui/ui_menubar.h>
 #include <ui/ui_theme.h>
@@ -72,7 +73,7 @@ typedef struct UiSystem UiSystem;
 struct UiSystem {
   struct nk_glfw glfw;
   struct nk_context *ctx;
-  GLFWwindow *window_handle;
+  PlatformWindow *window;
   UiMenuBar *menu_bar;
   UiThemeTokens theme;
   char active_theme_id[UI_THEME_ID_CAPACITY];

--- a/tests/test_registry.c
+++ b/tests/test_registry.c
@@ -1,5 +1,5 @@
 #include <app/command_registry.h>
-#include <app/workspace.h>
+#include <app/workspace_internal.h>
 #include <commands/command.h>
 #include <input/keymap.h>
 #include <tools/tool.h>

--- a/tests/test_renderer.c
+++ b/tests/test_renderer.c
@@ -2,6 +2,7 @@
 #include <document/document.h>
 #include <render/canvas_drawlist.h>
 #include <render/canvas_renderer.h>
+#include <render/render_system.h>
 
 #include <app/extension_loader.h>
 
@@ -44,6 +45,7 @@ typedef struct MockDrawCall {
     int point_count;
     RenderPathMode mode;
     float line_width;
+    Vec2 first_point;
 } MockDrawCall;
 
 typedef struct MockRenderDevice {
@@ -123,11 +125,12 @@ static void mock_draw_path(RenderDevice* device,
                            float line_width)
 {
     MockRenderDevice* mock = (MockRenderDevice*)device;
-    (void)points;
     snprintf(mock->calls[mock->call_count++], sizeof(mock->calls[0]), "path");
     mock->draw_calls[mock->draw_call_count].point_count = point_count;
     mock->draw_calls[mock->draw_call_count].mode = mode;
     mock->draw_calls[mock->draw_call_count].line_width = line_width;
+    mock->draw_calls[mock->draw_call_count].first_point =
+        point_count > 0 ? points[0] : (Vec2){0.0f, 0.0f};
     mock->draw_call_count++;
 }
 
@@ -171,6 +174,37 @@ static const RenderDeviceVTable MOCK_VTABLE = {
 static GraphicObject* make_rect(float x, float y, float w, float h)
 {
     return object_create_rect((RectF){x, y, w, h}, object_default_style());
+}
+
+static void mock_reset_frame_capture(MockRenderDevice* mock)
+{
+    if (!mock) {
+        return;
+    }
+
+    memset(mock->calls, 0, sizeof(mock->calls));
+    memset(mock->draw_calls, 0, sizeof(mock->draw_calls));
+    mock->call_count = 0;
+    mock->draw_call_count = 0;
+}
+
+static const MockDrawCall* mock_find_widest_draw_call(const MockRenderDevice* mock)
+{
+    const MockDrawCall* widest = NULL;
+    int i = 0;
+
+    if (!mock || mock->draw_call_count <= 0) {
+        return NULL;
+    }
+
+    widest = &mock->draw_calls[0];
+    for (i = 1; i < mock->draw_call_count; ++i) {
+        if (mock->draw_calls[i].line_width > widest->line_width) {
+            widest = &mock->draw_calls[i];
+        }
+    }
+
+    return widest;
 }
 
 static int test_canvas_renderer_submit_sequence(void)
@@ -253,12 +287,61 @@ static int test_selected_object_emits_highlight_first(void)
     return 0;
 }
 
+static int test_render_system_invalidates_on_selection_revision(void)
+{
+    Document document;
+    CanvasView canvas;
+    SelectionSet selection = {0};
+    MockRenderDevice mock = {0};
+    PlatformWindow window = {0};
+    RenderSystem* renderer = NULL;
+    const MockDrawCall* first_highlight = NULL;
+    const MockDrawCall* second_highlight = NULL;
+    float first_highlight_x = 0.0f;
+    float second_highlight_x = 0.0f;
+
+    document_init(&document);
+    canvas_view_init(&canvas, &document, (RectF){0.0f, 0.0f, 640.0f, 480.0f});
+    canvas.show_grid = 0;
+    EXPECT_TRUE(document_add_object(&document, make_rect(0.0f, 0.0f, 10.0f, 20.0f)));
+    EXPECT_TRUE(document_add_object(&document, make_rect(100.0f, 0.0f, 10.0f, 20.0f)));
+    EXPECT_TRUE(selection_set_add(&selection, 1u));
+
+    mock.base.vtable = &MOCK_VTABLE;
+    window.width = 640;
+    window.height = 480;
+    window.framebuffer_width = 640;
+    window.framebuffer_height = 480;
+    renderer = render_system_create(&mock.base, &window);
+    EXPECT_TRUE(renderer != NULL);
+
+    render_system_draw(renderer, &document, &selection, &canvas, 0, (Vec2){0.0f, 0.0f}, NULL);
+    first_highlight = mock_find_widest_draw_call(&mock);
+    EXPECT_TRUE(first_highlight != NULL);
+    first_highlight_x = first_highlight->first_point.x;
+
+    mock_reset_frame_capture(&mock);
+    selection_set_clear(&selection);
+    EXPECT_TRUE(selection_set_add(&selection, 2u));
+    render_system_draw(renderer, &document, &selection, &canvas, 0, (Vec2){0.0f, 0.0f}, NULL);
+    second_highlight = mock_find_widest_draw_call(&mock);
+    EXPECT_TRUE(second_highlight != NULL);
+    second_highlight_x = second_highlight->first_point.x;
+    EXPECT_TRUE(first_highlight_x != second_highlight_x);
+
+    render_system_destroy(renderer);
+    selection_set_shutdown(&selection);
+    document_shutdown(&document);
+    return 0;
+}
+
 int main(void)
 {
     extension_loader_register_all();
 
     if (test_canvas_renderer_submit_sequence()) return 1;
     if (test_selected_object_emits_highlight_first()) return 1;
+    if (test_render_system_invalidates_on_selection_revision()) return 1;
 
     printf("[PASS] canvas draw list and renderer submission\n");
     return 0;

--- a/tests/test_renderer.c
+++ b/tests/test_renderer.c
@@ -43,18 +43,17 @@
 
 typedef struct MockDrawCall {
     int point_count;
-    RenderPathMode mode;
+    RenderPrimitiveType primitive;
     float line_width;
     Vec2 first_point;
+    Color color;
 } MockDrawCall;
 
 typedef struct MockRenderDevice {
     RenderDevice base;
     char calls[16][16];
     int call_count;
-    RectF clip_rect;
-    RenderTransform transform;
-    Color last_color;
+    RenderPass pass;
     RenderFrameDesc frame_desc;
     MockDrawCall draw_calls[8];
     int draw_call_count;
@@ -82,56 +81,28 @@ static int mock_begin_frame(RenderDevice* device, const RenderFrameDesc* frame_d
     return 1;
 }
 
-static void mock_set_transform(RenderDevice* device, const RenderTransform* transform)
+static int mock_begin_pass(RenderDevice* device, const RenderPass* pass)
 {
     MockRenderDevice* mock = (MockRenderDevice*)device;
-    snprintf(mock->calls[mock->call_count++], sizeof(mock->calls[0]), "transform");
-    mock->transform = *transform;
+    snprintf(mock->calls[mock->call_count++], sizeof(mock->calls[0]), "pass");
+    mock->pass = *pass;
+    return 1;
 }
 
-static void mock_set_clip_rect(RenderDevice* device, RectF clip_rect)
+static int mock_draw_geometry(RenderDevice* device,
+                              const RenderGeometry* geometry,
+                              const RenderMaterial* material)
 {
     MockRenderDevice* mock = (MockRenderDevice*)device;
-    snprintf(mock->calls[mock->call_count++], sizeof(mock->calls[0]), "clip");
-    mock->clip_rect = clip_rect;
-}
-
-static void mock_set_color(RenderDevice* device, Color color)
-{
-    MockRenderDevice* mock = (MockRenderDevice*)device;
-    snprintf(mock->calls[mock->call_count++], sizeof(mock->calls[0]), "color");
-    mock->last_color = color;
-}
-
-static void mock_draw_line(RenderDevice* device, Vec2 from, Vec2 to, float line_width)
-{
-    (void)device;
-    (void)from;
-    (void)to;
-    (void)line_width;
-}
-
-static void mock_draw_rect(RenderDevice* device, RectF rect, float line_width)
-{
-    (void)device;
-    (void)rect;
-    (void)line_width;
-}
-
-static void mock_draw_path(RenderDevice* device,
-                           const Vec2* points,
-                           int point_count,
-                           RenderPathMode mode,
-                           float line_width)
-{
-    MockRenderDevice* mock = (MockRenderDevice*)device;
-    snprintf(mock->calls[mock->call_count++], sizeof(mock->calls[0]), "path");
-    mock->draw_calls[mock->draw_call_count].point_count = point_count;
-    mock->draw_calls[mock->draw_call_count].mode = mode;
-    mock->draw_calls[mock->draw_call_count].line_width = line_width;
+    snprintf(mock->calls[mock->call_count++], sizeof(mock->calls[0]), "draw");
+    mock->draw_calls[mock->draw_call_count].point_count = geometry->point_count;
+    mock->draw_calls[mock->draw_call_count].primitive = geometry->primitive;
+    mock->draw_calls[mock->draw_call_count].line_width = material->line_width;
+    mock->draw_calls[mock->draw_call_count].color = material->color;
     mock->draw_calls[mock->draw_call_count].first_point =
-        point_count > 0 ? points[0] : (Vec2){0.0f, 0.0f};
+        geometry->point_count > 0 ? geometry->points[0] : (Vec2){0.0f, 0.0f};
     mock->draw_call_count++;
+    return 1;
 }
 
 static int mock_read_pixels(RenderDevice* device,
@@ -160,12 +131,8 @@ static void mock_destroy(RenderDevice* device)
 static const RenderDeviceVTable MOCK_VTABLE = {
     mock_resize,
     mock_begin_frame,
-    mock_set_transform,
-    mock_set_clip_rect,
-    mock_set_color,
-    mock_draw_line,
-    mock_draw_rect,
-    mock_draw_path,
+    mock_begin_pass,
+    mock_draw_geometry,
     mock_read_pixels,
     mock_end_frame,
     mock_destroy
@@ -240,17 +207,17 @@ static int test_canvas_renderer_submit_sequence(void)
     frame_desc.clear_color = draw_list.clear_color;
 
     EXPECT_TRUE(canvas_renderer_submit(&mock.base, &frame_desc, &transform, &draw_list));
-    EXPECT_INT_EQ(mock.call_count, 6);
+    EXPECT_INT_EQ(mock.call_count, 4);
     EXPECT_TRUE(strcmp(mock.calls[0], "begin") == 0);
-    EXPECT_TRUE(strcmp(mock.calls[1], "transform") == 0);
-    EXPECT_TRUE(strcmp(mock.calls[2], "clip") == 0);
-    EXPECT_TRUE(strcmp(mock.calls[3], "color") == 0);
-    EXPECT_TRUE(strcmp(mock.calls[4], "path") == 0);
-    EXPECT_TRUE(strcmp(mock.calls[5], "end") == 0);
-    EXPECT_FLOAT_EQ(mock.clip_rect.w, 800.0f);
-    EXPECT_FLOAT_EQ(mock.clip_rect.h, 600.0f);
+    EXPECT_TRUE(strcmp(mock.calls[1], "pass") == 0);
+    EXPECT_TRUE(strcmp(mock.calls[2], "draw") == 0);
+    EXPECT_TRUE(strcmp(mock.calls[3], "end") == 0);
+    EXPECT_FLOAT_EQ(mock.pass.clip_rect.w, 800.0f);
+    EXPECT_FLOAT_EQ(mock.pass.clip_rect.h, 600.0f);
+    EXPECT_FLOAT_EQ(mock.pass.transform.scale_x, 1.0f);
+    EXPECT_FLOAT_EQ(mock.pass.transform.scale_y, 1.0f);
     EXPECT_INT_EQ(mock.draw_calls[0].point_count, 5);
-    EXPECT_INT_EQ((int)mock.draw_calls[0].mode, (int)RENDER_PATH_LINE_STRIP);
+    EXPECT_INT_EQ((int)mock.draw_calls[0].primitive, (int)RENDER_PRIMITIVE_LINE_STRIP);
 
     canvas_drawlist_shutdown(&draw_list);
     document_shutdown(&document);
@@ -335,6 +302,49 @@ static int test_render_system_invalidates_on_selection_revision(void)
     return 0;
 }
 
+static int test_canvas_drawlist_reuses_scratch_arena_between_builds(void)
+{
+    Document document;
+    CanvasView canvas;
+    SelectionSet selection = {0};
+    CanvasDrawList draw_list;
+    unsigned char* first_memory = NULL;
+    size_t first_capacity = 0u;
+
+    document_init(&document);
+    canvas_view_init(&canvas, &document, (RectF){0.0f, 0.0f, 640.0f, 480.0f});
+    canvas.show_grid = 1;
+    EXPECT_TRUE(document_add_object(&document, make_rect(0.0f, 0.0f, 120.0f, 80.0f)));
+    EXPECT_TRUE(document_add_object(&document, make_rect(240.0f, 120.0f, 100.0f, 60.0f)));
+
+    canvas_drawlist_init(&draw_list);
+    EXPECT_TRUE(canvas_drawlist_build(&draw_list,
+                                      &document,
+                                      &selection,
+                                      &canvas,
+                                      0,
+                                      (Vec2){0.0f, 0.0f},
+                                      NULL));
+    EXPECT_TRUE(draw_list.scratch_arena.memory != NULL);
+    EXPECT_TRUE(draw_list.scratch_arena.capacity_bytes > 0u);
+    first_memory = draw_list.scratch_arena.memory;
+    first_capacity = draw_list.scratch_arena.capacity_bytes;
+
+    EXPECT_TRUE(canvas_drawlist_build(&draw_list,
+                                      &document,
+                                      &selection,
+                                      &canvas,
+                                      0,
+                                      (Vec2){0.0f, 0.0f},
+                                      NULL));
+    EXPECT_TRUE(draw_list.scratch_arena.memory == first_memory);
+    EXPECT_TRUE(draw_list.scratch_arena.capacity_bytes == first_capacity);
+
+    canvas_drawlist_shutdown(&draw_list);
+    document_shutdown(&document);
+    return 0;
+}
+
 int main(void)
 {
     extension_loader_register_all();
@@ -342,6 +352,7 @@ int main(void)
     if (test_canvas_renderer_submit_sequence()) return 1;
     if (test_selected_object_emits_highlight_first()) return 1;
     if (test_render_system_invalidates_on_selection_revision()) return 1;
+    if (test_canvas_drawlist_reuses_scratch_arena_between_builds()) return 1;
 
     printf("[PASS] canvas draw list and renderer submission\n");
     return 0;

--- a/tests/test_script_runtime.c
+++ b/tests/test_script_runtime.c
@@ -27,6 +27,43 @@
         }                                                                    \
     } while (0)
 
+typedef struct {
+    CommandExecutor* executor;
+} ScriptRuntimeTestPorts;
+
+static int test_ports_execute_command(void* user, Command* command, Document* document)
+{
+    ScriptRuntimeTestPorts* ports = (ScriptRuntimeTestPorts*)user;
+
+    if (!ports || !ports->executor || !document || !command) {
+        return 0;
+    }
+
+    return command_executor_execute(ports->executor, command, document);
+}
+
+static int test_ports_undo(void* user, Document* document)
+{
+    ScriptRuntimeTestPorts* ports = (ScriptRuntimeTestPorts*)user;
+
+    if (!ports || !ports->executor || !document) {
+        return 0;
+    }
+
+    return command_executor_undo(ports->executor, document);
+}
+
+static int test_ports_redo(void* user, Document* document)
+{
+    ScriptRuntimeTestPorts* ports = (ScriptRuntimeTestPorts*)user;
+
+    if (!ports || !ports->executor || !document) {
+        return 0;
+    }
+
+    return command_executor_redo(ports->executor, document);
+}
+
 static int make_temp_path(char* buffer, size_t buffer_size, const char* suffix)
 {
     char base_name[L_tmpnam] = {0};
@@ -96,6 +133,8 @@ static int test_script_runtime_uses_safe_env_and_caches_script(void)
     CommandExecutor executor;
     SelectionSet selection = {0};
     ScriptRuntime runtime;
+    ScriptRuntimeTestPorts ports;
+    ToolPorts tool_ports;
     ToolEvent event = {0};
     char script_path[512] = {0};
 
@@ -103,11 +142,17 @@ static int test_script_runtime_uses_safe_env_and_caches_script(void)
     document_init(&document);
     EXPECT_TRUE(command_executor_init(&executor));
     EXPECT_TRUE(script_runtime_init(&runtime));
+    ports.executor = &executor;
+    memset(&tool_ports, 0, sizeof(tool_ports));
+    tool_ports.execute_command = test_ports_execute_command;
+    tool_ports.undo = test_ports_undo;
+    tool_ports.redo = test_ports_redo;
+    tool_ports.user = &ports;
 
     EXPECT_TRUE(make_temp_path(script_path, sizeof(script_path), ".lua"));
     EXPECT_TRUE(write_script_file(script_path, script_source));
 
-    script_runtime_set_context(&runtime, &document, &selection, &executor);
+    script_runtime_set_context(&runtime, &document, &selection, &tool_ports);
     event.world_pos.x = 12.0f;
     event.world_pos.y = 34.0f;
 

--- a/tests/test_script_runtime.c
+++ b/tests/test_script_runtime.c
@@ -1,0 +1,132 @@
+#include <app/extension_loader.h>
+#include <commands/command.h>
+#include <document/document.h>
+#include <script/script_runtime.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define EXPECT_TRUE(expr)                                                     \
+    do {                                                                     \
+        if (!(expr)) {                                                        \
+            fprintf(stderr, "EXPECT_TRUE failed: %s:%d: %s\n",               \
+                    __FILE__, __LINE__, #expr);                              \
+            return 1;                                                        \
+        }                                                                    \
+    } while (0)
+
+#define EXPECT_INT_EQ(actual, expected)                                      \
+    do {                                                                     \
+        int actual_value = (actual);                                         \
+        int expected_value = (expected);                                     \
+        if (actual_value != expected_value) {                                \
+            fprintf(stderr, "EXPECT_INT_EQ failed: %s:%d: %d != %d\n",       \
+                    __FILE__, __LINE__, actual_value, expected_value);       \
+            return 1;                                                        \
+        }                                                                    \
+    } while (0)
+
+static int make_temp_path(char* buffer, size_t buffer_size, const char* suffix)
+{
+    char base_name[L_tmpnam] = {0};
+
+#ifdef _WIN32
+    if (tmpnam_s(base_name, sizeof(base_name)) != 0) {
+        return 0;
+    }
+#else
+    if (!tmpnam(base_name)) {
+        return 0;
+    }
+#endif
+
+    if (snprintf(buffer, buffer_size, "%s%s", base_name, suffix) >= (int)buffer_size) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static int write_script_file(const char* path, const char* source)
+{
+    FILE* file = NULL;
+
+    if (!path || !source) {
+        return 0;
+    }
+
+    file = fopen(path, "wb");
+    if (!file) {
+        return 0;
+    }
+    if (fputs(source, file) < 0) {
+        fclose(file);
+        return 0;
+    }
+
+    fclose(file);
+    return 1;
+}
+
+static int test_script_runtime_uses_safe_env_and_caches_script(void)
+{
+    static const char* script_source =
+        "local gld = gldraw\n"
+        "gld.load_count = (gld.load_count or 0) + 1\n"
+        "if os ~= nil or io ~= nil or package ~= nil or debug ~= nil or dofile ~= nil or loadfile ~= nil or require ~= nil then\n"
+        "    error('unsafe lua libraries are exposed')\n"
+        "end\n"
+        "function on_event(event)\n"
+        "    if event.name ~= 'pointer_up' then\n"
+        "        return true\n"
+        "    end\n"
+        "    if gld.load_count ~= 1 then\n"
+        "        error('script should be loaded once')\n"
+        "    end\n"
+        "    return gld.document_add_object('rect', {\n"
+        "        x = event.x,\n"
+        "        y = event.y,\n"
+        "        width = 10.0,\n"
+        "        height = 5.0,\n"
+        "        stroke_width = 1.0\n"
+        "    }) ~= nil\n"
+        "end\n";
+    Document document;
+    CommandExecutor executor;
+    SelectionSet selection = {0};
+    ScriptRuntime runtime;
+    ToolEvent event = {0};
+    char script_path[512] = {0};
+
+    extension_loader_register_all();
+    document_init(&document);
+    EXPECT_TRUE(command_executor_init(&executor));
+    EXPECT_TRUE(script_runtime_init(&runtime));
+
+    EXPECT_TRUE(make_temp_path(script_path, sizeof(script_path), ".lua"));
+    EXPECT_TRUE(write_script_file(script_path, script_source));
+
+    script_runtime_set_context(&runtime, &document, &selection, &executor);
+    event.world_pos.x = 12.0f;
+    event.world_pos.y = 34.0f;
+
+    EXPECT_TRUE(script_runtime_execute_file_event(&runtime, script_path, "pointer_up", &event));
+    EXPECT_TRUE(script_runtime_execute_file_event(&runtime, script_path, "pointer_up", &event));
+    EXPECT_INT_EQ(document.count, 2);
+
+    remove(script_path);
+    script_runtime_shutdown(&runtime);
+    command_executor_shutdown(&executor);
+    selection_set_shutdown(&selection);
+    document_shutdown(&document);
+    return 0;
+}
+
+int main(void)
+{
+    if (test_script_runtime_uses_safe_env_and_caches_script()) return 1;
+
+    printf("[PASS] script runtime uses safe env and caches scripts\n");
+    return 0;
+}

--- a/tests/test_selection.c
+++ b/tests/test_selection.c
@@ -1,5 +1,6 @@
 #include <model/selection.h>
 
+#include <inttypes.h>
 #include <stdio.h>
 
 #define EXPECT_TRUE(expr)                                                     \
@@ -22,20 +23,50 @@
             return 1;                                                        \
         }                                                                    \
     } while (0)
+#define EXPECT_UINT64_EQ(actual, expected)                                     \
+    do {                                                                       \
+        uint64_t actual_value = (actual);                                      \
+        uint64_t expected_value = (expected);                                  \
+        if (actual_value != expected_value) {                                  \
+            fprintf(stderr,                                                     \
+                    "EXPECT_UINT64_EQ failed: %s:%d: %s=%" PRIu64              \
+                    " expected %" PRIu64 "\n",                                 \
+                    __FILE__, __LINE__, #actual, actual_value, expected_value); \
+            return 1;                                                          \
+        }                                                                      \
+    } while (0)
 
 int main(void)
 {
     SelectionSet selection = {0};
+    SelectionSet copy = {0};
 
+    EXPECT_UINT64_EQ(selection.revision, 0u);
     EXPECT_TRUE(selection_set_add(&selection, 7u));
+    EXPECT_UINT64_EQ(selection.revision, 1u);
     EXPECT_TRUE(selection_set_contains(&selection, 7u));
     EXPECT_INT_EQ(selection.count, 1);
 
+    EXPECT_TRUE(selection_set_add(&selection, 7u));
+    EXPECT_UINT64_EQ(selection.revision, 1u);
+
     selection_set_toggle(&selection, 7u);
+    EXPECT_UINT64_EQ(selection.revision, 2u);
     EXPECT_FALSE(selection_set_contains(&selection, 7u));
     EXPECT_INT_EQ(selection.count, 0);
 
+    EXPECT_TRUE(selection_set_add(&selection, 9u));
+    EXPECT_UINT64_EQ(selection.revision, 3u);
+    EXPECT_TRUE(selection_set_copy(&copy, &selection));
+    EXPECT_UINT64_EQ(copy.revision, 1u);
+    EXPECT_TRUE(selection_set_copy(&copy, &selection));
+    EXPECT_UINT64_EQ(copy.revision, 1u);
+
+    selection_set_clear(&selection);
+    EXPECT_UINT64_EQ(selection.revision, 4u);
+
+    selection_set_shutdown(&copy);
     selection_set_shutdown(&selection);
-    printf("[PASS] selection helpers add and toggle IDs\n");
+    printf("[PASS] selection helpers track content revisions\n");
     return 0;
 }

--- a/tests/test_ui_logic.c
+++ b/tests/test_ui_logic.c
@@ -307,10 +307,12 @@ static int test_workspace_tool_context_and_preview_accessors(void)
     context = workspace_tool_context(&workspace);
     preview_delta = workspace_selection_preview_delta(&workspace);
 
-    EXPECT_TRUE(context.workspace == &workspace);
     EXPECT_TRUE(context.document == &workspace.core.document);
     EXPECT_TRUE(context.canvas == &workspace.core.canvas);
     EXPECT_TRUE(context.selection == &workspace.session.selection);
+    EXPECT_TRUE(context.ports.execute_command != NULL);
+    EXPECT_TRUE(context.ports.set_selection_preview != NULL);
+    EXPECT_TRUE(context.ports.sync_document_dirty != NULL);
     EXPECT_TRUE(workspace_selection_preview_active(&workspace) == 1);
     EXPECT_FLOAT_EQ(preview_delta.x, 7.0f);
     EXPECT_FLOAT_EQ(preview_delta.y, -3.0f);
@@ -345,11 +347,7 @@ static int test_locked_layers_block_pick_and_shape_creation(void)
     EXPECT_TRUE(document_set_active_layer(&workspace.core.document, locked_layer));
     EXPECT_TRUE(tool_controller_set_active(&workspace.core.tools, NULL, "rect"));
 
-    memset(&context, 0, sizeof(context));
-    context.workspace = &workspace;
-    context.document = &workspace.core.document;
-    context.canvas = &workspace.core.canvas;
-    context.selection = &workspace.session.selection;
+    context = workspace_tool_context(&workspace);
 
     memset(&down_event, 0, sizeof(down_event));
     down_event.button = 0; /* GLFW_MOUSE_BUTTON_LEFT */
@@ -386,11 +384,7 @@ static int test_command_registry_respects_locked_layers(void)
     EXPECT_TRUE(document_add_object(&workspace.core.document,
                                     make_rect(20.0f, 0.0f, 10.0f, 10.0f)));
 
-    memset(&context, 0, sizeof(context));
-    context.workspace = &workspace;
-    context.document = &workspace.core.document;
-    context.canvas = &workspace.core.canvas;
-    context.selection = &workspace.session.selection;
+    context = workspace_tool_context(&workspace);
 
     EXPECT_TRUE(command_registry_execute(&workspace, &context, EDITOR_COMMAND_EDIT_SELECT_ALL));
     EXPECT_INT_EQ(workspace.session.selection.count, 1);

--- a/tests/test_ui_logic.c
+++ b/tests/test_ui_logic.c
@@ -1,6 +1,6 @@
 #include <app/command_dispatcher.h>
 #include <app/extension_loader.h>
-#include <app/workspace.h>
+#include <app/workspace_internal.h>
 #include <app/workspace_dialogs.h>
 #include <base/math2d.h>
 #include <canvas/canvas_view.h>
@@ -11,6 +11,7 @@
 
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define EXPECT_TRUE(expr)                                                     \

--- a/tests/test_workspace_service.c
+++ b/tests/test_workspace_service.c
@@ -1,4 +1,5 @@
 #include <app/workspace_service.h>
+#include <app/workspace_internal.h>
 
 #include <base/math2d.h>
 


### PR DESCRIPTION
## Summary
- harden the editor foundation by fixing selection cache invalidation and tightening the optional Lua runtime boundary
- decouple tools, workspace internals, platform window callbacks, and CMake runtime layering to enforce cleaner subsystem boundaries
- introduce render resource management, reusable arena-backed draw-list scratch storage, and explicit frame/pass/material/geometry render submission abstractions

## Testing
- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure`

## Notes
- scripting-enabled builds still require a local Lua development package; default builds and tests were validated with scripting disabled