### PR TITLE
chore(release): add legacy asset workflow

### DIFF
--- a/.github/workflows/legacy-release.yml
+++ b/.github/workflows/legacy-release.yml
@@ -1,0 +1,131 @@
+name: Legacy Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, for example 0.0.1"
+        required: true
+        type: string
+      target_ref:
+        description: "Git ref to package, for example v0.0.1 or 7ed56f5"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            platform: windows-x64
+            artifact: GLDraw-windows-x64
+          - os: ubuntu-latest
+            platform: linux-x64
+            artifact: GLDraw-linux-x64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_ref }}
+
+      - name: Cache GLFW source
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: ${{ runner.os }}-legacy-glfw-3.3.9-${{ inputs.target_ref }}
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+
+      - name: Build Windows
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: build.bat release
+
+      - name: Build Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: bash ./build.sh release
+
+      - name: Package Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+          $platform = "${{ matrix.platform }}"
+          $root = "GLDraw-v$version-$platform"
+          $stage = Join-Path "dist" $root
+          New-Item -ItemType Directory -Path $stage | Out-Null
+          Copy-Item -LiteralPath "build/Release/bin/GLDraw.exe" -Destination $stage
+          foreach ($dir in @("shaders", "themes", "scripts")) {
+            $path = Join-Path "build/Release/bin" $dir
+            if (Test-Path $path) {
+              Copy-Item -Recurse -LiteralPath $path -Destination $stage
+            }
+          }
+          foreach ($file in @("README.md", "README.zh-CN.md", "LICENSE.txt")) {
+            if (Test-Path $file) {
+              Copy-Item -LiteralPath $file -Destination $stage
+            }
+          }
+          Compress-Archive -Path $stage -DestinationPath "dist/$root.zip" -Force
+
+      - name: Package Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          version="${{ inputs.version }}"
+          platform="${{ matrix.platform }}"
+          root="GLDraw-v$version-$platform"
+          stage="dist/$root"
+          mkdir -p "$stage"
+          cp "build/Release/bin/GLDraw" "$stage/"
+          for dir in shaders themes scripts; do
+            if [ -d "build/Release/bin/$dir" ]; then
+              cp -R "build/Release/bin/$dir" "$stage/"
+            fi
+          done
+          for file in README.md README.zh-CN.md LICENSE.txt; do
+            if [ -f "$file" ]; then
+              cp "$file" "$stage/"
+            fi
+          done
+          tar -czf "dist/$root.tar.gz" -C dist "$root"
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            dist/GLDraw-v*.zip
+            dist/GLDraw-v*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    needs: package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="v${{ inputs.version }}"
+          gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || gh release create "$tag" --repo "$GITHUB_REPOSITORY" --target "${{ inputs.target_ref }}" --title "$tag" --notes ""
+          gh release upload "$tag" dist/GLDraw-v*.zip dist/GLDraw-v*.tar.gz --repo "$GITHUB_REPOSITORY" --clobber


### PR DESCRIPTION
Closes N/A

## Summary
- Add a manual legacy release workflow that checks out a specified ref.
- Build and package Windows/Linux assets from that target ref.
- Upload generated archives to the matching GitHub Release.

## Testing
- Built v0.0.1 Windows package locally from tag `v0.0.1`.
- `ctest --test-dir build\Release --output-on-failure` passed in the v0.0.1 worktree.

## Related
- Used for v0.0.1 initial public release assets.

## Notes
- This workflow is for older refs that do not contain the current release scripts.