### PR TITLE
chore(release): add packaging workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version override, for example 2.0.1"
+        required: false
+        type: string
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            platform: windows-x64
+            artifact: GLDraw-windows-x64
+          - os: ubuntu-latest
+            platform: linux-x64
+            artifact: GLDraw-linux-x64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache GLFW source
+        uses: actions/cache@v4
+        with:
+          path: build/Release/_deps
+          key: ${{ runner.os }}-release-glfw-3.3.9-${{ hashFiles('CMakeLists.txt') }}
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+
+      - name: Package Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $version = "${{ github.event.inputs.version }}"
+          if ($version) {
+            ./release.bat -Version $version -Platform ${{ matrix.platform }}
+          } else {
+            ./release.bat -Platform ${{ matrix.platform }}
+          }
+
+      - name: Package Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            bash ./release.sh --version "${{ github.event.inputs.version }}" --platform "${{ matrix.platform }}"
+          else
+            bash ./release.sh --platform "${{ matrix.platform }}"
+          fi
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/GLDraw-v*
+          if-no-files-found: error
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes ""
+          gh release upload "$GITHUB_REF_NAME" dist/GLDraw-v* --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ deps/
 external/
 third_party/
 
+# Release packages
+dist/
+
 ### System and OS ###
 # Windows
 Thumbs.db

--- a/doc/build.md
+++ b/doc/build.md
@@ -104,6 +104,47 @@ For manual CMake builds, replace `build/Release` with the build directory used
 during configure.
 
 
+Release Packaging
+-----------------
+
+On Windows with MinGW/MSYS2, create a distributable zip package with:
+
+```bat
+release.bat
+```
+
+On Linux, create a distributable tarball with:
+
+```sh
+bash ./release.sh
+```
+
+The package is written to `dist/` and contains the application binary, bundled
+resources, README files, license text, and detected non-system runtime DLLs. The
+installed layout is:
+
+```text
+bin/GLDraw.exe
+share/gldraw/shaders/
+share/gldraw/themes/
+share/gldraw/scripts/
+```
+
+Override the generated version or platform label when needed:
+
+```bat
+release.bat -Version 0.0.3 -Platform windows-x64
+```
+
+```sh
+bash ./release.sh --version 0.0.3 --platform linux-x64
+```
+
+GitHub Actions also has a release workflow. Pushing a tag such as `v0.0.3`
+builds and uploads both `windows-x64` and `linux-x64` packages to the matching
+GitHub Release.
+
+
 Troubleshooting
 ---------------
 

--- a/release.bat
+++ b/release.bat
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0tools\package_release.ps1" %*

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/tools/package_release.sh" "$@"

