### PR TITLE
feat(release): add installer assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+          sudo apt-get install -y build-essential cmake curl libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
 
       - name: Package Windows
         if: runner.os == 'Windows'
@@ -63,9 +63,21 @@ jobs:
         run: |
           $version = "${{ steps.version.outputs.value }}"
           if ($version) {
-            ./release.bat -Version $version -Platform ${{ matrix.platform }}
+            ./release.bat -Version $version -Platform "${{ matrix.platform }}"
           } else {
-            ./release.bat -Platform ${{ matrix.platform }}
+            ./release.bat -Platform "${{ matrix.platform }}"
+          }
+
+      - name: Build Windows installer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.value }}"
+          choco install innosetup --no-progress -y
+          if ($version) {
+            pwsh -NoProfile -ExecutionPolicy Bypass -File tools/package_windows_installer.ps1 -Version $version -Platform "${{ matrix.platform }}"
+          } else {
+            pwsh -NoProfile -ExecutionPolicy Bypass -File tools/package_windows_installer.ps1 -Platform "${{ matrix.platform }}"
           }
 
       - name: Package Linux
@@ -78,11 +90,25 @@ jobs:
             bash ./release.sh --platform "${{ matrix.platform }}"
           fi
 
+      - name: Build Linux AppImage
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          version="${{ steps.version.outputs.value }}"
+          if [ -z "$version" ]; then
+            version="$(sed -nE '/project[[:space:]]*\([[:space:]]*GLDraw/,/\)/s/.*VERSION[[:space:]]+([0-9A-Za-z._-]+).*/\1/p' CMakeLists.txt | head -n 1)"
+          fi
+          bash ./tools/package_appimage.sh --version "$version" --platform "${{ matrix.platform }}"
+
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: dist/GLDraw-v*
+          path: |
+            dist/GLDraw-v*.zip
+            dist/GLDraw-v*.tar.gz
+            dist/GLDraw-v*.exe
+            dist/GLDraw-v*.AppImage
           if-no-files-found: error
 
   publish:

--- a/doc/build.md
+++ b/doc/build.md
@@ -113,15 +113,28 @@ On Windows with MinGW/MSYS2, create a distributable zip package with:
 release.bat
 ```
 
+After creating the Windows zip package, create a Windows installer when Inno
+Setup 6 is installed:
+
+```bat
+powershell -NoProfile -ExecutionPolicy Bypass -File tools\package_windows_installer.ps1 -Version 0.0.3 -Platform windows-x64
+```
+
 On Linux, create a distributable tarball with:
 
 ```sh
 bash ./release.sh
 ```
 
+After creating the Linux tarball, create an AppImage:
+
+```sh
+bash ./tools/package_appimage.sh --version 0.0.3 --platform linux-x64
+```
+
 The package is written to `dist/` and contains the application binary, bundled
 resources, README files, license text, and detected non-system runtime DLLs. The
-installed layout is:
+installed layout used by current releases is:
 
 ```text
 bin/GLDraw.exe
@@ -142,7 +155,36 @@ bash ./release.sh --version 0.0.3 --platform linux-x64
 
 GitHub Actions also has a release workflow. Pushing a tag such as `v0.0.3`, or
 running the workflow manually with version `0.0.3`, builds and uploads both
-`windows-x64` and `linux-x64` packages to the matching GitHub Release.
+Windows and Linux packages to the matching GitHub Release:
+
+```text
+GLDraw-v0.0.3-windows-x64-setup.exe
+GLDraw-v0.0.3-windows-x64.zip
+GLDraw-v0.0.3-linux-x64.AppImage
+GLDraw-v0.0.3-linux-x64.tar.gz
+```
+
+Use the Windows setup installer for normal installation, the Windows zip package
+for portable use, the Linux AppImage for a desktop-style portable app, or the
+Linux tarball for manual extraction.
+
+Release notes should use this short format:
+
+```text
+GLDraw vX.Y.Z <one-sentence release summary>.
+
+Highlights:
+- ...
+
+Downloads:
+- GLDraw-vX.Y.Z-windows-x64-setup.exe
+- GLDraw-vX.Y.Z-windows-x64.zip
+- GLDraw-vX.Y.Z-linux-x64.AppImage
+- GLDraw-vX.Y.Z-linux-x64.tar.gz
+
+Target commit:
+- <short-sha> <commit title>
+```
 
 
 Troubleshooting

