### PR TITLE
refactor: render scene snapshot and lifecycle boundaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(RENDER_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/canvas_drawlist.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/canvas_renderer.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_arena.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_scene_snapshot.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/render_system.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/image/png_writer.c
 )

--- a/REFACTOR_LOG.md
+++ b/REFACTOR_LOG.md
@@ -1,5 +1,22 @@
 # Refactor Log
 
+## 2026-05-29 - R2: Tighten Window And Nuklear GL Lifetimes
+
+- Branch:
+  `refactor-render-scene-snapshot-boundaries`
+- Modified files:
+  `include/nuklear/nuklear_glfw_gl3.h`,
+  `src/platform/window.c`,
+  `doc/architecture/refactor-roadmap.md`,
+  `REFACTOR_LOG.md`
+- Key changes:
+  Matched the Nuklear GL3 backend's VAO creation with explicit VAO deletion during device teardown and cleared device handles after release.
+  Kept single-window behavior unchanged while making `platform_window_shutdown()` terminate GLFW only after the final tracked window is removed.
+- Validation:
+  `cmake --build build --parallel` passed.
+  `ctest --test-dir build --output-on-failure` passed.
+  `git diff --check` passed.
+
 ## 2026-05-29 - R1: Capture Render Scene Snapshots Internally
 
 - Branch:

--- a/REFACTOR_LOG.md
+++ b/REFACTOR_LOG.md
@@ -1,5 +1,28 @@
 # Refactor Log
 
+## 2026-05-29 - R1: Capture Render Scene Snapshots Internally
+
+- Branch:
+  `refactor-render-scene-snapshot-boundaries`
+- Modified files:
+  `CMakeLists.txt`,
+  `include/render/render_scene.h`,
+  `include/render/render_system.h`,
+  `src/render/render_scene_snapshot.c`,
+  `src/render/render_scene_snapshot.h`,
+  `src/render/render_system.c`,
+  `doc/reference/file-map.md`,
+  `doc/architecture/refactor-roadmap.md`,
+  `REFACTOR_LOG.md`
+- Key changes:
+  Moved the public `RenderSceneDesc` value type into a dedicated render-scene header so render-system lifecycle APIs are no longer the owner of editor scene input shape.
+  Added an internal render scene snapshot helper that captures descriptor pointers plus cache-key values before draw-list reuse decisions.
+  Kept `render_system_draw()` behavior and external call sites unchanged while separating scene capture/cache comparison from frame submission.
+- Validation:
+  `cmake --build build --parallel` passed.
+  `ctest --test-dir build --output-on-failure` passed.
+  `git diff --check` passed.
+
 ## 2026-05-29 - R6: Harden Bundled Resource Lookup And Install Layout
 
 - Branch:

--- a/REFACTOR_LOG.md
+++ b/REFACTOR_LOG.md
@@ -1,5 +1,21 @@
 # Refactor Log
 
+## 2026-05-29 - R3: Preserve Render Device Ownership On Startup Failure
+
+- Branch:
+  `refactor-render-scene-snapshot-boundaries`
+- Modified files:
+  `src/app/application.c`,
+  `doc/architecture/refactor-roadmap.md`,
+  `REFACTOR_LOG.md`
+- Key changes:
+  Released a successfully created `RenderDevice` when `render_system_create()` fails during application startup.
+  Kept the successful startup path and normal render-system-owned teardown path unchanged.
+- Validation:
+  `cmake --build build --parallel` passed.
+  `ctest --test-dir build --output-on-failure` passed.
+  `git diff --check` passed.
+
 ## 2026-05-29 - R2: Tighten Window And Nuklear GL Lifetimes
 
 - Branch:

--- a/doc/architecture/refactor-roadmap.md
+++ b/doc/architecture/refactor-roadmap.md
@@ -24,6 +24,7 @@ The next refactor should not reduce layering for its own sake. It should turn pa
 - UI frame construction has moved to `src/ui/ui_frame.c`, the inspector's layer controls now live in `src/ui/ui_layer_panel.c`, menu bar rendering lives in `src/ui/ui_menubar_render.c`, and context menu rendering lives in `src/ui/ui_context_menu_render.c`.
 - Render submission now uses `RenderSceneDesc`; render-system internals capture that descriptor into a scene snapshot/cache-key helper before deciding whether to reuse the draw list.
 - The GLFW/Nuklear boundary now pairs Nuklear GL3 VAO teardown with creation and keeps GLFW initialized until the final tracked platform window is shut down.