--- a/tools/package_release.ps1
+++ b/tools/package_release.ps1
@@ -1,0 +1,162 @@
+param(
+    [string]$Version = "",
+    [string]$Generator = "MinGW Makefiles",
+    [string]$BuildDir = "build/Release",
+    [string]$DistDir = "dist",
+    [string]$Platform = "",
+    [switch]$SkipBuild,
+    [switch]$SkipRuntimeDlls
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $RepoRoot
+
+function Get-ProjectVersion {
+    $cmakeText = Get-Content "CMakeLists.txt" -Raw
+    $match = [regex]::Match($cmakeText, "project\s*\(\s*GLDraw[\s\S]*?VERSION\s+([0-9A-Za-z._-]+)")
+    if (-not $match.Success) {
+        throw "Could not find project version in CMakeLists.txt."
+    }
+    return $match.Groups[1].Value
+}
+
+function Get-DefaultPlatform {
+    if ($IsWindows -or $env:OS -eq "Windows_NT") {
+        return "windows-x64"
+    }
+    if ($IsMacOS) {
+        return "macos"
+    }
+    return "linux-x64"
+}
+
+function Copy-IfExists {
+    param(
+        [string]$Path,
+        [string]$Destination
+    )
+
+    if (Test-Path $Path) {
+        Copy-Item -LiteralPath $Path -Destination $Destination -Force
+    }
+}
+
+function Get-ObjdumpDllNames {
+    param([string]$Executable)
+
+    $objdump = Get-Command objdump -ErrorAction SilentlyContinue
+    if (-not $objdump) {
+        Write-Host "objdump not found; skipping runtime DLL scan."
+        return @()
+    }
+
+    $output = & $objdump.Source -p $Executable
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "objdump failed; skipping runtime DLL scan."
+        return @()
+    }
+
+    return $output |
+        Select-String "DLL Name:\s+(.+)$" |
+        ForEach-Object { $_.Matches[0].Groups[1].Value.Trim() } |
+        Sort-Object -Unique
+}
+
+function Copy-RuntimeDlls {
+    param([string]$Executable)
+
+    if (-not ($IsWindows -or $env:OS -eq "Windows_NT")) {
+        return
+    }
+
+    $systemDlls = @(
+        "advapi32.dll",
+        "comdlg32.dll",
+        "gdi32.dll",
+        "kernel32.dll",
+        "msvcrt.dll",
+        "ole32.dll",
+        "opengl32.dll",
+        "shell32.dll",
+        "ucrtbase.dll",
+        "user32.dll",
+        "winmm.dll"
+    )
+
+    $exeDir = Split-Path -Parent $Executable
+    $dllNames = Get-ObjdumpDllNames $Executable
+
+    foreach ($dllName in $dllNames) {
+        $normalizedDllName = $dllName.ToLowerInvariant()
+        if ($systemDlls -contains $normalizedDllName) {
+            continue
+        }
+
+        if ($normalizedDllName.StartsWith("api-ms-win-") -or $normalizedDllName.StartsWith("ext-ms-")) {
+            continue
+        }
+
+        $found = Get-Command $dllName -ErrorAction SilentlyContinue
+        if ($found -and (Test-Path $found.Source)) {
+            Copy-Item -LiteralPath $found.Source -Destination $exeDir -Force
+            Write-Host "Bundled runtime DLL: $dllName"
+        } else {
+            Write-Host "Runtime DLL not found on PATH: $dllName"
+        }
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = Get-ProjectVersion
+}
+
+if ([string]::IsNullOrWhiteSpace($Platform)) {
+    $Platform = Get-DefaultPlatform
+}
+
+$BuildDir = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $BuildDir))
+$DistDir = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $DistDir))
+$StageRoot = Join-Path $DistDir "stage"
+$PackageName = "GLDraw-v$Version-$Platform"
+$PackageRoot = Join-Path $StageRoot $PackageName
+$ArchivePath = Join-Path $DistDir "$PackageName.zip"
+
+cmake -G $Generator -DCMAKE_BUILD_TYPE=Release -S $RepoRoot -B $BuildDir
+if ($LASTEXITCODE -ne 0) { throw "CMake configure failed." }
+
+if (-not $SkipBuild) {
+    cmake --build $BuildDir --parallel
+    if ($LASTEXITCODE -ne 0) { throw "CMake build failed." }
+}
+
+if (Test-Path $StageRoot) {
+    Remove-Item -LiteralPath $StageRoot -Recurse -Force
+}
+
+New-Item -ItemType Directory -Path $PackageRoot | Out-Null
+
+cmake --install $BuildDir --prefix $PackageRoot
+if ($LASTEXITCODE -ne 0) { throw "CMake install failed." }
+
+Copy-IfExists "LICENSE.txt" $PackageRoot
+Copy-IfExists "README.md" $PackageRoot
+Copy-IfExists "README.zh-CN.md" $PackageRoot
+Copy-IfExists "doc/build.md" $PackageRoot
+Copy-IfExists "doc/controls.md" $PackageRoot
+
+$exePath = Join-Path $PackageRoot "bin/GLDraw.exe"
+if ((Test-Path $exePath) -and -not $SkipRuntimeDlls) {
+    Copy-RuntimeDlls $exePath
+}
+
+if (Test-Path $ArchivePath) {
+    Remove-Item -LiteralPath $ArchivePath -Force
+}
+
+Compress-Archive -Path $PackageRoot -DestinationPath $ArchivePath -Force
+
+Write-Host ""
+Write-Host "Release package created:"
+Write-Host "  $ArchivePath"