--- a/packaging/linux/GLDraw.desktop
+++ b/packaging/linux/GLDraw.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=GLDraw
+Comment=Canvas-oriented OpenGL drawing editor
+Exec=GLDraw
+Icon=gldraw
+Terminal=false
+Categories=Graphics;2DGraphics;RasterGraphics;

--- a/packaging/linux/gldraw.svg
+++ b/packaging/linux/gldraw.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <rect width="256" height="256" rx="32" fill="#1f2937"/>
+  <rect x="44" y="44" width="64" height="64" rx="10" fill="#f8fafc"/>
+  <rect x="44" y="148" width="64" height="64" rx="10" fill="#38bdf8"/>
+  <rect x="148" y="44" width="64" height="64" rx="10" fill="#a7f3d0"/>
+  <path d="M72 184 184 72" stroke="#f8fafc" stroke-width="18" stroke-linecap="round"/>
+  <path d="M92 184h-32l8-31" fill="none" stroke="#f8fafc" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packaging/windows/GLDraw.iss
+++ b/packaging/windows/GLDraw.iss
@@ -1,0 +1,47 @@
+#define AppName "GLDraw"
+#ifndef AppVersion
+#define AppVersion "0.0.0"
+#endif
+#ifndef SourceDir
+#define SourceDir "..\..\dist\stage\GLDraw-v" + AppVersion + "-windows-x64"
+#endif
+#ifndef OutputDir
+#define OutputDir "..\..\dist"
+#endif
+#ifndef OutputBaseFilename
+#define OutputBaseFilename "GLDraw-v" + AppVersion + "-windows-x64-setup"
+#endif
+
+[Setup]
+AppId={{B28BA2D6-2B20-40EC-B3D7-29F5BDE5DE2F}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher=GLDraw
+DefaultDirName={autopf}\{#AppName}
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+LicenseFile={#SourceDir}\LICENSE.txt
+OutputDir={#OutputDir}
+OutputBaseFilename={#OutputBaseFilename}
+Compression=lzma
+SolidCompression=yes
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+UninstallDisplayIcon={app}\bin\GLDraw.exe
+WizardStyle=modern
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\GLDraw"; Filename: "{app}\bin\GLDraw.exe"; WorkingDir: "{app}"
+Name: "{autodesktop}\GLDraw"; Filename: "{app}\bin\GLDraw.exe"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\bin\GLDraw.exe"; Description: "{cm:LaunchProgram,GLDraw}"; Flags: nowait postinstall skipifsilent

--- a/tools/package_appimage.sh
+++ b/tools/package_appimage.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=""
+PLATFORM="linux-x64"
+DIST_DIR="dist"
+STAGE_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version)
+            VERSION="${2:-}"
+            shift 2
+            ;;
+        --platform)
+            PLATFORM="${2:-}"
+            shift 2
+            ;;
+        --dist-dir)
+            DIST_DIR="${2:-}"
+            shift 2
+            ;;
+        --stage-dir)
+            STAGE_DIR="${2:-}"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ -z "$VERSION" ]]; then
+    echo "--version is required." >&2
+    exit 1
+fi
+
+DIST_DIR="$(mkdir -p "$DIST_DIR" && cd "$DIST_DIR" && pwd)"
+PACKAGE_NAME="GLDraw-v$VERSION-$PLATFORM"
+
+if [[ -z "$STAGE_DIR" ]]; then
+    STAGE_DIR="$DIST_DIR/stage/$PACKAGE_NAME"
+fi
+
+if [[ ! -x "$STAGE_DIR/bin/GLDraw" ]]; then
+    echo "Missing staged GLDraw executable: $STAGE_DIR/bin/GLDraw" >&2
+    exit 1
+fi
+
+APPDIR="$DIST_DIR/appimage/$PACKAGE_NAME.AppDir"
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin" "$APPDIR/usr/share/gldraw" "$APPDIR/usr/share/applications" "$APPDIR/usr/share/icons/hicolor/scalable/apps"
+
+cp "$STAGE_DIR/bin/GLDraw" "$APPDIR/usr/bin/GLDraw"
+if [[ -d "$STAGE_DIR/share/gldraw" ]]; then
+    cp -R "$STAGE_DIR/share/gldraw/." "$APPDIR/usr/share/gldraw/"
+fi
+
+cp "packaging/linux/GLDraw.desktop" "$APPDIR/usr/share/applications/GLDraw.desktop"
+cp "packaging/linux/gldraw.svg" "$APPDIR/usr/share/icons/hicolor/scalable/apps/gldraw.svg"
+cp "packaging/linux/GLDraw.desktop" "$APPDIR/GLDraw.desktop"
+cp "packaging/linux/gldraw.svg" "$APPDIR/gldraw.svg"
+
+LINUXDEPLOY="$DIST_DIR/linuxdeploy-x86_64.AppImage"
+if [[ ! -x "$LINUXDEPLOY" ]]; then
+    curl -L -o "$LINUXDEPLOY" "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+    chmod +x "$LINUXDEPLOY"
+fi
+
+APPIMAGE_EXTRACT_AND_RUN=1 "$LINUXDEPLOY" --appdir "$APPDIR" --output appimage
+mv "GLDraw-"*.AppImage "$DIST_DIR/$PACKAGE_NAME.AppImage"
+
+echo ""
+echo "AppImage created:"
+echo "  $DIST_DIR/$PACKAGE_NAME.AppImage"