+- Application startup now preserves render-device ownership on render-system creation failure before normal renderer ownership begins.
 - Canvas draw-list strokes are normalized to line-segment geometry and `canvas_renderer_submit()` batches adjacent strokes with identical material and primitive metadata before backend submission.
 - Bundled shader, theme, and script paths now resolve through a base resource-path helper instead of assuming the process current working directory is the repository root.
 
@@ -68,6 +69,7 @@ The next refactor should not reduce layering for its own sake. It should turn pa
 - `render_system_draw()` consumes `RenderSceneDesc`.
 - `RenderSceneDesc` lives in `include/render/render_scene.h`, while scene cache-key capture and comparison live behind the render-system implementation boundary.
 - Platform window and Nuklear GL lifetimes are still adapter-owned, with teardown now matching tracked resource ownership more closely.
+- Application lifecycle owns the render-device handoff until `render_system_create()` succeeds.
 - Resource lookup for bundled files lives in `base/resource_path`, with OpenGL shader loading, UI theme directory reloads, and optional script tools resolving the same installed/development search paths.
 - CMake installs bundled `shaders`, `themes`, and `scripts` under `share/gldraw`, and the GLFW FetchContent declaration pins the downloaded archive with `URL_HASH`.
 - This refactor round is complete for theme modules, document persistence modules, object command modules, application lifecycle boundaries, input/document/render boundary tightening, and bundled resource/build layout hardening.

--- a/doc/architecture/refactor-roadmap.md
+++ b/doc/architecture/refactor-roadmap.md
@@ -22,7 +22,7 @@ The next refactor should not reduce layering for its own sake. It should turn pa
 - Dynamic tool activation now lives in `workspace_tool_commands`.
 - View-model construction now captures workspace state into a build context and emits summary, command, tool, layer, property, and dialog snapshots through separate builders.
 - UI frame construction has moved to `src/ui/ui_frame.c`, the inspector's layer controls now live in `src/ui/ui_layer_panel.c`, menu bar rendering lives in `src/ui/ui_menubar_render.c`, and context menu rendering lives in `src/ui/ui_context_menu_render.c`.
-- Render submission now uses `RenderSceneDesc` and a cache-key value. The next render cleanup should focus on ownership and lifetime of scene snapshots rather than parameter shape.
+- Render submission now uses `RenderSceneDesc`; render-system internals capture that descriptor into a scene snapshot/cache-key helper before deciding whether to reuse the draw list.
 - Canvas draw-list strokes are normalized to line-segment geometry and `canvas_renderer_submit()` batches adjacent strokes with identical material and primitive metadata before backend submission.
 - Bundled shader, theme, and script paths now resolve through a base resource-path helper instead of assuming the process current working directory is the repository root.
 
@@ -65,6 +65,7 @@ The next refactor should not reduce layering for its own sake. It should turn pa
 - Application-owned workspace save/load/export and workspace action callbacks live in `application_workspace_services.c`.
 - `application.c` is scoped to lifecycle setup, shutdown, and frame sequencing.
 - `render_system_draw()` consumes `RenderSceneDesc`.
+- `RenderSceneDesc` lives in `include/render/render_scene.h`, while scene cache-key capture and comparison live behind the render-system implementation boundary.
 - Resource lookup for bundled files lives in `base/resource_path`, with OpenGL shader loading, UI theme directory reloads, and optional script tools resolving the same installed/development search paths.
 - CMake installs bundled `shaders`, `themes`, and `scripts` under `share/gldraw`, and the GLFW FetchContent declaration pins the downloaded archive with `URL_HASH`.
 - This refactor round is complete for theme modules, document persistence modules, object command modules, application lifecycle boundaries, input/document/render boundary tightening, and bundled resource/build layout hardening.
@@ -175,4 +176,4 @@ These rules are the target state for the refactor:
 
 ## Suggested Next Implementation Slice
 
-This refactor round is complete. Future work should be planned as a new round, starting with render scene snapshot ownership or the larger theme system only after adding focused tests around the target area.
+The render scene snapshot ownership slice is complete. Future work should be planned as a separate slice, starting with GL/Nuklear backend lifecycle hardening or the larger theme system only after adding focused tests around the target area.

