### PR TITLE
docs(ai): add agent contribution foundation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 * @wubing7755
 
 /.github/ @wubing7755
+/AGENTS.md @wubing7755
 /CMakeLists.txt @wubing7755
 /CMakePresets.json @wubing7755
 /build.bat @wubing7755
@@ -22,3 +23,5 @@
 /src/app/ @wubing7755
 /tests/ @wubing7755
 /doc/ @wubing7755
+/doc/ai-agents.md @wubing7755
+/doc/agent-playbooks.md @wubing7755

--- a/.github/ISSUE_TEMPLATE/agent_task.yml
+++ b/.github/ISSUE_TEMPLATE/agent_task.yml
@@ -1,0 +1,89 @@
+name: AI agent task
+description: Prepare a scoped task for AI-assisted implementation or analysis.
+title: "[agent] "
+labels: ["agent-task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for work that should be clear enough for an AI agent
+        and reviewable by a maintainer. Keep the task focused.
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: What context or problem should the agent understand?
+      placeholder: Describe the current behavior, related issue, or reason for the task.
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should be true when the task is complete?
+      placeholder: Describe the desired outcome in concrete terms.
+    validations:
+      required: true
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-goals
+      description: What should the agent avoid changing?
+      placeholder: List behavior, modules, or follow-up work that is out of scope.
+    validations:
+      required: true
+  - type: checkboxes
+    id: required-context
+    attributes:
+      label: Required context
+      description: Documents the agent should read before editing.
+      options:
+        - label: AGENTS.md
+          required: true
+        - label: CONTRIBUTING.md
+          required: true
+        - label: doc/ai-agents.md
+          required: true
+        - label: doc/agent-playbooks.md
+          required: true
+        - label: doc/testing.md
+          required: true
+        - label: Relevant ADRs in doc/adr/
+          required: false
+        - label: doc/build.md or doc/release.md for build, CI, packaging, or release work
+          required: false
+  - type: textarea
+    id: affected-areas
+    attributes:
+      label: Expected affected areas
+      description: Which files, modules, or ownership boundaries are likely involved?
+      placeholder: Example: src/commands/, tests/, doc/testing.md
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete conditions reviewers can verify.
+      placeholder: |
+        - ...
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: checks
+    attributes:
+      label: Required checks
+      description: Which local or CI checks should pass for this task?
+      placeholder: |
+        - cmake --list-presets
+        - ctest --preset debug --output-on-failure
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes for reviewers
+      description: Mention manual verification, screenshots, risks, or follow-up work.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: GLDraw Documentation
-    url: https://github.com/wubing7755/GLDraw/blob/master/doc/README.md
+    url: https://github.com/wubing7755/GLDraw/blob/main/doc/README.md
     about: Read the local build, run, and controls documentation before opening new work.
   - name: GLDraw Architecture Guide
     url: https://zread.ai/wubing7755/GLDraw

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,6 +36,14 @@ Closes #xx
 - [ ] UI/rendering screenshots or recordings attached when applicable.
 - [ ] Not run; reason:
 
+## AI Assistance
+- [ ] AI assistance was used.
+- Agent/tool:
+- What the agent did:
+- Required docs read:
+- Human verification performed:
+- [ ] Not applicable.
+
 ## Compatibility and Release Notes
 - File format impact:
 - Packaging or runtime dependency impact:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- PR title format: type(scope): summary, for example docs(ai): add agent policy -->
+
 Closes #xx
 
 ## Summary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,29 @@
 
 This file gives Codex repository-specific guidance for GLDraw.
 
+## Required Reading For AI Agents
+
+Before making changes, read:
+
+* `CONTRIBUTING.md` - contributor workflow, PR expectations, and architecture
+  boundaries.
+* `doc/ai-agents.md` - AI agent policy, restrictions, review, and disclosure
+  rules.
+* `doc/agent-playbooks.md` - task-specific AI workflows.
+* `doc/testing.md` - test layers, regression expectations, and manual
+  verification.
+
+For architecture-sensitive work, also read:
+
+* `doc/adr/README.md`
+* Relevant ADR files in `doc/adr/`
+
+For build, CI, packaging, release, dependency, or security work, also read:
+
+* `doc/build.md`
+* `doc/release.md`
+* `SECURITY.md` when dependency or vulnerability handling is involved.
+
 ## Project Shape
 
 GLDraw is a C11 canvas drawing editor built with CMake, GLFW, GLAD, Nuklear,
@@ -129,9 +152,12 @@ Repository-local docs are intentionally short:
 * `doc/README.md` - documentation entrypoint.
 * `doc/build.md` - build, run, dependencies, and troubleshooting.
 * `doc/controls.md` - default shortcuts and pointer behavior.
+* `doc/testing.md` - testing policy and expectations.
+* `doc/ai-agents.md` - AI agent policy.
+* `doc/agent-playbooks.md` - AI-assisted task workflows.
 
 Architecture and source navigation are maintained through Zread:
 https://zread.ai/wubing7755/GLDraw
 
-Update local docs only when build commands, run paths, dependencies, controls,
-or documentation policy change.
+Update local docs when build commands, run paths, dependencies, controls,
+testing policy, release policy, AI agent policy, or documentation policy change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ grouped by release.
   contributor workflows.
 * Local check scripts for shell and PowerShell.
 * Testing, security, release, and ADR documentation for team collaboration.
+* AI agent policy, playbooks, PR disclosure, task issue template, and ADR for
+  AI-assisted contribution boundaries.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,25 @@ Before opening a pull request:
 Reviewers should focus first on behavior, ownership boundaries, and tests. Style
 feedback should point back to the shared formatting rules where possible.
 
+## AI-Assisted Contributions
+
+AI-assisted contributions are welcome when they are scoped, reviewable, and
+verified like any other change. Before editing, AI agents should read AGENTS.md,
+doc/ai-agents.md, doc/agent-playbooks.md, and the documents required by the task
+area.
+
+When meaningful AI assistance was used:
+
+* Disclose it in the pull request template.
+* Name the agent or tool.
+* Summarize what the agent did.
+* List the required docs read.
+* Record human verification and any remaining manual checks.
+
+AI-generated changes must not bypass architecture boundaries, weaken checks, or
+replace maintainer review. Use the AI agent task issue template when preparing
+work that should be handed to an agent.
+
 ## Architecture Boundaries
 
 Keep changes aligned with the current ownership model:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,8 @@ chore(ci): align builds with CMake presets
 
 Before opening a pull request:
 
+* Use a Conventional Commit style PR title: `type(scope): summary`, for example
+  `fix(commands): preserve selection after undo`.
 * Rebase or merge the target branch if the change depends on recent CI or build
   updates.
 * Run the smallest local verification that covers the touched area.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Documentation
 * Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
 * Testing: [doc/testing.md](doc/testing.md)
 * Release process: [doc/release.md](doc/release.md)
+* AI agent policy: [doc/ai-agents.md](doc/ai-agents.md)
+* AI agent playbooks: [doc/agent-playbooks.md](doc/agent-playbooks.md)
 * Changelog: [CHANGELOG.md](CHANGELOG.md)
 * Security policy: [SECURITY.md](SECURITY.md)
 * Local documentation index: [doc/README.md](doc/README.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,6 +53,8 @@ build\Release\bin\GLDraw.exe
 * 贡献指南：[CONTRIBUTING.md](CONTRIBUTING.md)
 * 测试策略：[doc/testing.md](doc/testing.md)
 * 发布流程：[doc/release.md](doc/release.md)
+* AI agent 策略：[doc/ai-agents.md](doc/ai-agents.md)
+* AI agent 流程：[doc/agent-playbooks.md](doc/agent-playbooks.md)
 * 变更记录：[CHANGELOG.md](CHANGELOG.md)
 * 安全策略：[SECURITY.md](SECURITY.md)
 * 本地文档入口：[doc/README.md](doc/README.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -3,7 +3,7 @@ GLDraw Documentation
 
 This directory contains only the small documentation that should live with the
 repository: build instructions, run commands, basic controls, testing policy,
-release policy, and short architecture decision records.
+release policy, AI agent policy, and short architecture decision records.
 
 Project architecture, source navigation, and module-level explanations are
 maintained through Zread:
@@ -20,6 +20,7 @@ Quick Start
 * Learn basic controls: See controls.md
 * Understand testing expectations: See testing.md
 * Prepare a release: See release.md
+* Use AI agents safely: See ai-agents.md and agent-playbooks.md
 * Review stable architecture decisions: See adr/README.md
 * Read project architecture: https://zread.ai/wubing7755/GLDraw
 * Check the license: See ../LICENSE.txt
@@ -34,6 +35,8 @@ All users and contributors should be familiar with:
 * Runtime controls: controls.md
 * Testing policy: testing.md
 * Release policy: release.md
+* AI agent policy: ai-agents.md
+* AI agent playbooks: agent-playbooks.md
 * Contributor guide: ../CONTRIBUTING.md
 * Project overview: ../README.md
 * Source and architecture guide: https://zread.ai/wubing7755/GLDraw
@@ -44,7 +47,8 @@ Documentation Policy
 
 Keep this directory short.
 
-* Build, run, dependency, control, testing, and release notes belong here.
+* Build, run, dependency, control, testing, release, and AI agent notes belong
+  here.
 * Short ADRs may live in adr/ when they record stable contributor-facing
   decisions.
 * Long architecture pages should stay out of this directory.

--- a/doc/adr/0005-ai-agent-contribution-boundaries.md
+++ b/doc/adr/0005-ai-agent-contribution-boundaries.md
@@ -1,0 +1,29 @@
+# ADR 0005: AI Agent Contribution Boundaries
+
+## Status
+
+Accepted.
+
+## Context
+
+AI agents can accelerate repository maintenance, tests, documentation, and
+implementation work. They can also make broad changes quickly, miss project
+context, or bypass architecture boundaries if the rules are not explicit.
+
+## Decision
+
+AI-assisted contributions are allowed, but they must follow the same repository
+rules as human-authored contributions. AGENTS.md is the required entry point for
+AI agents. AI agent policy, playbooks, issue templates, and PR disclosure are
+used to make agent work reviewable and auditable.
+
+## Consequences
+
+* AI agents must read the required repository context before editing.
+* AI-generated code must preserve Workspace, CommandExecutor, tool, UI, render,
+  and document ownership boundaries.
+* Pull requests should disclose meaningful AI assistance and human verification.
+* Agent-suitable issues should define goals, non-goals, acceptance criteria, and
+  required checks.
+* Maintainers may reject AI-assisted changes that are too broad, weakly tested,
+  or not traceable to the task context.

--- a/doc/agent-playbooks.md
+++ b/doc/agent-playbooks.md
@@ -1,0 +1,94 @@
+AI Agent Playbooks
+==================
+
+These playbooks define the default workflow for common AI-assisted tasks. They
+do not replace AGENTS.md, CONTRIBUTING.md, or the ADRs.
+
+
+General Workflow
+----------------
+
+1. Read AGENTS.md and the task issue.
+2. Read CONTRIBUTING.md, doc/ai-agents.md, and doc/testing.md.
+3. Inspect the smallest relevant set of files before editing.
+4. State or record the intended scope.
+5. Make focused changes.
+6. Run the relevant local checks.
+7. Summarize changed files, validation, and residual risk.
+
+
+Bug Fix
+-------
+
+Use this for reproducible defects.
+
+1. Reproduce or identify the failing behavior.
+2. Locate the owning module before editing.
+3. Add or update a regression test when practical.
+4. Fix the smallest behavior surface that owns the bug.
+5. Run targeted tests, then the broader preset when risk justifies it.
+6. Document any manual verification that remains.
+
+
+Feature Work
+------------
+
+Use this for user-visible additions.
+
+1. Confirm the goal, non-goals, and affected workflow.
+2. Identify whether the feature belongs in document, command, tool, workspace,
+   UI, render, or platform code.
+3. Add durable document changes through commands.
+4. Keep UI code thin and action-oriented.
+5. Add tests for behavior and state transitions.
+6. Update controls, build, release, or user documentation when behavior changes.
+
+
+CI or Build Fix
+---------------
+
+Use this for workflow, compiler, test, or packaging failures.
+
+1. Inspect the failing check, logs, and workflow.
+2. Reproduce locally when practical with the matching preset or script.
+3. Fix the project cause rather than masking the check.
+4. Keep workflow changes aligned with CMakePresets.json and scripts/check.*.
+5. Run `cmake --list-presets`, `ctest --list-presets`, and any targeted check
+   touched by the change.
+
+
+Code Review
+-----------
+
+Use this for review assistance.
+
+1. Read the PR diff and relevant source context.
+2. Prioritize correctness, regressions, ownership boundaries, and missing tests.
+3. Cite file paths and lines for findings.
+4. Avoid style-only feedback unless it violates shared project rules.
+5. Distinguish confirmed issues from questions or risks.
+
+
+Refactor
+--------
+
+Use this for behavior-preserving internal changes.
+
+1. Define the behavior that must remain unchanged.
+2. Identify the owning boundary and avoid cross-module reshaping unless required.
+3. Prefer small mechanical steps with tests passing between them.
+4. Avoid mixing refactor and feature behavior in the same change.
+5. Run tests that cover all touched modules.
+
+
+Release or Packaging
+--------------------
+
+Use this for release scripts, package layouts, or workflow publishing.
+
+1. Read doc/build.md and doc/release.md.
+2. Preserve the documented package asset names and installed layout unless the
+   task explicitly changes them.
+3. Run release smoke checks locally or through GitHub Actions when practical.
+4. Update CHANGELOG.md and release notes guidance for user-visible changes.
+5. Do not publish tags or releases unless explicitly instructed by a maintainer.

--- a/doc/ai-agents.md
+++ b/doc/ai-agents.md
@@ -1,0 +1,105 @@
+AI Agent Policy
+===============
+
+AI agents may help with GLDraw development, but their output is treated like any
+other contribution: it must follow the architecture boundaries, pass the relevant
+checks, and receive human review.
+
+
+Required Reading
+----------------
+
+Before changing files, an AI agent should read:
+
+* AGENTS.md
+* CONTRIBUTING.md
+* doc/testing.md
+* This document
+
+For architecture-sensitive work, also read:
+
+* doc/adr/README.md
+* The ADRs that match the touched area
+* The source entry points listed in AGENTS.md
+
+For release, packaging, CI, or dependency work, also read:
+
+* doc/build.md
+* doc/release.md
+* SECURITY.md when dependency or vulnerability handling is involved
+
+
+Appropriate Uses
+----------------
+
+AI agents are appropriate for:
+
+* Focused bug fixes with clear reproduction steps.
+* Small to medium implementation tasks with explicit acceptance criteria.
+* Test additions and regression coverage.
+* Documentation updates.
+* Build, CI, packaging, and repository maintenance.
+* Mechanical refactors that preserve behavior and are easy to review.
+* First-pass code review or risk analysis.
+
+
+Restricted Uses
+---------------
+
+AI agents should not independently:
+
+* Redesign core architecture without an ADR or maintainer direction.
+* Change document file format compatibility without explicit review.
+* Bypass `CommandExecutor` for durable document mutations.
+* Move editing rules into UI widgets.
+* Add direct `workspace_internal.h` dependencies outside approved workspace
+  implementation or lifecycle tests.
+* Weaken tests, CI, static analysis, security checks, or release validation to
+  make a change pass.
+* Introduce generated code, large vendored dependencies, or license-sensitive
+  assets without maintainer approval.
+* Publish releases, rotate credentials, or change repository permissions.
+
+
+Human Review Requirements
+-------------------------
+
+Human review is required for all AI-assisted pull requests. Reviewers should
+check:
+
+* Whether the agent read and followed the required context.
+* Whether the change is scoped to the task.
+* Whether architecture boundaries are preserved.
+* Whether tests cover the actual behavior.
+* Whether generated text, code, or assets are license-safe and appropriate for
+  the repository.
+* Whether any manual UI, rendering, or packaging verification is still needed.
+
+
+Disclosure
+----------
+
+Pull requests should disclose meaningful AI assistance in the PR template. The
+disclosure should name the agent or tool, describe what it did, list the required
+docs read, and summarize human verification.
+
+Small editor completions or syntax suggestions do not need detailed disclosure
+unless they materially shaped the design or implementation.
+
+
+Traceability
+------------
+
+Agent-suitable issues should use the AI agent task template. The issue should
+define:
+
+* Background.
+* Goal.
+* Non-goals.
+* Required context.
+* Expected files or modules.
+* Acceptance criteria.
+* Required checks.
+
+This keeps agent work reviewable and reduces the chance of broad, unstated
+changes.


### PR DESCRIPTION
## Summary
- Adds AI agent policy and task playbooks for scoped, reviewable agent work.
- Adds an ADR for AI-assisted contribution boundaries.
- Adds an AI agent task issue form and PR disclosure fields.
- Updates AGENTS.md, CONTRIBUTING.md, README files, CODEOWNERS, docs index, and changelog to point to the new AI agent workflow.

## Validation
- git diff --cached --check
- git diff --check
- cmake --list-presets
- ctest --list-presets

Full build and CTest were not run locally because this change is documentation and GitHub template focused.