### PR TITLE
fix(release): run linux packaging script with bash

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-"$SCRIPT_DIR/tools/package_release.sh" "$@"
+bash "$SCRIPT_DIR/tools/package_release.sh" "$@"


### PR DESCRIPTION
Closes N/A

## Summary
- Run the Linux release packaging helper through `bash` from `release.sh`.
- Avoid depending on executable bits after GitHub Actions checkout.

## Testing
- Release workflow failure log showed `tools/package_release.sh: Permission denied`; this change addresses that path directly.

## Related
- Follow-up to #109

## Notes
- Needed before re-triggering the `v0.0.2` release workflow.