--- a/tools/package_release.sh
+++ b/tools/package_release.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=""
+GENERATOR="Unix Makefiles"
+BUILD_DIR="build/Release"
+DIST_DIR="dist"
+PLATFORM=""
+SKIP_BUILD=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version)
+            VERSION="${2:-}"
+            shift 2
+            ;;
+        --generator)
+            GENERATOR="${2:-}"
+            shift 2
+            ;;
+        --build-dir)
+            BUILD_DIR="${2:-}"
+            shift 2
+            ;;
+        --dist-dir)
+            DIST_DIR="${2:-}"
+            shift 2
+            ;;
+        --platform)
+            PLATFORM="${2:-}"
+            shift 2
+            ;;
+        --skip-build)
+            SKIP_BUILD=1
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ -z "$VERSION" ]]; then
+    VERSION="$(sed -nE '/project[[:space:]]*\([[:space:]]*GLDraw/,/\)/s/.*VERSION[[:space:]]+([0-9A-Za-z._-]+).*/\1/p' CMakeLists.txt | head -n 1)"
+fi
+
+if [[ -z "$VERSION" ]]; then
+    echo "Could not find project version in CMakeLists.txt." >&2
+    exit 1
+fi
+
+if [[ -z "$PLATFORM" ]]; then
+    case "$(uname -s)" in
+        Linux*) PLATFORM="linux-x64" ;;
+        Darwin*) PLATFORM="macos" ;;
+        *) PLATFORM="unknown" ;;
+    esac
+fi
+
+mkdir -p "$(dirname "$BUILD_DIR")"
+BUILD_DIR="$(cd "$(dirname "$BUILD_DIR")" && pwd)/$(basename "$BUILD_DIR")"
+mkdir -p "$DIST_DIR"
+DIST_DIR="$(cd "$DIST_DIR" && pwd)"
+
+STAGE_ROOT="$DIST_DIR/stage"
+PACKAGE_NAME="GLDraw-v$VERSION-$PLATFORM"
+PACKAGE_ROOT="$STAGE_ROOT/$PACKAGE_NAME"
+ARCHIVE_PATH="$DIST_DIR/$PACKAGE_NAME.tar.gz"
+
+cmake -G "$GENERATOR" -DCMAKE_BUILD_TYPE=Release -S "$REPO_ROOT" -B "$BUILD_DIR"
+
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+    cmake --build "$BUILD_DIR" --parallel
+fi
+
+rm -rf "$STAGE_ROOT"
+mkdir -p "$PACKAGE_ROOT"
+
+cmake --install "$BUILD_DIR" --prefix "$PACKAGE_ROOT"
+
+for file in LICENSE.txt README.md README.zh-CN.md doc/build.md doc/controls.md; do
+    if [[ -f "$file" ]]; then
+        cp "$file" "$PACKAGE_ROOT/"
+    fi
+done
+
+tar -czf "$ARCHIVE_PATH" -C "$STAGE_ROOT" "$PACKAGE_NAME"
+
+echo ""
+echo "Release package created:"
+echo "  $ARCHIVE_PATH"


### PR DESCRIPTION
Closes N/A

## Summary
- Add Windows and Linux release packaging scripts.
- Add a GitHub Actions release workflow for windows-x64 and linux-x64 packages.
- Document local and tag-based release packaging commands.

## Testing
- `release.bat -SkipBuild`
- `ctest --test-dir build\Release --output-on-failure`

## Related
- N/A

## Notes
- Linux package generation is expected to run on a Linux host or the GitHub Actions Ubuntu runner.