### PR TITLE
chore(infra): add team foundation infrastructure

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,24 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+ColumnLimit: 100
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+BreakBeforeBraces: Allman
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+BinPackParameters: false
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+PointerAlignment: Right
+SortIncludes: false
+IncludeBlocks: Preserve
+SpaceBeforeParens: ControlStatements
+SpacesInParentheses: false
+Cpp11BracedListStyle: false
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+Checks: >
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  bugprone-*,
+  performance-*,
+  portability-*,
+  misc-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  -bugprone-suspicious-string-compare,
+  -misc-include-cleaner,
+  -misc-no-recursion,
+  -readability-*
+WarningsAsErrors: ''
+HeaderFilterRegex: '^(include|src|tests)/'
+FormatStyle: file
+CheckOptions:
+  - key: bugprone-assert-side-effect.AssertMacros
+    value: assert

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,38 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{c,h}]
+indent_style = space
+indent_size = 4
+max_line_length = 100
+
+[CMakeLists.txt]
+indent_style = space
+indent_size = 4
+
+[*.cmake]
+indent_style = space
+indent_size = 4
+
+[*.{md,yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.bat]
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+
+[*.ps1]
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+
+[*.sh]
+indent_style = space
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.ico binary
+*.exe binary
+*.dll binary
+*.zip binary
+*.tar.gz binary
+*.AppImage binary

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# Keep ownership broad until stable module owners are assigned.
+
+* @wubing7755
+
+/.github/ @wubing7755
+/CMakeLists.txt @wubing7755
+/CMakePresets.json @wubing7755
+/build.bat @wubing7755
+/build.sh @wubing7755
+/release.bat @wubing7755
+/release.sh @wubing7755
+/scripts/ @wubing7755
+/tools/ @wubing7755
+
+/include/document/ @wubing7755
+/src/document/ @wubing7755
+/src/commands/ @wubing7755
+/include/tools/ @wubing7755
+/src/tools/ @wubing7755
+/src/ui/ @wubing7755
+/src/render/ @wubing7755
+/src/app/ @wubing7755
+/tests/ @wubing7755
+/doc/ @wubing7755

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,14 +3,46 @@ Closes #xx
 ## Summary
 - ...
 - ...
-- ...
+
+## Change Type
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Infrastructure / CI / packaging
+- [ ] Documentation
+- [ ] Release preparation
+
+## Areas Touched
+- [ ] Document model / persistence
+- [ ] Commands / undo / redo
+- [ ] Tools / input handling
+- [ ] Workspace / session / services
+- [ ] UI / menus / panels / dialogs
+- [ ] Rendering / shaders / resources
+- [ ] Build / tests / CI / release
+
+## Architecture Checklist
+- [ ] Durable document mutations go through `CommandExecutor`.
+- [ ] UI code dispatches actions and does not own editing rules.
+- [ ] Tool input flows through editor controller / tool runtime boundaries.
+- [ ] Rendering changes consume scene state rather than defining document behavior.
+- [ ] No new `workspace_internal.h` include was added outside workspace implementation files.
+- [ ] Not applicable.
 
 ## Testing
-- ...
-- ...
+- [ ] Local build completed.
+- [ ] Relevant CTest tests completed.
+- [ ] Format or static-analysis checks completed when applicable.
+- [ ] UI/rendering screenshots or recordings attached when applicable.
+- [ ] Not run; reason:
+
+## Compatibility and Release Notes
+- File format impact:
+- Packaging or runtime dependency impact:
+- User-visible change for changelog:
 
 ## Related
-- refs #yy
+- Refs #yy
 
 ## Notes
-- Optional: compatibility, migration, or review context
+- Optional: migration details, review context, or follow-up work.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Cache GLFW source
       uses: actions/cache@v4
       with:
-        path: build/_deps
+        path: build/**/_deps
         key: ${{ runner.os }}-glfw-3.3.9-${{ hashFiles('CMakeLists.txt') }}
 
     - name: Install dependencies (Linux)
@@ -38,24 +38,20 @@ jobs:
     - name: Configure CMake
       shell: bash
       run: |
-        BUILD_DIR="build/${{ matrix.os }}-${{ matrix.build_type }}"
-        if [ "${{ matrix.os }}" == "windows-latest" ]; then
-          cmake -B "$BUILD_DIR" -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        else
-          cmake -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        preset="$(echo "${{ matrix.build_type }}" | tr '[:upper:]' '[:lower:]')"
+        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          preset="mingw-$preset"
         fi
+        echo "GLDRAW_CMAKE_PRESET=$preset" >> "$GITHUB_ENV"
+        cmake --preset "$preset"
 
     - name: Build
       shell: bash
-      run: |
-        BUILD_DIR="build/${{ matrix.os }}-${{ matrix.build_type }}"
-        cmake --build "$BUILD_DIR" --config ${{ matrix.build_type }}
+      run: cmake --build --preset "$GLDRAW_CMAKE_PRESET" --parallel
 
     - name: Test
       shell: bash
-      run: |
-        BUILD_DIR="build/${{ matrix.os }}-${{ matrix.build_type }}"
-        cd "$BUILD_DIR" && ctest --output-on-failure
+      run: ctest --preset "$GLDRAW_CMAKE_PRESET" --output-on-failure
 
   sanitize:
     strategy:
@@ -71,7 +67,7 @@ jobs:
     - name: Cache GLFW source
       uses: actions/cache@v4
       with:
-        path: build/_deps
+        path: build/**/_deps
         key: ${{ runner.os }}-glfw-3.3.9-${{ hashFiles('CMakeLists.txt') }}
 
     - name: Install dependencies (Linux)
@@ -86,18 +82,12 @@ jobs:
 
     - name: Configure with ASan
       shell: bash
-      run: |
-        BUILD_DIR="build/${{ matrix.os }}-asan"
-        cmake -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Debug -DGLDRAW_ENABLE_ASAN=ON
+      run: cmake --preset asan
 
     - name: Build with ASan
       shell: bash
-      run: |
-        BUILD_DIR="build/${{ matrix.os }}-asan"
-        cmake --build "$BUILD_DIR" --config Debug
+      run: cmake --build --preset asan --parallel
 
     - name: Test with ASan
       shell: bash
-      run: |
-        BUILD_DIR="build/${{ matrix.os }}-asan"
-        cd "$BUILD_DIR" && ctest --output-on-failure
+      run: ctest --preset asan --output-on-failure

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,10 +14,6 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
 
-    env:
-      CFLAGS: --coverage -O0 -g
-      LDFLAGS: --coverage
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,13 +24,13 @@ jobs:
           sudo apt-get install -y build-essential cmake gcovr libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
 
       - name: Configure CMake
-        run: cmake -S . -B build/coverage -DCMAKE_BUILD_TYPE=Debug
+        run: cmake --preset coverage
 
       - name: Build
-        run: cmake --build build/coverage --parallel
+        run: cmake --build --preset coverage --parallel
 
       - name: Test
-        run: ctest --test-dir build/coverage --output-on-failure
+        run: ctest --preset coverage --output-on-failure
 
       - name: Generate coverage reports
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,6 @@ Thumbs.db
 *~
 
 ### Version Control ###
-.gitattributes
 .git/
 *.orig
 *.rej

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable user-facing and contributor-facing changes should be recorded here.
+
+This project uses a simple, human-written changelog. Keep entries concise and
+grouped by release.
+
+## Unreleased
+
+### Added
+
+* Contributor guide for branch naming, pull requests, architecture boundaries,
+  and local verification.
+* Code owner rules for repository, build, documentation, and major source
+  areas.
+* Shared editor, clang-format, and clang-tidy configuration files.
+* CMake presets for debug, release, coverage, AddressSanitizer, MinGW, and MSVC
+  contributor workflows.
+* Local check scripts for shell and PowerShell.
+* Testing, security, release, and ADR documentation for team collaboration.
+
+### Changed
+
+* CI and coverage workflows now use CMake presets for configure, build, and test
+  steps.
+
+## 0.0.2
+
+### Notes
+
+* See the GitHub Release notes for packaged assets and release-specific
+  highlights.
+
+## 0.0.1
+
+### Notes
+
+* Initial public release series.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,180 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "description": "Debug build with the default host generator.",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "description": "Release build with the default host generator.",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "coverage",
+      "displayName": "Coverage",
+      "description": "Debug build with gcov-compatible coverage flags.",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_FLAGS": "--coverage -O0 -g",
+        "CMAKE_EXE_LINKER_FLAGS": "--coverage"
+      }
+    },
+    {
+      "name": "asan",
+      "displayName": "AddressSanitizer",
+      "description": "Debug build with GLDraw AddressSanitizer support enabled.",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "GLDRAW_ENABLE_ASAN": "ON"
+      }
+    },
+    {
+      "name": "mingw-debug",
+      "displayName": "MinGW Debug",
+      "description": "Debug build using MinGW Makefiles on Windows.",
+      "inherits": "base",
+      "generator": "MinGW Makefiles",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "mingw-release",
+      "displayName": "MinGW Release",
+      "description": "Release build using MinGW Makefiles on Windows.",
+      "inherits": "base",
+      "generator": "MinGW Makefiles",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "msvc-release",
+      "displayName": "MSVC Release",
+      "description": "Release build using Visual Studio 2022 x64.",
+      "inherits": "base",
+      "generator": "Visual Studio 17 2022",
+      "architecture": "x64"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release",
+      "configuration": "Release"
+    },
+    {
+      "name": "coverage",
+      "configurePreset": "coverage",
+      "configuration": "Debug"
+    },
+    {
+      "name": "asan",
+      "configurePreset": "asan",
+      "configuration": "Debug"
+    },
+    {
+      "name": "mingw-debug",
+      "configurePreset": "mingw-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "mingw-release",
+      "configurePreset": "mingw-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "msvc-release",
+      "configurePreset": "msvc-release",
+      "configuration": "Release"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "release",
+      "configurePreset": "release",
+      "configuration": "Release",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "coverage",
+      "configurePreset": "coverage",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "asan",
+      "configurePreset": "asan",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "mingw-debug",
+      "configurePreset": "mingw-debug",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "mingw-release",
+      "configurePreset": "mingw-release",
+      "configuration": "Release",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "msvc-release",
+      "configurePreset": "msvc-release",
+      "configuration": "Release",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,155 @@
+# Contributing to GLDraw
+
+GLDraw is a C11 OpenGL drawing editor. This guide keeps day-to-day
+contributions aligned across contributors, reviewers, and CI.
+
+## Development Setup
+
+Use the repository build scripts for normal local builds:
+
+```sh
+./build.sh
+./build.sh debug
+```
+
+On Windows with MinGW/MSYS2 from CMD:
+
+```bat
+build.bat
+build.bat debug
+```
+
+Manual CMake and packaging details are documented in [doc/build.md](doc/build.md).
+Optional CMake presets are available for contributors with a recent CMake:
+
+```sh
+cmake --preset debug
+cmake --build --preset debug
+ctest --preset debug --output-on-failure
+```
+
+## Branches and Commits
+
+Use short, scoped branch names:
+
+* `feature/<topic>` for user-facing behavior.
+* `fix/<topic>` for bug fixes.
+* `refactor/<topic>` for internal reshaping without intended behavior changes.
+* `infra/<topic>` for build, CI, documentation, packaging, or tooling.
+* `release/<version>` for release preparation.
+
+Prefer focused commits that can be reviewed independently. Commit subjects should
+start with a useful scope when possible, for example:
+
+```text
+fix(commands): preserve selection after undo
+feat(tools): add polygon drag lifecycle
+chore(ci): align builds with CMake presets
+```
+
+## Pull Requests
+
+Before opening a pull request:
+
+* Rebase or merge the target branch if the change depends on recent CI or build
+  updates.
+* Run the smallest local verification that covers the touched area.
+* Include screenshots or short recordings for visible UI, canvas, rendering, or
+  theme changes.
+* Explain any compatibility, file format, packaging, or release impact.
+* Link issues with `Closes #...` or `Refs #...` when applicable.
+
+Reviewers should focus first on behavior, ownership boundaries, and tests. Style
+feedback should point back to the shared formatting rules where possible.
+
+## Architecture Boundaries
+
+Keep changes aligned with the current ownership model:
+
+* Durable document mutations should go through `CommandExecutor`.
+* Object storage, layers, IDs, revisions, and spatial queries belong in
+  `document/`.
+* Selection, clipboard, dialogs, dirty state, and layout are workspace/session
+  concerns.
+* Tool input should flow through `editor_controller` and `tool_runtime`.
+* UI code should consume view-model or workspace query state and emit actions; it
+  should not own editing rules.
+* Rendering consumes render scene state; it should not define document behavior.
+* Platform-specific input values should be converted at the app/input boundary.
+* Resource lookup for shaders, themes, and scripts should use
+  `base/resource_path`.
+
+Avoid adding new includes of `workspace_internal.h` outside workspace
+implementation files unless a test explicitly verifies internal lifecycle
+behavior.
+
+## Adding Document Objects
+
+Objects are descriptor-driven through `GraphicObjectDescriptor`.
+
+When adding or changing an object type:
+
+* Implement create, clone, destroy, translate, bounds, hit-test, path, property,
+  and persistence callbacks as needed.
+* Register descriptors with `register_object_type()`.
+* Add built-in object registration through `src/app/extension_manifest.c`.
+* Prefer `GRAPHIC_OBJECT_INVALID` for new auto-assigned object type IDs.
+* Add focused tests for persistence, bounds, hit-testing, and property behavior
+  when the object affects those contracts.
+
+## Adding Tools
+
+Tools are descriptor-driven through `ToolDescriptor`.
+
+When adding or changing a tool:
+
+* Register custom tools with `register_tool()`.
+* Use `register_shape_tool()` when the standard shape-drag lifecycle is enough.
+* Add built-in tool registration through `src/app/tool_manifest.c`.
+* Keep durable edits command-based; use overlays for previews.
+* Test command creation and cancellation behavior where practical.
+
+## Adding Commands
+
+Command metadata, availability, and execution are split:
+
+* `command_catalog` owns command descriptors and IDs.
+* `command_availability` owns executable-state checks.
+* `command_registry_execute()` remains the public execution entrypoint.
+* Concrete workspace behavior is split across focused workspace command modules.
+
+Command changes should include tests for success paths, unavailable states, and
+undo/redo behavior when durable document state changes.
+
+## UI Changes
+
+UI frame construction is split across focused `src/ui/` modules. Keep UI changes
+thin: read workspace query state, present controls, and dispatch actions. Avoid
+moving editing rules into widgets.
+
+Visible UI changes should include a screenshot or short recording in the pull
+request when possible.
+
+## Local Verification
+
+Use the local check scripts when available:
+
+```sh
+./scripts/check.sh
+```
+
+On Windows PowerShell:
+
+```powershell
+./scripts/check.ps1
+```
+
+For targeted work, run the relevant CMake preset directly:
+
+```sh
+cmake --preset debug
+cmake --build --preset debug
+ctest --preset debug --output-on-failure
+```
+
+CI remains the source of truth for platform coverage.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Documentation
 
 * Build and run: [doc/build.md](doc/build.md)
 * Controls: [doc/controls.md](doc/controls.md)
+* Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
+* Testing: [doc/testing.md](doc/testing.md)
+* Release process: [doc/release.md](doc/release.md)
+* Changelog: [CHANGELOG.md](CHANGELOG.md)
+* Security policy: [SECURITY.md](SECURITY.md)
 * Local documentation index: [doc/README.md](doc/README.md)
 * Architecture and source guide: https://zread.ai/wubing7755/GLDraw
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,6 +50,11 @@ build\Release\bin\GLDraw.exe
 
 * 构建和运行：[doc/build.md](doc/build.md)
 * 快捷键和基本操作：[doc/controls.md](doc/controls.md)
+* 贡献指南：[CONTRIBUTING.md](CONTRIBUTING.md)
+* 测试策略：[doc/testing.md](doc/testing.md)
+* 发布流程：[doc/release.md](doc/release.md)
+* 变更记录：[CHANGELOG.md](CHANGELOG.md)
+* 安全策略：[SECURITY.md](SECURITY.md)
 * 本地文档入口：[doc/README.md](doc/README.md)
 * 架构和源码导览：https://zread.ai/wubing7755/GLDraw
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes target the current `main` branch and the latest published
+release when a backport is practical. Older releases may receive fixes when the
+impact is high and the patch can be applied safely.
+
+## Reporting a Vulnerability
+
+Do not publish exploit details in a public issue.
+
+Preferred reporting path:
+
+1. Use GitHub private vulnerability reporting if it is enabled for the
+   repository.
+2. If private reporting is not available, open a minimal public issue asking for
+   a private maintainer contact and omit sensitive details.
+
+Please include:
+
+* Affected version, commit, or release asset.
+* Operating system and toolchain.
+* Reproduction steps or a proof of concept.
+* Impact assessment.
+* Whether the issue affects source builds, packaged releases, or both.
+
+## Dependency Security
+
+GLDraw uses CMake, GLFW, GLAD, Nuklear, OpenGL platform libraries, and packaging
+tools. Dependency updates should go through normal pull request review and CI.
+Security-driven dependency updates may be handled outside the regular release
+cadence when the risk justifies it.
+
+## Disclosure
+
+Maintainers should acknowledge reports as soon as practical, coordinate a fix in
+a private branch or security advisory when available, and publish release notes
+once users have a patched version or clear mitigation.

--- a/doc/README.md
+++ b/doc/README.md
@@ -2,7 +2,8 @@ GLDraw Documentation
 ====================
 
 This directory contains only the small documentation that should live with the
-repository: build instructions, run commands, and basic controls.
+repository: build instructions, run commands, basic controls, testing policy,
+release policy, and short architecture decision records.
 
 Project architecture, source navigation, and module-level explanations are
 maintained through Zread:
@@ -17,6 +18,9 @@ Quick Start
 
 * Build and run GLDraw: See build.md
 * Learn basic controls: See controls.md
+* Understand testing expectations: See testing.md
+* Prepare a release: See release.md
+* Review stable architecture decisions: See adr/README.md
 * Read project architecture: https://zread.ai/wubing7755/GLDraw
 * Check the license: See ../LICENSE.txt
 
@@ -28,6 +32,9 @@ All users and contributors should be familiar with:
 
 * Build requirements: build.md
 * Runtime controls: controls.md
+* Testing policy: testing.md
+* Release policy: release.md
+* Contributor guide: ../CONTRIBUTING.md
 * Project overview: ../README.md
 * Source and architecture guide: https://zread.ai/wubing7755/GLDraw
 
@@ -37,7 +44,9 @@ Documentation Policy
 
 Keep this directory short.
 
-* Build, run, dependency, and control notes belong here.
+* Build, run, dependency, control, testing, and release notes belong here.
+* Short ADRs may live in adr/ when they record stable contributor-facing
+  decisions.
 * Long architecture pages should stay out of this directory.
 * Source maps, subsystem descriptions, and refactor narratives should be read
   through Zread or generated from the current source tree.

--- a/doc/adr/0001-workspace-as-editor-hub.md
+++ b/doc/adr/0001-workspace-as-editor-hub.md
@@ -1,0 +1,28 @@
+# ADR 0001: Workspace as the Editor Hub
+
+## Status
+
+Accepted.
+
+## Context
+
+GLDraw coordinates document state, editing commands, tools, UI state, save/load
+services, and rendering state. These areas need one integration point, but they
+should not freely reach into each other's internals.
+
+## Decision
+
+`Workspace` remains the editor hub. It owns the editor core, editor session, and
+editor services integration, while public workspace and controller APIs are the
+preferred access path for other modules.
+
+## Consequences
+
+* New top-level editor behavior should normally enter through workspace,
+  controller, service, or command APIs.
+* Direct access to workspace internals should stay inside workspace
+  implementation files.
+* Tests may include internal headers only when they are explicitly verifying
+  internal lifecycle behavior.
+* UI, tools, rendering, and platform code should not become alternate editor
+  hubs.

--- a/doc/adr/0002-command-executor-for-durable-mutations.md
+++ b/doc/adr/0002-command-executor-for-durable-mutations.md
@@ -1,0 +1,24 @@
+# ADR 0002: CommandExecutor for Durable Mutations
+
+## Status
+
+Accepted.
+
+## Context
+
+GLDraw supports undo and redo. Durable document changes need consistent history,
+dirty-state, selection, and persistence behavior.
+
+## Decision
+
+Durable document mutations should go through `CommandExecutor`. Commands are the
+unit of undoable editing behavior.
+
+## Consequences
+
+* Tools and UI actions should emit commands for durable edits.
+* Direct document mutation is appropriate only for document-owned internals,
+  loading, tests, or narrowly scoped setup code.
+* Command changes should include tests for success paths, unavailable states, and
+  undo/redo behavior when document state changes.
+* Preview and overlay state may remain outside command history until committed.

--- a/doc/adr/0003-descriptor-driven-objects-and-tools.md
+++ b/doc/adr/0003-descriptor-driven-objects-and-tools.md
@@ -1,0 +1,28 @@
+# ADR 0003: Descriptor-Driven Objects and Tools
+
+## Status
+
+Accepted.
+
+## Context
+
+GLDraw supports built-in and future extensible object and tool behavior. The
+editor needs stable registration points without hard-coding every behavior into
+the workspace or UI.
+
+## Decision
+
+Graphic objects are registered through `GraphicObjectDescriptor`, and tools are
+registered through `ToolDescriptor`. Built-in registration is centralized in the
+application manifests.
+
+## Consequences
+
+* New object behavior should be expressed through descriptor callbacks for
+  lifecycle, geometry, hit-testing, properties, and persistence.
+* New tools should use `register_tool()` or `register_shape_tool()` depending on
+  whether the standard shape-drag lifecycle is sufficient.
+* Built-in object registration belongs in `src/app/extension_manifest.c`.
+* Built-in tool registration belongs in `src/app/tool_manifest.c`.
+* The UI should discover and invoke registered behavior instead of duplicating
+  object or tool rules.

--- a/doc/adr/0004-ui-does-not-own-editing-rules.md
+++ b/doc/adr/0004-ui-does-not-own-editing-rules.md
@@ -1,0 +1,27 @@
+# ADR 0004: UI Does Not Own Editing Rules
+
+## Status
+
+Accepted.
+
+## Context
+
+GLDraw's UI is built with Nuklear and split across focused `src/ui/` modules.
+Editing behavior must remain consistent across menus, shortcuts, context menus,
+dialogs, tools, and future automation.
+
+## Decision
+
+UI code should present state and dispatch actions. Editing rules belong in
+workspace commands, tool runtime, document modules, or services depending on the
+behavior.
+
+## Consequences
+
+* UI modules should consume workspace query state, view-model data, or command
+  availability.
+* Menu items, toolbar controls, dialogs, and context menus should converge on the
+  same command/action paths.
+* Business rules should not be hidden inside widget event branches.
+* UI tests should focus on state derivation and action routing rather than
+  duplicating document or command tests.

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,0 +1,14 @@
+Architecture Decision Records
+=============================
+
+This directory contains short Architecture Decision Records for stable decisions
+that affect contributors and reviewers.
+
+Keep ADRs concise:
+
+* State the decision.
+* Explain the context.
+* Record consequences for future changes.
+
+Detailed source navigation and module-level explanations remain in Zread:
+https://zread.ai/wubing7755/GLDraw

--- a/doc/build.md
+++ b/doc/build.md
@@ -4,13 +4,15 @@ Build and Run GLDraw
 GLDraw is a C11 OpenGL drawing editor built with CMake.
 
 The recommended path is to use the repository build scripts. Manual CMake
-commands are available when a specific generator or output layout is needed.
+commands and optional CMake presets are available when a specific generator or
+output layout is needed.
 
 
 Requirements
 ------------
 
 * CMake 3.15 or newer
+* CMake 3.21 or newer for optional CMake presets
 * A C11 compiler
 * OpenGL runtime and development files
 * Git and network access for the first CMake configure
@@ -60,6 +62,31 @@ Script output paths:
 
 * Release: build/Release/bin/GLDraw or build\Release\bin\GLDraw.exe
 * Debug: build/Debug/bin/GLDraw or build\Debug\bin\GLDraw.exe
+
+
+CMake Presets
+-------------
+
+Contributors with CMake 3.21 or newer can use shared presets:
+
+```sh
+cmake --preset debug
+cmake --build --preset debug
+ctest --preset debug --output-on-failure
+```
+
+Common presets:
+
+* debug
+* release
+* coverage
+* asan
+* mingw-debug
+* mingw-release
+* msvc-release
+
+Presets are used by CI, but the build scripts remain the recommended simple
+entry point for local users.
 
 
 Manual CMake

--- a/doc/release.md
+++ b/doc/release.md
@@ -1,0 +1,102 @@
+Release Process
+===============
+
+This document defines the release workflow used by maintainers. Build commands
+and package layouts are documented in build.md.
+
+
+Versioning
+----------
+
+Use `vX.Y.Z` Git tags for published releases. The release workflow accepts either
+a pushed tag such as `v0.0.3` or a manual workflow dispatch version such as
+`0.0.3`.
+
+Before tagging:
+
+* Update CHANGELOG.md with user-visible changes.
+* Confirm README and doc/build.md still match the packaged layout.
+* Confirm release notes use the short format documented in build.md.
+* Run the release smoke workflow for packaging changes.
+
+
+Preflight
+---------
+
+For normal code releases:
+
+```sh
+./scripts/check.sh --preset release
+```
+
+For Linux sanitizer coverage when available:
+
+```sh
+cmake --preset asan
+cmake --build --preset asan
+ctest --preset asan --output-on-failure
+```
+
+For package-related changes, validate the release smoke workflow before
+publishing.
+
+
+Publishing
+----------
+
+Preferred path:
+
+1. Ensure `main` contains the release commit.
+2. Create an annotated tag:
+
+   ```sh
+   git tag -a vX.Y.Z -m "chore(release): vX.Y.Z"
+   ```
+
+3. Push the tag:
+
+   ```sh
+   git push origin vX.Y.Z
+   ```
+
+4. Wait for the release workflow to build Windows and Linux assets.
+5. Confirm the GitHub Release contains the expected assets:
+
+   ```text
+   GLDraw-vX.Y.Z-windows-x64-setup.exe
+   GLDraw-vX.Y.Z-windows-x64.zip
+   GLDraw-vX.Y.Z-linux-x64.AppImage
+   GLDraw-vX.Y.Z-linux-x64.tar.gz
+   ```
+
+Manual workflow dispatch may be used when maintainers need to rebuild assets
+for an existing release version.
+
+
+Smoke Validation
+----------------
+
+The release smoke workflow validates package structure without publishing a real
+release. It should run for changes to:
+
+* Release workflows.
+* Packaging scripts.
+* Installer or AppImage tooling.
+* Resource layout.
+* CMake install or bundle rules.
+
+
+Hotfixes
+--------
+
+Use a `fix/<topic>` or `release/<version>` branch for hotfixes. Keep the patch
+minimal, add a regression test when practical, update CHANGELOG.md, and publish a
+patch version tag.
+
+
+Legacy Releases
+---------------
+
+For older tags that predate current packaging scripts, use the `Legacy Release`
+workflow. It builds from the target ref while using current packaging tools to
+produce the expected release assets.

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,0 +1,115 @@
+Testing GLDraw
+==============
+
+GLDraw uses CTest for automated tests. CI is the source of truth for platform
+coverage, while local checks should focus on the modules touched by a change.
+
+
+Quick Commands
+--------------
+
+Recommended local check:
+
+```sh
+./scripts/check.sh
+```
+
+Windows PowerShell:
+
+```powershell
+./scripts/check.ps1
+```
+
+Target a specific preset when needed:
+
+```sh
+cmake --preset debug
+cmake --build --preset debug
+ctest --preset debug --output-on-failure
+```
+
+AddressSanitizer and coverage presets are available for supported toolchains:
+
+```sh
+cmake --preset asan
+cmake --build --preset asan
+ctest --preset asan --output-on-failure
+```
+
+```sh
+cmake --preset coverage
+cmake --build --preset coverage
+ctest --preset coverage --output-on-failure
+```
+
+
+Test Layers
+-----------
+
+Use the narrowest test layer that proves the behavior:
+
+* Document tests should cover object storage, layers, IDs, bounds, persistence,
+  hit-testing, property bags, and spatial behavior.
+* Command tests should cover executable-state checks, success paths, undo/redo,
+  and dirty-state consequences when applicable.
+* Tool tests should cover lifecycle decisions, command creation, cancellation,
+  and preview state where practical.
+* Workspace/service tests should cover save, load, export, clipboard, selection,
+  dialogs, and cross-module behavior.
+* UI logic tests should cover view-model and state derivation. Avoid testing
+  Nuklear drawing details directly unless the behavior is owned locally.
+* Render tests should cover renderer-owned contracts without moving document
+  behavior into render code.
+
+
+Regression Expectations
+-----------------------
+
+Bug fixes should include a regression test unless the behavior is only
+observable through platform graphics output or manual UI interaction. When a
+test is not practical, document the reason in the pull request and include a
+manual verification note.
+
+New object types should usually include tests for:
+
+* Creation and destruction.
+* Clone and translate behavior.
+* Bounds and hit-testing.
+* Property read/write behavior.
+* Persistence round trips when the object is serialized.
+
+New commands should usually include tests for:
+
+* Availability checks.
+* Successful execution.
+* Undo and redo.
+* No-op or invalid-input behavior.
+
+New tools should usually include tests for:
+
+* Activation and cancellation.
+* Input sequence handling.
+* Command emission for durable edits.
+* Overlay or preview state when applicable.
+
+
+Coverage
+--------
+
+Coverage reports are generated in CI for Linux. Treat coverage as a guide for
+risk, not as a replacement for focused assertions. Avoid adding tests that only
+exercise lines without validating behavior.
+
+
+Manual Verification
+-------------------
+
+Use manual checks for changes that affect:
+
+* Canvas interaction feel.
+* Visual rendering output.
+* Menus, dialogs, panels, or theme appearance.
+* Platform packaging and executable layout.
+
+Attach screenshots or short recordings to the pull request when the result is
+visible.

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -1,0 +1,60 @@
+[CmdletBinding()]
+param(
+    [string]$Preset = "debug",
+    [switch]$SkipFormat,
+    [switch]$Tidy
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-FormatCheck {
+    if ($SkipFormat) {
+        Write-Host "Skipping clang-format."
+        return
+    }
+
+    if (-not (Get-Command clang-format -ErrorAction SilentlyContinue)) {
+        Write-Host "Skipping clang-format: command not found."
+        return
+    }
+
+    $roots = @("include", "src", "tests") | Where-Object { Test-Path $_ }
+    if ($roots.Count -eq 0) {
+        return
+    }
+
+    $files = Get-ChildItem -Path $roots -Recurse -File -Include *.c, *.h |
+        Where-Object {
+            $relative = Resolve-Path -Relative $_.FullName
+            $relative -notlike ".\include\glad\*" -and
+                $relative -notlike ".\include\KHR\*" -and
+                $relative -notlike ".\include\nuklear\*" -and
+                $relative -ne ".\src\glad.c"
+        } |
+        Sort-Object FullName
+
+    if ($files.Count -eq 0) {
+        return
+    }
+
+    & clang-format --dry-run --Werror @($files.FullName)
+}
+
+function Invoke-Tidy {
+    if (-not $Tidy) {
+        return
+    }
+
+    if (-not (Get-Command run-clang-tidy -ErrorAction SilentlyContinue)) {
+        Write-Host "Skipping clang-tidy: run-clang-tidy command not found."
+        return
+    }
+
+    & run-clang-tidy -p "build/$Preset"
+}
+
+Invoke-FormatCheck
+cmake --preset $Preset
+cmake --build --preset $Preset --parallel
+ctest --preset $Preset --output-on-failure
+Invoke-Tidy

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env sh
+set -eu
+
+PRESET="debug"
+SKIP_FORMAT=0
+RUN_TIDY=0
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/check.sh [--preset <name>] [--skip-format] [--tidy]
+
+Runs the standard local verification path:
+  1. clang-format dry run when clang-format is available
+  2. cmake configure with the selected preset
+  3. cmake build with the selected preset
+  4. ctest with the selected preset
+
+Use --tidy to also run run-clang-tidy when it is available.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --preset)
+            if [ "$#" -lt 2 ]; then
+                usage
+                exit 2
+            fi
+            PRESET="$2"
+            shift 2
+            ;;
+        --skip-format)
+            SKIP_FORMAT=1
+            shift
+            ;;
+        --tidy)
+            RUN_TIDY=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+format_files() {
+    if [ "$SKIP_FORMAT" -eq 1 ]; then
+        echo "Skipping clang-format."
+        return
+    fi
+
+    if ! command -v clang-format >/dev/null 2>&1; then
+        echo "Skipping clang-format: command not found."
+        return
+    fi
+
+    files=$(
+        find include src tests \
+            -type f \( -name '*.c' -o -name '*.h' \) \
+            ! -path 'include/glad/*' \
+            ! -path 'include/KHR/*' \
+            ! -path 'include/nuklear/*' \
+            ! -path 'src/glad.c' \
+            | sort
+    )
+
+    if [ -z "$files" ]; then
+        return
+    fi
+
+    echo "$files" | xargs clang-format --dry-run --Werror
+}
+
+run_tidy() {
+    if [ "$RUN_TIDY" -eq 0 ]; then
+        return
+    fi
+
+    if ! command -v run-clang-tidy >/dev/null 2>&1; then
+        echo "Skipping clang-tidy: run-clang-tidy command not found."
+        return
+    fi
+
+    run-clang-tidy -p "build/$PRESET"
+}
+
+format_files
+cmake --preset "$PRESET"
+cmake --build --preset "$PRESET" --parallel
+ctest --preset "$PRESET" --output-on-failure
+run_tidy


### PR DESCRIPTION
## Summary
- Adds contributor, security, testing, release, changelog, and ADR documentation.
- Adds shared editor, Git attributes, clang-format, clang-tidy, CODEOWNERS, CMake presets, and local check scripts.
- Aligns CI and coverage workflows to use CMake presets.

## Validation
- git diff --cached --check
- cmake --list-presets
- ctest --list-presets

Full build and CTest were not run locally because this change is documentation, workflow, and tooling focused.