### PR TITLE
refactor(core): optimize project maintenance hotspots

### DIFF
--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -1,305 +1,154 @@
-add_executable(gldraw_document_core_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/document/test_document_core.c
-)
-
-target_include_directories(gldraw_document_core_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_document_core_tests PRIVATE editor_runtime)
-
-gldraw_apply_compile_options(gldraw_document_core_tests)
-gldraw_apply_sanitizers(gldraw_document_core_tests)
-
-set_target_properties(gldraw_document_core_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_document_core_tests COMMAND $<TARGET_FILE:gldraw_document_core_tests>)
-
-add_executable(gldraw_png_writer_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/image/test_png_writer.c
-)
-
-target_include_directories(gldraw_png_writer_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_png_writer_tests PRIVATE render_core)
-
-gldraw_apply_compile_options(gldraw_png_writer_tests)
-gldraw_apply_sanitizers(gldraw_png_writer_tests)
-
-set_target_properties(gldraw_png_writer_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_png_writer_tests COMMAND $<TARGET_FILE:gldraw_png_writer_tests>)
-
-add_executable(gldraw_selection_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/document/test_selection.c
-)
-
-target_include_directories(gldraw_selection_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_selection_tests PRIVATE editor_model)
-
-gldraw_apply_compile_options(gldraw_selection_tests)
-gldraw_apply_sanitizers(gldraw_selection_tests)
-
-set_target_properties(gldraw_selection_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_selection_tests COMMAND $<TARGET_FILE:gldraw_selection_tests>)
-
-add_executable(gldraw_resource_path_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/base/test_resource_path.c
-)
-
-target_include_directories(gldraw_resource_path_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_resource_path_tests PRIVATE editor_model)
-
-gldraw_apply_compile_options(gldraw_resource_path_tests)
-gldraw_apply_sanitizers(gldraw_resource_path_tests)
-
-set_target_properties(gldraw_resource_path_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_resource_path_tests COMMAND $<TARGET_FILE:gldraw_resource_path_tests>)
-
-add_executable(gldraw_document_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/document/test_document.c
-)
-
-target_include_directories(gldraw_document_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_document_tests PRIVATE editor_model)
-
-gldraw_apply_compile_options(gldraw_document_tests)
-gldraw_apply_sanitizers(gldraw_document_tests)
-
-set_target_properties(gldraw_document_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_document_tests COMMAND $<TARGET_FILE:gldraw_document_tests>)
-
-add_executable(gldraw_command_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/commands/test_commands.c
-)
-
-target_include_directories(gldraw_command_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_command_tests PRIVATE editor_runtime)
-
-gldraw_apply_compile_options(gldraw_command_tests)
-gldraw_apply_sanitizers(gldraw_command_tests)
-
-set_target_properties(gldraw_command_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_command_tests COMMAND $<TARGET_FILE:gldraw_command_tests>)
-
-add_executable(gldraw_registry_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/app/test_registry.c
-)
-
-target_include_directories(gldraw_registry_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_registry_tests PRIVATE ui_nuklear_glfw)
-
-gldraw_apply_compile_options(gldraw_registry_tests)
-gldraw_apply_sanitizers(gldraw_registry_tests)
-
-set_target_properties(gldraw_registry_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_registry_tests COMMAND $<TARGET_FILE:gldraw_registry_tests>)
-
-if(GLDRAW_ENABLE_SCRIPTING)
-    add_executable(gldraw_script_runtime_tests
-        ${CMAKE_CURRENT_SOURCE_DIR}/tests/script/test_script_runtime.c
+function(gldraw_add_test target)
+    cmake_parse_arguments(GLDRAW_TEST
+        ""
+        ""
+        "SOURCES;LIBS"
+        ${ARGN}
     )
 
-    target_include_directories(gldraw_script_runtime_tests
+    if(NOT GLDRAW_TEST_SOURCES)
+        message(FATAL_ERROR "gldraw_add_test(${target}) requires SOURCES")
+    endif()
+
+    add_executable(${target}
+        ${GLDRAW_TEST_SOURCES}
+    )
+
+    target_include_directories(${target}
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
 
-    target_link_libraries(gldraw_script_runtime_tests PRIVATE editor_tools)
+    if(GLDRAW_TEST_LIBS)
+        target_link_libraries(${target} PRIVATE ${GLDRAW_TEST_LIBS})
+    endif()
 
-    gldraw_apply_compile_options(gldraw_script_runtime_tests)
-    gldraw_apply_sanitizers(gldraw_script_runtime_tests)
+    gldraw_apply_compile_options(${target})
+    gldraw_apply_sanitizers(${target})
 
-    set_target_properties(gldraw_script_runtime_tests PROPERTIES
+    set_target_properties(${target} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
     )
 
-    add_test(NAME gldraw_script_runtime_tests COMMAND $<TARGET_FILE:gldraw_script_runtime_tests>)
+    add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}>)
+    list(APPEND GLDRAW_TEST_TARGETS ${target})
+    set(GLDRAW_TEST_TARGETS "${GLDRAW_TEST_TARGETS}" PARENT_SCOPE)
+endfunction()
+
+gldraw_add_test(gldraw_document_core_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/document/test_document_core.c
+    LIBS
+        editor_runtime
+)
+
+gldraw_add_test(gldraw_png_writer_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/image/test_png_writer.c
+    LIBS
+        render_core
+)
+
+gldraw_add_test(gldraw_selection_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/document/test_selection.c
+    LIBS
+        editor_model
+)
+
+gldraw_add_test(gldraw_resource_path_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/base/test_resource_path.c
+    LIBS
+        editor_model
+)
+
+gldraw_add_test(gldraw_document_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/document/test_document.c
+    LIBS
+        editor_model
+)
+
+gldraw_add_test(gldraw_command_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/commands/test_commands.c
+    LIBS
+        editor_runtime
+)
+
+gldraw_add_test(gldraw_registry_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/app/test_registry.c
+    LIBS
+        ui_nuklear_glfw
+)
+
+if(GLDRAW_ENABLE_SCRIPTING)
+    gldraw_add_test(gldraw_script_runtime_tests
+        SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/tests/script/test_script_runtime.c
+        LIBS
+            editor_tools
+    )
 endif()
 
-add_executable(gldraw_fake_star_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/document/test_fake_star.c
+gldraw_add_test(gldraw_fake_star_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/document/test_fake_star.c
+    LIBS
+        render_core
 )
 
-target_include_directories(gldraw_fake_star_tests
+gldraw_add_test(gldraw_no_builtin_knowledge_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/app/test_no_builtin_knowledge.c
+    LIBS
+        editor_model
+)
+
+gldraw_add_test(gldraw_ui_logic_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/ui/test_ui_logic.c
+    LIBS
+        editor_runtime
+)
+
+gldraw_add_test(gldraw_ui_theme_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/ui/test_ui_theme.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/support/test_nuklear_impl.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme_apply.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme_builtin.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme_external.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme_parse.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme_settings.c
+    LIBS
+        editor_model
+)
+
+target_compile_options(gldraw_ui_theme_tests
     PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        $<$<COMPILE_LANG_AND_ID:C,GNU,Clang,AppleClang>:-Wno-unused-function>
+        $<$<COMPILE_LANG_AND_ID:C,MSVC>:/wd4505>
 )
 
-target_link_libraries(gldraw_fake_star_tests PRIVATE render_core)
-
-gldraw_apply_compile_options(gldraw_fake_star_tests)
-gldraw_apply_sanitizers(gldraw_fake_star_tests)
-
-set_target_properties(gldraw_fake_star_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+gldraw_add_test(gldraw_renderer_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/render/test_renderer.c
+    LIBS
+        render_core
 )
 
-add_test(NAME gldraw_fake_star_tests COMMAND $<TARGET_FILE:gldraw_fake_star_tests>)
-
-add_executable(gldraw_no_builtin_knowledge_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/app/test_no_builtin_knowledge.c
+gldraw_add_test(gldraw_workspace_service_tests
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/app/test_workspace_service.c
+    LIBS
+        editor_runtime
 )
-
-target_include_directories(gldraw_no_builtin_knowledge_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_no_builtin_knowledge_tests PRIVATE editor_model)
-
-gldraw_apply_compile_options(gldraw_no_builtin_knowledge_tests)
-gldraw_apply_sanitizers(gldraw_no_builtin_knowledge_tests)
-
-set_target_properties(gldraw_no_builtin_knowledge_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_no_builtin_knowledge_tests COMMAND $<TARGET_FILE:gldraw_no_builtin_knowledge_tests>)
-
-add_executable(gldraw_ui_logic_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/ui/test_ui_logic.c
-)
-
-target_include_directories(gldraw_ui_logic_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_ui_logic_tests PRIVATE editor_runtime)
-
-gldraw_apply_compile_options(gldraw_ui_logic_tests)
-gldraw_apply_sanitizers(gldraw_ui_logic_tests)
-
-set_target_properties(gldraw_ui_logic_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_ui_logic_tests COMMAND $<TARGET_FILE:gldraw_ui_logic_tests>)
-
-add_executable(gldraw_ui_theme_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/ui/test_ui_theme.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/support/test_nuklear_impl.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme_apply.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme_builtin.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme_external.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme_parse.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/ui_theme_settings.c
-)
-
-target_include_directories(gldraw_ui_theme_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_ui_theme_tests PRIVATE editor_model)
-
-gldraw_apply_compile_options(gldraw_ui_theme_tests)
-gldraw_apply_sanitizers(gldraw_ui_theme_tests)
-
-set_target_properties(gldraw_ui_theme_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_ui_theme_tests COMMAND $<TARGET_FILE:gldraw_ui_theme_tests>)
-
-add_executable(gldraw_renderer_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/render/test_renderer.c
-)
-
-target_include_directories(gldraw_renderer_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_renderer_tests PRIVATE render_core)
-
-gldraw_apply_compile_options(gldraw_renderer_tests)
-gldraw_apply_sanitizers(gldraw_renderer_tests)
-
-set_target_properties(gldraw_renderer_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_renderer_tests COMMAND $<TARGET_FILE:gldraw_renderer_tests>)
-
-add_executable(gldraw_workspace_service_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/app/test_workspace_service.c
-)
-
-target_include_directories(gldraw_workspace_service_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-
-target_link_libraries(gldraw_workspace_service_tests PRIVATE editor_runtime)
-
-gldraw_apply_compile_options(gldraw_workspace_service_tests)
-gldraw_apply_sanitizers(gldraw_workspace_service_tests)
-
-set_target_properties(gldraw_workspace_service_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-
-add_test(NAME gldraw_workspace_service_tests COMMAND $<TARGET_FILE:gldraw_workspace_service_tests>)
 
 add_custom_target(gldraw_tests
     DEPENDS
-        gldraw_document_core_tests
-        gldraw_png_writer_tests
-        gldraw_selection_tests
-        gldraw_resource_path_tests
-        gldraw_document_tests
-        gldraw_command_tests
-        gldraw_registry_tests
-        gldraw_fake_star_tests
-        gldraw_no_builtin_knowledge_tests
-        gldraw_ui_logic_tests
-        gldraw_ui_theme_tests
-        gldraw_renderer_tests
-        gldraw_workspace_service_tests
+        ${GLDRAW_TEST_TARGETS}
 )

--- a/src/app/editor_viewmodel.c
+++ b/src/app/editor_viewmodel.c
@@ -356,13 +356,32 @@ static int editor_viewmodel_reserve_layers(EditorViewModel* view_model, int need
     return 1;
 }
 
+static int editor_viewmodel_layer_index_for_id(const EditorViewModel* view_model,
+                                               LayerId layer_id)
+{
+    int i = 0;
+
+    if (!view_model) {
+        return -1;
+    }
+
+    for (i = 0; i < view_model->layer_count; ++i) {
+        if (view_model->layers[i].id == layer_id) {
+            return i;
+        }
+    }
+    return -1;
+}
+
 static void editor_viewmodel_build_layers(EditorViewModel* view_model,
                                           const EditorViewModelBuildContext* context)
 {
     int i = 0;
-    int j = 0;
     int doc_layer_count = 0;
     int object_count = 0;
+    LayerId max_layer_id = 0u;
+    int* layer_index_by_id = NULL;
+    size_t layer_lookup_count = 0u;
 
     if (!view_model || !context || !context->document) {
         return;
@@ -391,15 +410,47 @@ static void editor_viewmodel_build_layers(EditorViewModel* view_model,
         layer_view->active =
             (document_active_layer_id(context->document) == layer->id);
         layer_view->object_count = 0;
+        if (layer->id > max_layer_id) {
+            max_layer_id = layer->id;
+        }
+    }
 
-        for (j = 0; j < object_count; ++j) {
-            const GraphicObject* object =
-                document_get_object_at_const(context->document, j);
-            if (object && object->layer_id == layer->id) {
-                layer_view->object_count++;
+    if (max_layer_id > 0u &&
+        max_layer_id <= (LayerId)(doc_layer_count * 8 + 64)) {
+        layer_lookup_count = (size_t)max_layer_id + 1u;
+        layer_index_by_id = (int*)malloc(layer_lookup_count * sizeof(layer_index_by_id[0]));
+        if (layer_index_by_id) {
+            for (i = 0; i < (int)layer_lookup_count; ++i) {
+                layer_index_by_id[i] = -1;
+            }
+            for (i = 0; i < view_model->layer_count; ++i) {
+                layer_index_by_id[view_model->layers[i].id] = i;
             }
         }
     }
+
+    for (i = 0; i < object_count; ++i) {
+        const GraphicObject* object =
+            document_get_object_at_const(context->document, i);
+        int layer_view_index = -1;
+
+        if (!object) {
+            continue;
+        }
+
+        if (layer_index_by_id && object->layer_id <= max_layer_id) {
+            layer_view_index = layer_index_by_id[object->layer_id];
+        } else {
+            layer_view_index =
+                editor_viewmodel_layer_index_for_id(view_model, object->layer_id);
+        }
+
+        if (layer_view_index >= 0) {
+            view_model->layers[layer_view_index].object_count++;
+        }
+    }
+
+    free(layer_index_by_id);
 }
 
 static void editor_viewmodel_build_summary(

--- a/src/commands/command_executor.c
+++ b/src/commands/command_executor.c
@@ -112,20 +112,33 @@ static void command_executor_clear_tail(CommandExecutor* executor)
 
 static void command_executor_prune_budget(CommandExecutor* executor)
 {
-    size_t i = 0u;
+    size_t prune_count = 0u;
+    size_t remaining_count = 0u;
 
     if (!executor || executor->memory_budget_bytes == 0u) {
         return;
     }
 
-    while (executor->used_bytes > executor->memory_budget_bytes && executor->cursor > 1u) {
-        executor->used_bytes -= executor->entries[0].bytes;
-        command_executor_discard_entry(&executor->entries[0]);
-        for (i = 1u; i < executor->entry_count; ++i) {
-            executor->entries[i - 1u] = executor->entries[i];
-        }
-        executor->entry_count--;
-        executor->cursor--;
+    while (executor->used_bytes > executor->memory_budget_bytes &&
+           prune_count + 1u < executor->cursor) {
+        executor->used_bytes =
+            (executor->used_bytes >= executor->entries[prune_count].bytes)
+                ? executor->used_bytes - executor->entries[prune_count].bytes
+                : 0u;
+        command_executor_discard_entry(&executor->entries[prune_count]);
+        prune_count++;
+    }
+
+    if (prune_count > 0u) {
+        remaining_count = executor->entry_count - prune_count;
+        memmove(executor->entries,
+                executor->entries + prune_count,
+                remaining_count * sizeof(executor->entries[0]));
+        memset(executor->entries + remaining_count,
+               0,
+               prune_count * sizeof(executor->entries[0]));
+        executor->entry_count = remaining_count;
+        executor->cursor -= prune_count;
     }
     command_executor_refresh_counts(executor);
 }

--- a/src/document/document_spatial_index.c
+++ b/src/document/document_spatial_index.c
@@ -197,6 +197,32 @@ static int document_spatial_rebuild(Document* document)
     return 1;
 }
 
+static int document_spatial_ensure_current(const Document* document)
+{
+    return document ? document_spatial_rebuild((Document*)document) : 0;
+}
+
+static unsigned int document_spatial_next_query_token(const Document* document)
+{
+    Document* mutable_document = (Document*)document;
+
+    if (!mutable_document) {
+        return 0u;
+    }
+
+    if (mutable_document->spatial_query_token == 0xffffffffu) {
+        memset(mutable_document->spatial_marks,
+               0,
+               (size_t)mutable_document->spatial_mark_capacity *
+                   sizeof(mutable_document->spatial_marks[0]));
+        mutable_document->spatial_query_token = 1u;
+    } else {
+        mutable_document->spatial_query_token++;
+    }
+
+    return mutable_document->spatial_query_token;
+}
+
 static int rect_intersects(const RectF* a, const RectF* b)
 {
     if (!a || !b) {
@@ -245,7 +271,6 @@ int document_query_visible_indices(const Document* document,
                                    int* out_indices,
                                    int max_indices)
 {
-    Document* mutable_document = (Document*)document;
     int count = 0;
     int cell_min_col = 0;
     int cell_max_col = 0;
@@ -253,23 +278,18 @@ int document_query_visible_indices(const Document* document,
     int cell_max_row = 0;
     int row = 0;
     int col = 0;
+    unsigned int query_token = 0u;
 
     if (!document || !out_indices || max_indices <= 0) {
         return 0;
     }
 
-    if (!document_spatial_rebuild(mutable_document) || document->count <= 0 ||
+    if (!document_spatial_ensure_current(document) || document->count <= 0 ||
         document->spatial_cell_count <= 0) {
         return 0;
     }
 
-    if (document->spatial_query_token == 0xffffffffu) {
-        memset(document->spatial_marks, 0,
-               (size_t)document->spatial_mark_capacity * sizeof(document->spatial_marks[0]));
-        mutable_document->spatial_query_token = 1u;
-    } else {
-        mutable_document->spatial_query_token++;
-    }
+    query_token = document_spatial_next_query_token(document);
 
     cell_min_col = (int)floorf((visible_rect.x - document->spatial_bounds.x) /
                                document->spatial_cell_size);
@@ -302,14 +322,14 @@ int document_query_visible_indices(const Document* document,
                     object ? document_layer_find_const(document, object->layer_id) : NULL;
 
                 if (object &&
-                    document->spatial_marks[object_index] != document->spatial_query_token &&
+                    document->spatial_marks[object_index] != query_token &&
                     layer && layer->visible) {
                     RectF object_bounds = object_get_bounds(object);
                     if (!rect_intersects(&visible_rect, &object_bounds)) {
                         entry_index = document->spatial_entries[entry_index].next;
                         continue;
                     }
-                    document->spatial_marks[object_index] = document->spatial_query_token;
+                    document->spatial_marks[object_index] = query_token;
                     if (count < max_indices) {
                         out_indices[count++] = object_index;
                     }

--- a/src/document/object_ellipse.c
+++ b/src/document/object_ellipse.c
@@ -31,28 +31,18 @@ static GraphicObject* ellipse_create(const void* init_data, GraphicStyle style)
     const GraphicObjectDescriptor* descriptor = object_registry_lookup("ellipse");
     const RectF* bounds = (const RectF*)init_data;
     EllipseData* data = NULL;
-    GraphicObject* object = NULL;
 
     if (!descriptor || !bounds) {
         return NULL;
     }
 
     data = (EllipseData*)calloc(1u, sizeof(*data));
-    object = (GraphicObject*)calloc(1u, sizeof(*object));
-    if (!data || !object) {
-        free(data);
-        free(object);
+    if (!data) {
         return NULL;
     }
 
     data->bounds = *bounds;
-    object->type = descriptor->type;
-    object->layer_id = 1u;
-    object->descriptor = descriptor;
-    object->impl = data;
-    object->style = style;
-    object->revision = 1u;
-    return object;
+    return object_alloc(descriptor->type, descriptor, data, style);
 }
 
 static GraphicObject* ellipse_clone(const GraphicObject* object)
@@ -62,11 +52,7 @@ static GraphicObject* ellipse_clone(const GraphicObject* object)
 
 static void ellipse_destroy(GraphicObject* object)
 {
-    if (!object) {
-        return;
-    }
-    free(object->impl);
-    free(object);
+    default_destroy_object(object);
 }
 
 /* ------------------------------------------------------------------ */
@@ -185,7 +171,6 @@ static GraphicObject* ellipse_deserialize(const GraphicPropertyBag* properties,
 {
     RectF bounds = {0.0f, 0.0f, 0.0f, 0.0f};
     GraphicObject* object = NULL;
-    float value = 0.0f;
 
     if (!properties ||
         !graphic_property_bag_get(properties, "x", &bounds.x) ||
@@ -201,13 +186,7 @@ static GraphicObject* ellipse_deserialize(const GraphicPropertyBag* properties,
         return NULL;
     }
 
-    if (graphic_property_bag_get(properties, "stroke_r", &value)) { object->style.stroke_color.r = value; }
-    if (graphic_property_bag_get(properties, "stroke_g", &value)) { object->style.stroke_color.g = value; }
-    if (graphic_property_bag_get(properties, "stroke_b", &value)) { object->style.stroke_color.b = value; }
-    if (graphic_property_bag_get(properties, "stroke_a", &value)) { object->style.stroke_color.a = value; }
-    if (graphic_property_bag_get(properties, "stroke_width", &value) && value > 0.0f) {
-        object->style.stroke_width = value;
-    }
+    default_apply_style_properties(properties, object);
     return object;
 }
 

--- a/src/document/object_fake_star.c
+++ b/src/document/object_fake_star.c
@@ -2,6 +2,8 @@
 
 #include <base/math2d.h>
 
+#include "object_internal.h"
+
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -10,88 +12,33 @@ typedef struct {
     RectF bounds;
 } FakeStarData;
 
-static int fake_star_style_get_scalar(const GraphicObject* object,
-                                      const char* key,
-                                      float* out_value)
-{
-    if (!object || !key || !out_value) {
-        return 0;
-    }
-
-    if (strcmp(key, "stroke_r") == 0) { *out_value = object->style.stroke_color.r; return 1; }
-    if (strcmp(key, "stroke_g") == 0) { *out_value = object->style.stroke_color.g; return 1; }
-    if (strcmp(key, "stroke_b") == 0) { *out_value = object->style.stroke_color.b; return 1; }
-    if (strcmp(key, "stroke_a") == 0) { *out_value = object->style.stroke_color.a; return 1; }
-    if (strcmp(key, "stroke_width") == 0) { *out_value = object->style.stroke_width; return 1; }
-    return 0;
-}
-
-static int fake_star_style_set_scalar(GraphicObject* object,
-                                      const char* key,
-                                      float value)
-{
-    if (!object || !key) {
-        return 0;
-    }
-
-    if (strcmp(key, "stroke_r") == 0) { object->style.stroke_color.r = value; return 1; }
-    if (strcmp(key, "stroke_g") == 0) { object->style.stroke_color.g = value; return 1; }
-    if (strcmp(key, "stroke_b") == 0) { object->style.stroke_color.b = value; return 1; }
-    if (strcmp(key, "stroke_a") == 0) { object->style.stroke_color.a = value; return 1; }
-    if (strcmp(key, "stroke_width") == 0) { object->style.stroke_width = value; return 1; }
-    return 0;
-}
-
 static GraphicObject* fake_star_create(const void* init_data, GraphicStyle style)
 {
     const GraphicObjectDescriptor* descriptor = object_registry_lookup("fake_star");
     const RectF* bounds = (const RectF*)init_data;
     FakeStarData* data = NULL;
-    GraphicObject* object = NULL;
 
     if (!descriptor || !bounds || bounds->w <= 0.0f || bounds->h <= 0.0f) {
         return NULL;
     }
 
     data = (FakeStarData*)calloc(1u, sizeof(*data));
-    object = (GraphicObject*)calloc(1u, sizeof(*object));
-    if (!data || !object) {
-        free(data);
-        free(object);
+    if (!data) {
         return NULL;
     }
 
     data->bounds = *bounds;
-    object->type = descriptor->type;
-    object->layer_id = 1u;
-    object->descriptor = descriptor;
-    object->impl = data;
-    object->style = style;
-    object->revision = 1u;
-    return object;
+    return object_alloc(descriptor->type, descriptor, data, style);
 }
 
 static GraphicObject* fake_star_clone(const GraphicObject* object)
 {
-    const FakeStarData* data = object ? (const FakeStarData*)object->impl : NULL;
-    GraphicObject* clone = data ? fake_star_create(&data->bounds, object->style) : NULL;
-
-    if (clone && object) {
-        clone->id = object->id;
-        clone->layer_id = object->layer_id;
-        clone->revision = object->revision;
-    }
-    return clone;
+    return default_clone_object(object);
 }
 
 static void fake_star_destroy(GraphicObject* object)
 {
-    if (!object) {
-        return;
-    }
-
-    free(object->impl);
-    free(object);
+    default_destroy_object(object);
 }
 
 static void fake_star_translate(GraphicObject* object, Vec2 delta)
@@ -160,7 +107,7 @@ static int fake_star_get_scalar(const GraphicObject* object,
     if (strcmp(key, "y") == 0) { *out_value = data->bounds.y; return 1; }
     if (strcmp(key, "width") == 0) { *out_value = data->bounds.w; return 1; }
     if (strcmp(key, "height") == 0) { *out_value = data->bounds.h; return 1; }
-    return fake_star_style_get_scalar(object, key, out_value);
+    return style_get_scalar(object, key, out_value);
 }
 
 static int fake_star_set_scalar(GraphicObject* object, const char* key, float value)
@@ -175,30 +122,12 @@ static int fake_star_set_scalar(GraphicObject* object, const char* key, float va
     if (strcmp(key, "y") == 0) { data->bounds.y = value; return 1; }
     if (strcmp(key, "width") == 0 && value > 0.0f) { data->bounds.w = value; return 1; }
     if (strcmp(key, "height") == 0 && value > 0.0f) { data->bounds.h = value; return 1; }
-    return fake_star_style_set_scalar(object, key, value);
+    return style_set_scalar(object, key, value);
 }
 
 static int fake_star_serialize(const GraphicObject* object, GraphicPropertyBag* out_properties)
 {
-    float value = 0.0f;
-    static const char* keys[] = {
-        "x", "y", "width", "height",
-        "stroke_r", "stroke_g", "stroke_b", "stroke_a", "stroke_width"
-    };
-    int i = 0;
-
-    if (!object || !out_properties) {
-        return 0;
-    }
-
-    graphic_property_bag_init(out_properties);
-    for (i = 0; i < (int)(sizeof(keys) / sizeof(keys[0])); ++i) {
-        if (object_get_scalar(object, keys[i], &value) &&
-            !graphic_property_bag_set(out_properties, keys[i], value)) {
-            return 0;
-        }
-    }
-    return 1;
+    return default_serialize_from_schema(object, out_properties);
 }
 
 static GraphicObject* fake_star_deserialize(const GraphicPropertyBag* properties,
@@ -206,7 +135,6 @@ static GraphicObject* fake_star_deserialize(const GraphicPropertyBag* properties
 {
     RectF bounds = {0.0f, 0.0f, 0.0f, 0.0f};
     GraphicObject* object = NULL;
-    float value = 0.0f;
 
     if (!properties ||
         !graphic_property_bag_get(properties, "x", &bounds.x) ||
@@ -222,13 +150,7 @@ static GraphicObject* fake_star_deserialize(const GraphicPropertyBag* properties
         return NULL;
     }
 
-    if (graphic_property_bag_get(properties, "stroke_r", &value)) { object->style.stroke_color.r = value; }
-    if (graphic_property_bag_get(properties, "stroke_g", &value)) { object->style.stroke_color.g = value; }
-    if (graphic_property_bag_get(properties, "stroke_b", &value)) { object->style.stroke_color.b = value; }
-    if (graphic_property_bag_get(properties, "stroke_a", &value)) { object->style.stroke_color.a = value; }
-    if (graphic_property_bag_get(properties, "stroke_width", &value) && value > 0.0f) {
-        object->style.stroke_width = value;
-    }
+    default_apply_style_properties(properties, object);
     return object;
 }
 

--- a/src/document/object_internal.h
+++ b/src/document/object_internal.h
@@ -45,6 +45,15 @@ int default_serialize_from_schema(const GraphicObject* object,
                                   GraphicPropertyBag* out_properties);
 
 /**
+ * @brief Apply serialized style properties to an existing object.
+ *
+ * Reads optional "stroke_r", "stroke_g", "stroke_b", "stroke_a", and
+ * positive "stroke_width" values from @p properties.
+ */
+void default_apply_style_properties(const GraphicPropertyBag* properties,
+                                    GraphicObject* object);
+
+/**
  * @brief Allocate and initialize a GraphicObject with the given fields.
  *
  * Takes ownership of @p impl on success; caller must NOT free it.
@@ -54,5 +63,10 @@ GraphicObject* object_alloc(GraphicObjectType type,
                             const GraphicObjectDescriptor* descriptor,
                             void* impl,
                             GraphicStyle style);
+
+/**
+ * @brief Destroy a GraphicObject allocated with object_alloc().
+ */
+void default_destroy_object(GraphicObject* object);
 
 #endif /* GLDRAW_DOCUMENT_OBJECT_INTERNAL_H */

--- a/src/document/object_line.c
+++ b/src/document/object_line.c
@@ -50,29 +50,19 @@ static GraphicObject* line_create(const void* init_data, GraphicStyle style)
     const GraphicObjectDescriptor* descriptor = object_registry_lookup("line");
     const Vec2* points = (const Vec2*)init_data;
     LineData* data = NULL;
-    GraphicObject* object = NULL;
 
     if (!descriptor || !points) {
         return NULL;
     }
 
     data = (LineData*)calloc(1u, sizeof(*data));
-    object = (GraphicObject*)calloc(1u, sizeof(*object));
-    if (!data || !object) {
-        free(data);
-        free(object);
+    if (!data) {
         return NULL;
     }
 
     data->p1 = points[0];
     data->p2 = points[1];
-    object->type = descriptor->type;
-    object->layer_id = 1u;
-    object->descriptor = descriptor;
-    object->impl = data;
-    object->style = style;
-    object->revision = 1u;
-    return object;
+    return object_alloc(descriptor->type, descriptor, data, style);
 }
 
 static GraphicObject* line_clone(const GraphicObject* object)
@@ -82,11 +72,7 @@ static GraphicObject* line_clone(const GraphicObject* object)
 
 static void line_destroy(GraphicObject* object)
 {
-    if (!object) {
-        return;
-    }
-    free(object->impl);
-    free(object);
+    default_destroy_object(object);
 }
 
 /* ------------------------------------------------------------------ */
@@ -194,7 +180,6 @@ static GraphicObject* line_deserialize(const GraphicPropertyBag* properties,
 {
     Vec2 points[2] = {{0.0f, 0.0f}, {0.0f, 0.0f}};
     GraphicObject* object = NULL;
-    float value = 0.0f;
 
     if (!properties ||
         !graphic_property_bag_get(properties, "x1", &points[0].x) ||
@@ -209,13 +194,7 @@ static GraphicObject* line_deserialize(const GraphicPropertyBag* properties,
         return NULL;
     }
 
-    if (graphic_property_bag_get(properties, "stroke_r", &value)) { object->style.stroke_color.r = value; }
-    if (graphic_property_bag_get(properties, "stroke_g", &value)) { object->style.stroke_color.g = value; }
-    if (graphic_property_bag_get(properties, "stroke_b", &value)) { object->style.stroke_color.b = value; }
-    if (graphic_property_bag_get(properties, "stroke_a", &value)) { object->style.stroke_color.a = value; }
-    if (graphic_property_bag_get(properties, "stroke_width", &value) && value > 0.0f) {
-        object->style.stroke_width = value;
-    }
+    default_apply_style_properties(properties, object);
     return object;
 }
 

--- a/src/document/object_properties.c
+++ b/src/document/object_properties.c
@@ -121,6 +121,33 @@ int default_serialize_from_schema(const GraphicObject* object, GraphicPropertyBa
     return 1;
 }
 
+void default_apply_style_properties(const GraphicPropertyBag* properties,
+                                    GraphicObject* object)
+{
+    float value = 0.0f;
+
+    if (!properties || !object) {
+        return;
+    }
+
+    if (graphic_property_bag_get(properties, "stroke_r", &value)) {
+        object->style.stroke_color.r = value;
+    }
+    if (graphic_property_bag_get(properties, "stroke_g", &value)) {
+        object->style.stroke_color.g = value;
+    }
+    if (graphic_property_bag_get(properties, "stroke_b", &value)) {
+        object->style.stroke_color.b = value;
+    }
+    if (graphic_property_bag_get(properties, "stroke_a", &value)) {
+        object->style.stroke_color.a = value;
+    }
+    if (graphic_property_bag_get(properties, "stroke_width", &value) &&
+        value > 0.0f) {
+        object->style.stroke_width = value;
+    }
+}
+
 GraphicObject* default_clone_object(const GraphicObject* object)
 {
     GraphicPropertyBag properties;

--- a/src/document/object_rect.c
+++ b/src/document/object_rect.c
@@ -28,28 +28,18 @@ static GraphicObject* rect_create(const void* init_data, GraphicStyle style)
     const GraphicObjectDescriptor* descriptor = object_registry_lookup("rect");
     const RectF* bounds = (const RectF*)init_data;
     RectData* data = NULL;
-    GraphicObject* object = NULL;
 
     if (!descriptor || !bounds) {
         return NULL;
     }
 
     data = (RectData*)calloc(1u, sizeof(*data));
-    object = (GraphicObject*)calloc(1u, sizeof(*object));
-    if (!data || !object) {
-        free(data);
-        free(object);
+    if (!data) {
         return NULL;
     }
 
     data->rect = *bounds;
-    object->type = descriptor->type;
-    object->layer_id = 1u;
-    object->descriptor = descriptor;
-    object->impl = data;
-    object->style = style;
-    object->revision = 1u;
-    return object;
+    return object_alloc(descriptor->type, descriptor, data, style);
 }
 
 static GraphicObject* rect_clone(const GraphicObject* object)
@@ -59,11 +49,7 @@ static GraphicObject* rect_clone(const GraphicObject* object)
 
 static void rect_destroy(GraphicObject* object)
 {
-    if (!object) {
-        return;
-    }
-    free(object->impl);
-    free(object);
+    default_destroy_object(object);
 }
 
 /* ------------------------------------------------------------------ */
@@ -162,7 +148,6 @@ static GraphicObject* rect_deserialize(const GraphicPropertyBag* properties,
 {
     RectF bounds = {0.0f, 0.0f, 0.0f, 0.0f};
     GraphicObject* object = NULL;
-    float value = 0.0f;
 
     if (!properties ||
         !graphic_property_bag_get(properties, "x", &bounds.x) ||
@@ -178,13 +163,7 @@ static GraphicObject* rect_deserialize(const GraphicPropertyBag* properties,
         return NULL;
     }
 
-    if (graphic_property_bag_get(properties, "stroke_r", &value)) { object->style.stroke_color.r = value; }
-    if (graphic_property_bag_get(properties, "stroke_g", &value)) { object->style.stroke_color.g = value; }
-    if (graphic_property_bag_get(properties, "stroke_b", &value)) { object->style.stroke_color.b = value; }
-    if (graphic_property_bag_get(properties, "stroke_a", &value)) { object->style.stroke_color.a = value; }
-    if (graphic_property_bag_get(properties, "stroke_width", &value) && value > 0.0f) {
-        object->style.stroke_width = value;
-    }
+    default_apply_style_properties(properties, object);
     return object;
 }
 

--- a/src/document/object_runtime.c
+++ b/src/document/object_runtime.c
@@ -34,6 +34,16 @@ GraphicObject* object_alloc(GraphicObjectType type,
     return object;
 }
 
+void default_destroy_object(GraphicObject* object)
+{
+    if (!object) {
+        return;
+    }
+
+    free(object->impl);
+    free(object);
+}
+
 GraphicStyle object_default_style(void)
 {
     GraphicStyle style;

--- a/src/ui/ui_inspector_panel.c
+++ b/src/ui/ui_inspector_panel.c
@@ -7,12 +7,22 @@
 #include <math.h>
 #include <stdio.h>
 
+static const char *UI_INSPECTOR_EMPTY_HINTS[] = {
+    "No selection",
+    "Shortcuts: V H L R E",
+    "Document: Ctrl+S save, Ctrl+O load",
+    "Wheel zooms at cursor",
+    "Delete removes selection"
+};
+
 static void ui_inspector_empty_hint(struct nk_context *ctx) {
-  nk_label(ctx, "No selection", NK_TEXT_LEFT);
-  nk_label(ctx, "Shortcuts: V H L R E", NK_TEXT_LEFT);
-  nk_label(ctx, "Document: Ctrl+S save, Ctrl+O load", NK_TEXT_LEFT);
-  nk_label(ctx, "Wheel zooms at cursor", NK_TEXT_LEFT);
-  nk_label(ctx, "Delete removes selection", NK_TEXT_LEFT);
+  int i = 0;
+
+  for (i = 0; i < (int)(sizeof(UI_INSPECTOR_EMPTY_HINTS) /
+                        sizeof(UI_INSPECTOR_EMPTY_HINTS[0]));
+       ++i) {
+    nk_label(ctx, UI_INSPECTOR_EMPTY_HINTS[i], NK_TEXT_LEFT);
+  }
 }
 
 static void ui_inspector_overview(struct nk_context *ctx,

--- a/tests/commands/test_commands.c
+++ b/tests/commands/test_commands.c
@@ -354,6 +354,42 @@ static int test_memory_budget_prunes_old_undo_entries(void)
     return 0;
 }
 
+static int test_memory_budget_set_prunes_history_in_bulk(void)
+{
+    Document document;
+    CommandExecutor executor;
+    int i = 0;
+
+    document_init(&document);
+    EXPECT_TRUE(command_executor_init_with_budget(&executor, 1024u * 1024u));
+
+    for (i = 0; i < 5; ++i) {
+        EXPECT_TRUE(command_executor_execute(
+            &executor,
+            command_create_create_object(make_rect((float)i * 20.0f,
+                                                   0.0f,
+                                                   10.0f,
+                                                   10.0f)),
+            &document));
+    }
+    EXPECT_INT_EQ(document.count, 5);
+    EXPECT_INT_EQ((int)executor.undo_count, 5);
+
+    command_executor_set_memory_budget(&executor, 1u);
+    EXPECT_INT_EQ((int)executor.entry_count, 1);
+    EXPECT_INT_EQ((int)executor.undo_count, 1);
+    EXPECT_FALSE(command_executor_can_redo(&executor));
+
+    EXPECT_TRUE(command_executor_undo(&executor, &document));
+    EXPECT_INT_EQ(document.count, 4);
+    EXPECT_FALSE(command_executor_can_undo(&executor));
+    EXPECT_TRUE(command_executor_can_redo(&executor));
+
+    command_executor_shutdown(&executor);
+    document_shutdown(&document);
+    return 0;
+}
+
 static int test_layer_commands_undo_redo(void)
 {
     Document document;
@@ -768,6 +804,7 @@ int main(void)
     if (test_transaction_commit_and_undo()) return 1;
     if (test_transaction_rollback_restores_document()) return 1;
     if (test_memory_budget_prunes_old_undo_entries()) return 1;
+    if (test_memory_budget_set_prunes_history_in_bulk()) return 1;
     if (test_layer_commands_undo_redo()) return 1;
     if (test_command_execute_respects_locked_targets()) return 1;
     if (test_command_can_execute_reports_capability()) return 1;

--- a/tests/document/test_document_core.c
+++ b/tests/document/test_document_core.c
@@ -607,6 +607,7 @@ static int test_layer_visibility_and_spatial_query(void)
                                            indices,
                                            document.count);
     EXPECT_INT_EQ(count, 1);
+    EXPECT_UINT_EQ(document.spatial_revision, document.revision);
     EXPECT_UINT_EQ(document.objects[indices[0]]->id, visible->id);
 
     free(indices);

--- a/tests/ui/test_ui_logic.c
+++ b/tests/ui/test_ui_logic.c
@@ -174,6 +174,7 @@ static int test_editor_viewmodel_builds_selection_properties(void)
     Workspace workspace;
     EditorViewModel view_model = {0};
     LayerId overlay_layer = 0u;
+    LayerId detail_layer = 0u;
     EditorToolView* first_tools = NULL;
     EditorLayerView* first_layers = NULL;
     int first_tool_capacity = 0;
@@ -185,19 +186,29 @@ static int test_editor_viewmodel_builds_selection_properties(void)
     EXPECT_TRUE(document_set_active_layer(&workspace.core.document, overlay_layer));
     EXPECT_TRUE(document_add_object(&workspace.core.document,
                                     make_rect(10.0f, 20.0f, 40.0f, 50.0f)));
+    detail_layer = document_create_layer(&workspace.core.document, "Details");
+    EXPECT_TRUE(detail_layer != 0u);
+    EXPECT_TRUE(document_set_active_layer(&workspace.core.document, detail_layer));
+    EXPECT_TRUE(document_add_object(&workspace.core.document,
+                                    make_rect(60.0f, 20.0f, 20.0f, 20.0f)));
+    EXPECT_TRUE(document_add_object(&workspace.core.document,
+                                    make_rect(90.0f, 20.0f, 20.0f, 20.0f)));
+    EXPECT_TRUE(document_set_active_layer(&workspace.core.document, overlay_layer));
     EXPECT_TRUE(selection_set_add(&workspace.session.selection, 1u));
     EXPECT_TRUE(editor_viewmodel_build(&view_model, &workspace));
 
-    EXPECT_INT_EQ(view_model.summary.object_count, 1);
+    EXPECT_INT_EQ(view_model.summary.object_count, 3);
     EXPECT_INT_EQ(view_model.summary.selection_count, 1);
     EXPECT_TRUE(view_model.has_selection);
     EXPECT_STR_EQ(view_model.summary.selection_type_name, "Rectangle");
     EXPECT_TRUE(view_model.property_count >= 4);
     EXPECT_STR_EQ(view_model.tools[0].id, "select");
     EXPECT_TRUE(view_model.tools[0].active);
-    EXPECT_INT_EQ(view_model.layer_count, 2);
+    EXPECT_INT_EQ(view_model.layer_count, 3);
+    EXPECT_INT_EQ(view_model.layers[0].object_count, 0);
     EXPECT_TRUE(view_model.layers[1].active);
     EXPECT_INT_EQ(view_model.layers[1].object_count, 1);
+    EXPECT_INT_EQ(view_model.layers[2].object_count, 2);
     EXPECT_TRUE(view_model.properties[0].editable);
     EXPECT_TRUE(view_model.tools[2].available);
     EXPECT_TRUE(view_model.tools[3].available);


### PR DESCRIPTION
## Summary
- reduce repeated CMake test target boilerplate and isolate Nuklear test warnings
- optimize command history pruning and editor view-model layer counting
- reuse document object helpers and centralize spatial query cache refresh

## Validation
- cmake --preset debug
- cmake --build --preset debug --parallel
- ctest --preset debug --output-on-failure
- git diff --check