--- a/doc/architecture/refactor-roadmap.md
+++ b/doc/architecture/refactor-roadmap.md
@@ -23,6 +23,7 @@ The next refactor should not reduce layering for its own sake. It should turn pa
 - View-model construction now captures workspace state into a build context and emits summary, command, tool, layer, property, and dialog snapshots through separate builders.
 - UI frame construction has moved to `src/ui/ui_frame.c`, the inspector's layer controls now live in `src/ui/ui_layer_panel.c`, menu bar rendering lives in `src/ui/ui_menubar_render.c`, and context menu rendering lives in `src/ui/ui_context_menu_render.c`.
 - Render submission now uses `RenderSceneDesc`; render-system internals capture that descriptor into a scene snapshot/cache-key helper before deciding whether to reuse the draw list.
+- The GLFW/Nuklear boundary now pairs Nuklear GL3 VAO teardown with creation and keeps GLFW initialized until the final tracked platform window is shut down.
 - Canvas draw-list strokes are normalized to line-segment geometry and `canvas_renderer_submit()` batches adjacent strokes with identical material and primitive metadata before backend submission.
 - Bundled shader, theme, and script paths now resolve through a base resource-path helper instead of assuming the process current working directory is the repository root.
 
@@ -66,6 +67,7 @@ The next refactor should not reduce layering for its own sake. It should turn pa
 - `application.c` is scoped to lifecycle setup, shutdown, and frame sequencing.
 - `render_system_draw()` consumes `RenderSceneDesc`.
 - `RenderSceneDesc` lives in `include/render/render_scene.h`, while scene cache-key capture and comparison live behind the render-system implementation boundary.
+- Platform window and Nuklear GL lifetimes are still adapter-owned, with teardown now matching tracked resource ownership more closely.
 - Resource lookup for bundled files lives in `base/resource_path`, with OpenGL shader loading, UI theme directory reloads, and optional script tools resolving the same installed/development search paths.
 - CMake installs bundled `shaders`, `themes`, and `scripts` under `share/gldraw`, and the GLFW FetchContent declaration pins the downloaded archive with `URL_HASH`.
 - This refactor round is complete for theme modules, document persistence modules, object command modules, application lifecycle boundaries, input/document/render boundary tightening, and bundled resource/build layout hardening.
@@ -176,4 +178,4 @@ These rules are the target state for the refactor:
 
 ## Suggested Next Implementation Slice
 
-The render scene snapshot ownership slice is complete. Future work should be planned as a separate slice, starting with GL/Nuklear backend lifecycle hardening or the larger theme system only after adding focused tests around the target area.
+The render scene snapshot ownership and narrow GL/Nuklear lifetime slices are complete. Future work should be planned as a separate slice, starting with deeper GL state restoration or the larger theme system only after adding focused tests around the target area.

--- a/doc/reference/file-map.md
+++ b/doc/reference/file-map.md
@@ -133,7 +133,12 @@
 
 ### Understand rendering
 
+- `include/render/render_scene.h`
+  Public read-only scene descriptor consumed by `render_system_draw()`.
 - `src/render/render_system.c`
+  Owns render-system lifetime, resize/export operations, and cached scene submission.
+- `src/render/render_scene_snapshot.c`
+  Captures render-scene descriptors into internal cache keys for draw-list reuse decisions.
 - `src/render/canvas_drawlist.c`
   Builds cached canvas geometry and normalizes object outlines to line-segment strokes.
 - `src/render/canvas_renderer.c`

--- a/include/nuklear/nuklear_glfw_gl3.h
+++ b/include/nuklear/nuklear_glfw_gl3.h
@@ -211,7 +211,9 @@ nk_glfw3_device_destroy(struct nk_glfw* glfw)
     glDeleteTextures(1, &dev->font_tex);
     glDeleteBuffers(1, &dev->vbo);
     glDeleteBuffers(1, &dev->ebo);
+    glDeleteVertexArrays(1, &dev->vao);
     nk_buffer_free(&dev->cmds);
+    memset(dev, 0, sizeof(*dev));
 }
 
 NK_API void

--- a/include/render/render_scene.h
+++ b/include/render/render_scene.h
@@ -1,0 +1,21 @@
+/**
+ * @file render_scene.h
+ * @brief Read-only editor scene input consumed by the render system.
+ */
+#ifndef GLDRAW_RENDER_RENDER_SCENE_H
+#define GLDRAW_RENDER_RENDER_SCENE_H
+
+#include <canvas/canvas_view.h>
+#include <document/document.h>
+#include <model/selection.h>
+
+typedef struct RenderSceneDesc {
+    const Document* document;
+    const SelectionSet* selection;
+    const CanvasView* canvas;
+    int selection_preview_active;
+    Vec2 selection_preview_delta;
+    const GraphicObject* overlay_object;
+} RenderSceneDesc;
+
+#endif /* GLDRAW_RENDER_RENDER_SCENE_H */

