### PR TITLE
docs(contributing): clarify pull request format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,9 @@ Before opening a pull request:
 
 * Use a Conventional Commit style PR title: `type(scope): summary`, for example
   `fix(commands): preserve selection after undo`.
+* Use the repository pull request template as the shared review format. Keep the
+  standard sections unless they are clearly not applicable, and mark fields as
+  not applicable or not run instead of deleting review context.
 * Rebase or merge the target branch if the change depends on recent CI or build
   updates.
 * Run the smallest local verification that covers the touched area.
@@ -63,6 +66,21 @@ Before opening a pull request:
   theme changes.
 * Explain any compatibility, file format, packaging, or release impact.
 * Link issues with `Closes #...` or `Refs #...` when applicable.
+
+The pull request body should help reviewers collaborate without reconstructing
+the change from the diff:
+
+* `Summary` should state what changed and why, not list unrelated work.
+* `Change Type` and `Areas Touched` should identify the review owners and risk
+  surface.
+* `Architecture Checklist` should call out boundary-sensitive work or explicitly
+  mark it not applicable.
+* `Testing` should list the checks that actually ran and give a reason for any
+  relevant check that was skipped.
+* `AI Assistance` should disclose meaningful agent use, the required docs read,
+  and the human verification still needed.
+* `Compatibility and Release Notes` should make file format, dependency,
+  packaging, and changelog impact explicit.
 
 Reviewers should focus first on behavior, ownership boundaries, and tests. Style
 feedback should point back to the shared formatting rules where possible.


### PR DESCRIPTION
## Summary
- Document that the pull request template is the shared review format for contributors and reviewers.
- Clarify what each PR section should communicate so team collaboration context is explicit without requiring reviewers to reconstruct it from the diff.

## Change Type
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Infrastructure / CI / packaging
- [x] Documentation
- [ ] Release preparation

## Areas Touched
- [ ] Document model / persistence
- [ ] Commands / undo / redo
- [ ] Tools / input handling
- [ ] Workspace / session / services
- [ ] UI / menus / panels / dialogs
- [ ] Rendering / shaders / resources
- [ ] Build / tests / CI / release
- [x] Not applicable; contributor documentation only.

## Architecture Checklist
- [ ] Durable document mutations go through `CommandExecutor`.
- [ ] UI code dispatches actions and does not own editing rules.
- [ ] Tool input flows through editor controller / tool runtime boundaries.
- [ ] Rendering changes consume scene state rather than defining document behavior.
- [ ] No new `workspace_internal.h` include was added outside workspace implementation files.
- [x] Not applicable.

## Testing
- [ ] Local build completed.
- [ ] Relevant CTest tests completed.
- [x] Format or static-analysis checks completed when applicable.
- [ ] UI/rendering screenshots or recordings attached when applicable.
- [x] Not run; reason: Documentation-only change; `git diff --check origin/main...HEAD` was run, but build and CTest were not.

## AI Assistance
- [x] AI assistance was used.
- Agent/tool: Codex
- What the agent did: Added CONTRIBUTING.md guidance that centralizes PR format expectations for team collaboration.
- Required docs read: `AGENTS.md`, `CONTRIBUTING.md`, `doc/ai-agents.md`, `doc/agent-playbooks.md`, `doc/testing.md`
- Human verification performed: Pending maintainer review of the wording and whether the PR template section list matches team expectations.

## Compatibility and Release Notes
- File format impact: None.
- Packaging or runtime dependency impact: None.
- User-visible change for changelog: None; contributor documentation only.

## Related
- Refs #121

## Notes
- This follows up on PR #121 by documenting the PR formatting expectations in one contributor-facing place.