--- a/tools/package_windows_installer.ps1
+++ b/tools/package_windows_installer.ps1
@@ -1,0 +1,79 @@
+param(
+    [string]$Version = "",
+    [string]$Platform = "windows-x64",
+    [string]$DistDir = "dist",
+    [string]$SourceDir = "",
+    [string]$OutputDir = "",
+    [string]$OutputBaseFilename = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $RepoRoot
+
+function Get-ProjectVersion {
+    $cmakeText = Get-Content "CMakeLists.txt" -Raw
+    $match = [regex]::Match($cmakeText, "project\s*\(\s*GLDraw[\s\S]*?VERSION\s+([0-9A-Za-z._-]+)")
+    if (-not $match.Success) {
+        throw "Could not find project version in CMakeLists.txt."
+    }
+    return $match.Groups[1].Value
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = Get-ProjectVersion
+}
+
+$DistDir = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $DistDir))
+
+if ([string]::IsNullOrWhiteSpace($SourceDir)) {
+    $SourceDir = Join-Path $DistDir "stage/GLDraw-v$Version-$Platform"
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+    $OutputDir = $DistDir
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputBaseFilename)) {
+    $OutputBaseFilename = "GLDraw-v$Version-$Platform-setup"
+}
+
+$SourceDir = [System.IO.Path]::GetFullPath($SourceDir)
+$OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+$SetupScript = Join-Path $RepoRoot "packaging/windows/GLDraw.iss"
+
+if (-not (Test-Path (Join-Path $SourceDir "bin/GLDraw.exe"))) {
+    throw "Missing staged GLDraw executable under $SourceDir."
+}
+
+if (-not (Test-Path $OutputDir)) {
+    New-Item -ItemType Directory -Path $OutputDir | Out-Null
+}
+
+$iscc = Get-Command iscc -ErrorAction SilentlyContinue
+if (-not $iscc) {
+    $isccPath = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+    if (-not (Test-Path $isccPath)) {
+        throw "ISCC.exe not found. Install Inno Setup 6 or add iscc to PATH."
+    }
+} else {
+    $isccPath = $iscc.Source
+}
+
+& $isccPath `
+    $SetupScript `
+    "/DAppVersion=$Version" `
+    "/DSourceDir=$SourceDir" `
+    "/DOutputDir=$OutputDir" `
+    "/DOutputBaseFilename=$OutputBaseFilename"
+
+if ($LASTEXITCODE -ne 0) {
+    throw "Inno Setup failed."
+}
+
+$InstallerPath = Join-Path $OutputDir "$OutputBaseFilename.exe"
+
+Write-Host ""
+Write-Host "Windows installer created:"
+Write-Host "  $InstallerPath"


### PR DESCRIPTION
Closes N/A

## Summary
- Add Inno Setup packaging for a Windows setup installer.
- Add Linux AppImage metadata and packaging script.
- Extend the Release workflow to publish setup.exe, zip, AppImage, and tar.gz assets.
- Document installer/AppImage commands and release-note download conventions.

## Testing
- `release.bat -SkipBuild`
- `ctest --test-dir build\Release --output-on-failure`
- Parsed `tools/package_windows_installer.ps1` with PowerShell parser.

## Related
- Builds on the release packaging workflow added for v0.0.2.

## Notes
- Local machine does not have Inno Setup (`iscc`) installed and has no Linux runner, so setup.exe and AppImage generation are expected to be verified by GitHub Actions.