--- a/include/render/render_system.h
+++ b/include/render/render_system.h
@@ -6,10 +6,9 @@
 #define GLDRAW_RENDER_RENDER_SYSTEM_H
 
 #include <canvas/canvas_view.h>
-#include <document/document.h>
-#include <model/selection.h>
 #include <platform/window.h>
 #include <render/render_device.h>
+#include <render/render_scene.h>
 
 typedef struct RenderSystem RenderSystem;
 
@@ -20,15 +19,6 @@ typedef struct RenderSystemDesc {
     int framebuffer_height;
     int owns_device;
 } RenderSystemDesc;
-
-typedef struct RenderSceneDesc {
-    const Document* document;
-    const SelectionSet* selection;
-    const CanvasView* canvas;
-    int selection_preview_active;
-    Vec2 selection_preview_delta;
-    const GraphicObject* overlay_object;
-} RenderSceneDesc;
 
 /**
  * @brief Create the rendering system and initialize GPU resources.

--- a/src/app/application.c
+++ b/src/app/application.c
@@ -62,6 +62,9 @@ static int app_init(Application *app) {
   {
     RenderDevice *device = render_device_factory_create_gl(&app->window);
     app->renderer = render_system_create(device, &app->window);
+    if (!app->renderer) {
+      render_device_destroy(device);
+    }
   }
   if (!app->renderer) {
     LOG_ERROR("%s", "Failed to initialize renderer");

--- a/src/platform/window.c
+++ b/src/platform/window.c
@@ -271,7 +271,7 @@ void platform_window_shutdown(PlatformWindow* window)
     free(window->handle);
     window->handle = NULL;
 
-    if (g_glfw_initialized) {
+    if (g_glfw_initialized && !g_window_list) {
         glfwTerminate();
         g_glfw_initialized = 0;
     }

--- a/src/render/render_scene_snapshot.c
+++ b/src/render/render_scene_snapshot.c
@@ -1,0 +1,60 @@
+#include "render_scene_snapshot.h"
+
+static RenderSceneCacheKey render_scene_cache_key(const RenderSceneDesc* scene)
+{
+    RenderSceneCacheKey key;
+
+    key.document_revision = scene && scene->document ? document_revision(scene->document) : 0u;
+    key.overlay_revision = scene && scene->overlay_object
+                               ? scene->overlay_object->revision
+                               : 0u;
+    key.selection_count = scene && scene->selection ? scene->selection->count : 0;
+    key.selection_revision = scene && scene->selection ? scene->selection->revision : 0u;
+    key.selection_preview_active = scene ? scene->selection_preview_active : 0;
+    key.selection_preview_delta = scene ? scene->selection_preview_delta
+                                        : (Vec2){0.0f, 0.0f};
+    key.viewport = scene && scene->canvas ? canvas_view_viewport(scene->canvas)
+                                          : (RectF){0.0f, 0.0f, 0.0f, 0.0f};
+    key.center = scene && scene->canvas ? canvas_view_center(scene->canvas)
+                                        : (Vec2){0.0f, 0.0f};
+    key.zoom = scene && scene->canvas ? canvas_view_zoom(scene->canvas) : 0.0f;
+    return key;
+}
+
+int render_scene_snapshot_capture(RenderSceneSnapshot* snapshot,
+                                  const RenderSceneDesc* scene)
+{
+    if (!snapshot || !scene || !scene->document || !scene->canvas) {
+        return 0;
+    }
+
+    snapshot->desc = *scene;
+    snapshot->cache_key = render_scene_cache_key(scene);
+    return 1;
+}
+
+int render_scene_snapshot_equal(const RenderSceneSnapshot* a,
+                                const RenderSceneSnapshot* b)
+{
+    const RenderSceneCacheKey* a_key = a ? &a->cache_key : NULL;
+    const RenderSceneCacheKey* b_key = b ? &b->cache_key : NULL;
+
+    if (!a_key || !b_key) {
+        return 0;
+    }
+
+    return a_key->document_revision == b_key->document_revision &&
+           a_key->overlay_revision == b_key->overlay_revision &&
+           a_key->selection_count == b_key->selection_count &&
+           a_key->selection_revision == b_key->selection_revision &&
+           a_key->selection_preview_active == b_key->selection_preview_active &&
+           a_key->selection_preview_delta.x == b_key->selection_preview_delta.x &&
+           a_key->selection_preview_delta.y == b_key->selection_preview_delta.y &&
+           a_key->zoom == b_key->zoom &&
+           a_key->center.x == b_key->center.x &&
+           a_key->center.y == b_key->center.y &&
+           a_key->viewport.x == b_key->viewport.x &&
+           a_key->viewport.y == b_key->viewport.y &&
+           a_key->viewport.w == b_key->viewport.w &&
+           a_key->viewport.h == b_key->viewport.h;
+}

--- a/src/render/render_scene_snapshot.h
+++ b/src/render/render_scene_snapshot.h
@@ -1,0 +1,28 @@
+#ifndef GLDRAW_RENDER_RENDER_SCENE_SNAPSHOT_H
+#define GLDRAW_RENDER_RENDER_SCENE_SNAPSHOT_H
+
+#include <render/render_scene.h>
+
+typedef struct RenderSceneCacheKey {
+    unsigned int document_revision;
+    unsigned int overlay_revision;
+    int selection_count;
+    uint64_t selection_revision;
+    int selection_preview_active;
+    RectF viewport;
+    Vec2 center;
+    Vec2 selection_preview_delta;
+    float zoom;
+} RenderSceneCacheKey;
+
+typedef struct RenderSceneSnapshot {
+    RenderSceneDesc desc;
+    RenderSceneCacheKey cache_key;
+} RenderSceneSnapshot;
+
+int render_scene_snapshot_capture(RenderSceneSnapshot* snapshot,
+                                  const RenderSceneDesc* scene);
+int render_scene_snapshot_equal(const RenderSceneSnapshot* a,
+                                const RenderSceneSnapshot* b);
+
+#endif /* GLDRAW_RENDER_RENDER_SCENE_SNAPSHOT_H */

--- a/src/render/render_system.c
+++ b/src/render/render_system.c
@@ -3,20 +3,10 @@
 #include <image/png_writer.h>
 #include <render/canvas_renderer.h>
 
+#include "render_scene_snapshot.h"
+
 #include <math.h>
 #include <stdlib.h>
-
-typedef struct RenderSceneCacheKey {
-    unsigned int document_revision;
-    unsigned int overlay_revision;
-    int selection_count;
-    uint64_t selection_revision;
-    int selection_preview_active;
-    RectF viewport;
-    Vec2 center;
-    Vec2 selection_preview_delta;
-    float zoom;
-} RenderSceneCacheKey;
 
 struct RenderSystem {
     RenderDevice* device;
@@ -26,8 +16,8 @@ struct RenderSystem {
     int framebuffer_width;
     int framebuffer_height;
     int owns_device;
-    RenderSceneCacheKey cache_key;
-    int draw_list_valid;
+    RenderSceneSnapshot scene_snapshot;
+    int scene_snapshot_valid;
 };
 
 static RenderTransform render_system_make_transform(const RenderSystem* renderer)
@@ -47,50 +37,6 @@ static RenderTransform render_system_make_transform(const RenderSystem* renderer
             (float)renderer->framebuffer_height / (float)renderer->logical_height;
     }
     return transform;
-}
-
-static RenderSceneCacheKey render_system_scene_cache_key(const RenderSceneDesc* scene)
-{
-    RenderSceneCacheKey key;
-
-    key.document_revision = scene && scene->document ? document_revision(scene->document) : 0u;
-    key.overlay_revision = scene && scene->overlay_object
-                               ? scene->overlay_object->revision
-                               : 0u;
-    key.selection_count = scene && scene->selection ? scene->selection->count : 0;
-    key.selection_revision = scene && scene->selection ? scene->selection->revision : 0u;
-    key.selection_preview_active = scene ? scene->selection_preview_active : 0;
-    key.selection_preview_delta = scene ? scene->selection_preview_delta
-                                        : (Vec2){0.0f, 0.0f};
-    key.viewport = scene && scene->canvas ? canvas_view_viewport(scene->canvas)
-                                          : (RectF){0.0f, 0.0f, 0.0f, 0.0f};
-    key.center = scene && scene->canvas ? canvas_view_center(scene->canvas)
-                                        : (Vec2){0.0f, 0.0f};
-    key.zoom = scene && scene->canvas ? canvas_view_zoom(scene->canvas) : 0.0f;
-    return key;
-}
-
-static int render_system_scene_cache_key_equal(const RenderSceneCacheKey* a,
-                                               const RenderSceneCacheKey* b)
-{
-    if (!a || !b) {
-        return 0;
-    }
-
-    return a->document_revision == b->document_revision &&
-           a->overlay_revision == b->overlay_revision &&
-           a->selection_count == b->selection_count &&
-           a->selection_revision == b->selection_revision &&
-           a->selection_preview_active == b->selection_preview_active &&
-           a->selection_preview_delta.x == b->selection_preview_delta.x &&
-           a->selection_preview_delta.y == b->selection_preview_delta.y &&
-           a->zoom == b->zoom &&
-           a->center.x == b->center.x &&
-           a->center.y == b->center.y &&
-           a->viewport.x == b->viewport.x &&
-           a->viewport.y == b->viewport.y &&
-           a->viewport.w == b->viewport.w &&
-           a->viewport.h == b->viewport.h;
 }
 
 RenderSystem* render_system_create_with_desc(RenderDevice* device,
@@ -160,7 +106,7 @@ void render_system_resize(RenderSystem* renderer,
     renderer->logical_height = logical_height;
     renderer->framebuffer_width = framebuffer_width;
     renderer->framebuffer_height = framebuffer_height;
-    renderer->draw_list_valid = 0;
+    renderer->scene_snapshot_valid = 0;
     render_device_resize(renderer->device,
                          logical_width,
                          logical_height,
@@ -170,34 +116,26 @@ void render_system_resize(RenderSystem* renderer,
 
 void render_system_draw(RenderSystem* renderer, const RenderSceneDesc* scene)
 {
-    RenderSceneCacheKey cache_key;
+    RenderSceneSnapshot snapshot;
     RenderFrameDesc frame_desc;
     RenderTransform transform;
-    const Document* document = scene ? scene->document : NULL;
-    const SelectionSet* selection = scene ? scene->selection : NULL;
-    const CanvasView* canvas = scene ? scene->canvas : NULL;
-    const GraphicObject* overlay_object = scene ? scene->overlay_object : NULL;
-    int selection_preview_active = scene ? scene->selection_preview_active : 0;
-    Vec2 selection_preview_delta = scene ? scene->selection_preview_delta
-                                         : (Vec2){0.0f, 0.0f};
 
-    if (!renderer || !document || !canvas) {
+    if (!renderer || !render_scene_snapshot_capture(&snapshot, scene)) {
         return;
     }
-    cache_key = render_system_scene_cache_key(scene);
-    if (!renderer->draw_list_valid ||
-        !render_system_scene_cache_key_equal(&renderer->cache_key, &cache_key)) {
+    if (!renderer->scene_snapshot_valid ||
+        !render_scene_snapshot_equal(&renderer->scene_snapshot, &snapshot)) {
         if (!canvas_drawlist_build(&renderer->draw_list,
-                                   document,
-                                   selection,
-                                   canvas,
-                                   selection_preview_active,
-                                   selection_preview_delta,
-                                   overlay_object)) {
+                                   snapshot.desc.document,
+                                   snapshot.desc.selection,
+                                   snapshot.desc.canvas,
+                                   snapshot.desc.selection_preview_active,
+                                   snapshot.desc.selection_preview_delta,
+                                   snapshot.desc.overlay_object)) {
             return;
         }
-        renderer->cache_key = cache_key;
-        renderer->draw_list_valid = 1;
+        renderer->scene_snapshot = snapshot;
+        renderer->scene_snapshot_valid = 1;
     }
 
     frame_desc.logical_width = renderer->logical_width;


### PR DESCRIPTION
Closes N/A

## Summary
- Move RenderSceneDesc into a dedicated render_scene header and capture render-system cache state through an internal scene snapshot helper.
- Tighten GLFW/Nuklear lifetime handling by deleting the Nuklear VAO and terminating GLFW only after the final tracked window closes.
- Release a created RenderDevice if RenderSystem creation fails during application startup.

## Testing
- cmake --build build --parallel
- ctest --test-dir build --output-on-failure
- git diff --check

## Related
- refs #106

## Notes
- User-visible behavior is intended to remain unchanged; deeper GL state restoration is left for a separately tested follow-up.